### PR TITLE
운동 중 화면 현재 위치, 경로 Map에 표시

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5E171E67273258A4001C003B /* RunningMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E171E66273258A4001C003B /* RunningMode.swift */; };
 		5E32DC652731004D000E525B /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		5E32DC6827314764000E525B /* RoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC6727314764000E525B /* RoundedButton.swift */; };
+		5E36992427358F7300D2A6F2 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36992327358F7300D2A6F2 /* MapViewController.swift */; };
 		5E4E7A9F2730214700C6B762 /* MateRunningModeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */; };
 		5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */; };
 		5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */; };
@@ -96,6 +97,7 @@
 		5E171E66273258A4001C003B /* RunningMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningMode.swift; sourceTree = "<group>"; };
 		5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorRelayProperty.swift; sourceTree = "<group>"; };
 		5E32DC6727314764000E525B /* RoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedButton.swift; sourceTree = "<group>"; };
+		5E36992327358F7300D2A6F2 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewController.swift; sourceTree = "<group>"; };
 		5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewModel.swift; sourceTree = "<group>"; };
 		5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningInfoView.swift; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 				3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */,
 				AE6A6F522730423D005A3A5C /* RunningModeSettingViewController.swift */,
 				B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */,
+				5E36992327358F7300D2A6F2 /* MapViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -806,6 +809,7 @@
 				AE6A6F37272FC723005A3A5C /* UIFont+CustomFont.swift in Sources */,
 				AE6A6F5A2732B940005A3A5C /* DefaultRunningSettingUseCase.swift in Sources */,
 				B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */,
+				5E36992427358F7300D2A6F2 /* MapViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -1,0 +1,164 @@
+//
+//  MapViewController.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/06.
+//
+
+import UIKit
+import CoreLocation
+import MapKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+class MapViewController: UIViewController {
+    private var disposeBag = DisposeBag()
+    private var previousCoordinate: CLLocationCoordinate2D?
+    private var shouldSetCenter = true
+    
+    private lazy var locationManager: CLLocationManager = {
+        let locationManager = CLLocationManager()
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
+        return locationManager
+    }()
+    
+    private lazy var mapView: MKMapView = {
+        let mapView = MKMapView()
+        let panGestureRecognizer = UIPanGestureRecognizer()
+        panGestureRecognizer.delegate = self
+        mapView.delegate = self
+        mapView.mapType = .standard
+        mapView.showsUserLocation = true
+        mapView.addGestureRecognizer(panGestureRecognizer)
+        return mapView
+    }()
+    
+    private lazy var locateButton = createCircleButton(imageName: "location")
+    private lazy var backButton = createCircleButton(imageName: "xmark")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        bindUI()
+        self.locationManager.startUpdatingLocation()
+        self.mapView.setUserTrackingMode(.follow, animated: true)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.locationManager.stopUpdatingLocation()
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+
+extension MapViewController: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let coordinate = locations.last?.coordinate else { return }
+        
+        if shouldSetCenter {
+            self.mapView.userTrackingMode = .follow
+        }
+        
+        if let previousCoordinate = self.previousCoordinate {
+            let coordinates = [previousCoordinate, coordinate]
+            let line = MKPolyline(coordinates: coordinates, count: coordinates.count)
+            self.mapView.addOverlay(line)
+        }
+        
+        self.previousCoordinate = coordinate
+    }
+}
+
+extension MapViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let polyLine = overlay as? MKPolyline else { return MKOverlayRenderer() }
+
+        let renderer = MKPolylineRenderer(polyline: polyLine)
+        renderer.strokeColor = .mrPurple
+        renderer.lineWidth = 5.0
+        renderer.alpha = 1.0
+
+        return renderer
+    }
+}
+
+extension MapViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        return true
+    }
+}
+
+// MARK: - Private Functions
+
+private extension MapViewController {
+    func configureUI() {
+        self.view.addSubview(self.mapView)
+        self.mapView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        self.view.addSubview(self.locateButton)
+        self.locateButton.snp.makeConstraints { make in
+            make.left.equalToSuperview().inset(30)
+            make.bottom.equalToSuperview().inset(50)
+        }
+        
+        self.view.addSubview(self.backButton)
+        self.backButton.snp.makeConstraints { make in
+            make.right.equalToSuperview().inset(30)
+            make.bottom.equalToSuperview().inset(50)
+        }
+    }
+    
+    func bindUI() {
+        self.locateButton.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.locateButtonDidTap()
+            }).disposed(by: self.disposeBag)
+        
+        if let panGestureRecognizer = self.mapView.gestureRecognizers?.first {
+            panGestureRecognizer.rx.event
+                .asDriver()
+                .drive(onNext: { [weak self] gestureRecognizer in
+                    self?.panGestureDidRecognize(gestureRecognizer)
+                }).disposed(by: self.disposeBag)
+        }
+    }
+    
+    func configureCurrentLocation() {
+        let span = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+        let locationRegion = MKCoordinateRegion(center: self.mapView.userLocation.coordinate, span: span)
+        self.mapView.setRegion(locationRegion, animated: true)
+    }
+    
+    func createCircleButton(imageName: String) -> UIButton {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: imageName), for: .normal)
+        button.backgroundColor = .mrPurple
+        button.tintColor = .white
+        button.layer.cornerRadius = 30
+        button.snp.makeConstraints { make in
+            make.width.height.equalTo(60)
+        }
+        return button
+    }
+    
+    func locateButtonDidTap() {
+        self.configureCurrentLocation()
+        self.shouldSetCenter = true
+    }
+    
+    func panGestureDidRecognize(_ gestureRecognizer: UIGestureRecognizer) {
+        if gestureRecognizer.state == .began {
+            self.shouldSetCenter = false
+        }
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -33,6 +33,7 @@ class MapViewController: UIViewController {
         mapView.mapType = .standard
         mapView.showsUserLocation = true
         mapView.addGestureRecognizer(panGestureRecognizer)
+        mapView.setUserTrackingMode(.follow, animated: true)
         return mapView
     }()
     
@@ -41,10 +42,9 @@ class MapViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
-        bindUI()
-        self.locationManager.startUpdatingLocation()
-        self.mapView.setUserTrackingMode(.follow, animated: true)
+        self.configureUI()
+        self.bindUI()
+        self.configureLocationManager()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -131,6 +131,10 @@ private extension MapViewController {
                     self?.panGestureDidRecognize(gestureRecognizer)
                 }).disposed(by: self.disposeBag)
         }
+    }
+    
+    func configureLocationManager() {
+        self.locationManager.startUpdatingLocation()
     }
     
     func configureCurrentLocation() {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -5,15 +5,15 @@
 //  Created by 이정원 on 2021/11/06.
 //
 
-import UIKit
 import CoreLocation
 import MapKit
+import UIKit
 
 import RxCocoa
 import RxSwift
 import SnapKit
 
-class MapViewController: UIViewController {
+final class MapViewController: UIViewController {
     private var disposeBag = DisposeBag()
     private var previousCoordinate: CLLocationCoordinate2D?
     private var shouldSetCenter = true

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -31,12 +31,13 @@ final class SingleRunningViewController: UIViewController, UIScrollViewDelegate 
     }()
     
     private lazy var runningView = UIView()
-    private lazy var mapView = UIView()
-    
     private lazy var calorieView = RunningInfoView(name: "칼로리", value: "128")
     private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
     private lazy var distanceView = RunningInfoView(name: "킬로미터", value: "5.00", isLarge: true)
     private lazy var progressView = RunningProgressView(width: 250, color: .mrPurple)
+    
+    private lazy var mapContainerView = UIView()
+    private lazy var mapViewController = MapViewController()
     
     private lazy var cancelButton: UIButton = {
         let button = UIButton()
@@ -83,9 +84,12 @@ private extension SingleRunningViewController {
         }
         
         self.runningView.backgroundColor = .mrYellow
-        self.mapView.backgroundColor = .mrPurple
         self.contentStackView.addArrangedSubview(runningView)
-        self.contentStackView.addArrangedSubview(mapView)
+        self.contentStackView.addArrangedSubview(mapContainerView)
+        
+        self.addChild(self.mapViewController)
+        self.mapViewController.view.frame = self.mapContainerView.frame
+        self.mapContainerView.addSubview(self.mapViewController.view)
         
         self.runningView.addSubview(self.calorieView)
         self.calorieView.snp.makeConstraints { make in


### PR DESCRIPTION
### 📕 Issue Number

Close #16 #17


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 실시간 달리기 정보 화면 옆에 지도 표시
- [x] 현재 위치 표시 및 트래킹
- [x] 현 위치 버튼 동작 구현 
- [x] panGesture 감지한 경우 중앙 고정 해제



https://user-images.githubusercontent.com/77449223/140612459-be6179a5-ef65-492e-9eed-016a8b5b31b7.mp4


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 지도 화면을 Container View Controller로 구현
  달리기 모드에 상관 없이 지도화면의 UI와 동작은 동일하므로 지도 화면에 대한 View Controller를 재사용하기 위해 Container View Controller로 구현하였습니다. 또한 지도 화면은 paging을 통해 진입하였지만 지도 자체에 panning 기능이 있기 때문에 돌아가기 위해선 X버튼을 눌러 달리기 정보 화면으로 돌아가야 합니다. 이 과정에서 스크롤하는 동작은 부모 View Controller에서 구현해줘야 하므로 delegate 패턴을 사용하려고 하는데 괜찮은 방법일까요?
  
- 누가 CLLocationManager를 소유해야 하는가?
  CLLocationManagerDelegate의 메소드 안에서 현재 위치가 변경되었을 때에 대한 동작을 처리하는 것 같습니다. 추후에 서버에 업로드하거나 CoreData에 저장하는 작업을 생각해본다면, CLLocationManager를 View Controller가 소유하는 것이 맞는지 의문이 듭니다. 여러분들과 한 번 얘기를 나눠본 후에 리팩토링을 진행하려고 합니다.
  
- 결과 화면에 대한 지도 표시
  운동 중 화면에서 실시간으로 업데이트 되는 좌표를 계속 저장한다면 결과 화면에서는 CLLocationManager에 대한 구현이 없어도 될 것 같습니다. 다만 운동 중 화면에서 결과 화면으로 넘어갈 때 운동 중 화면이 가지고 있는 데이터를 넘겨줄 지, 아니면 storage 영역에 저장되어 있는 좌표 데이터를 결과 화면에서 불러오는 방식으로 구현할지는 같이 고민해보면 좋을 것 같습니다.

- Center 고정에 대한 이슈
  유진, 민지님이 구현하신 방식대로 실시간으로 위치가 업데이트 될 때마다 setRegion을 호출한다면 지도가 툭툭 끊기듯이 움직이게 됩니다. 이 부분에 대한 해결 방법을 나름 찾아보았는데, userTrackingMode를 업데이트될 때마다 follow로 지정해주면 현 위치가 중앙으로 고정되면서 지도가 부드럽게 움직이는 것 같습니다.

  하지만 사용자가 주변의 위치를 확인하기 위해 지도를 움직인다면 Nike Run Club처럼 중앙 고정이 해제되어야 할 것 같습니다. 따라서 mapView에 UIPanGestureRecognizer를 추가해주었고, pan 동작이 감지될 때 flag 값을 변경하여 고정하는 동작을 무시하도록 하였는데 맞는 방법인지 확신이 들지 않습니다...😂  이 부분 관련해서도 같이 얘기 나눠보면 좋을 것 같습니다..!


<br/><br/>
