### PR TITLE
현재 위치정보 허용 - 설정창 띄우기

### DIFF
--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -61,8 +61,8 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
-        self.getLocationUsagePermission()
         self.bindUI()
+        self.getLocationUsagePermission()
     }
     
     override func viewDidLayoutSubviews() {
@@ -87,9 +87,9 @@ extension HomeViewController: CLLocationManagerDelegate {
         switch status {
         case .authorizedAlways, .authorizedWhenInUse:
             self.locationManager.startUpdatingLocation()
-        case .restricted:
-            self.setAuthAlertAction()
-        case .denied:
+        case .notDetermined:
+            self.getLocationUsagePermission()
+        case .denied, .restricted:
             self.setAuthAlertAction()
         default:
             break
@@ -159,7 +159,7 @@ private extension HomeViewController {
     func setAuthAlertAction() {
         let authAlertController: UIAlertController
         authAlertController = UIAlertController(title: "위치정보 권한 요청",
-                                                message: "위치정보 권한을 허용해 주세요!",
+                                                message: "더 많은 기능을 위해서 위치정보 권한이 필요해요!",
                                                 preferredStyle: UIAlertController.Style.alert)
         
         let getAuthAction: UIAlertAction

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -87,10 +87,10 @@ extension HomeViewController: CLLocationManagerDelegate {
         switch status {
         case .authorizedAlways, .authorizedWhenInUse:
             self.locationManager.startUpdatingLocation()
-        case .restricted, .notDetermined:
-            getLocationUsagePermission()
+        case .restricted:
+            self.setAuthAlertAction()
         case .denied:
-            getLocationUsagePermission()
+            self.setAuthAlertAction()
         default:
             break
         }
@@ -154,5 +154,23 @@ private extension HomeViewController {
         self.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(runningModeSettingViewController, animated: true)
         self.hidesBottomBarWhenPushed = false
+    }
+    
+    func setAuthAlertAction() {
+        let authAlertController: UIAlertController
+        authAlertController = UIAlertController(title: "위치정보 권한 요청",
+                                                message: "위치정보 권한을 허용해 주세요!",
+                                                preferredStyle: UIAlertController.Style.alert)
+        
+        let getAuthAction: UIAlertAction
+        getAuthAction = UIAlertAction(title: "네 허용하겠습니다",
+                                      style: UIAlertAction.Style.default,
+                                      handler: { _ in
+            if let appSettings = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)
+            }
+        })
+        authAlertController.addAction(getAuthAction)
+        self.present(authAlertController, animated: true, completion: nil)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -160,11 +160,11 @@ private extension HomeViewController {
         let authAlertController: UIAlertController
         authAlertController = UIAlertController(title: "위치정보 권한 요청",
                                                 message: "더 많은 기능을 위해서 위치정보 권한이 필요해요!",
-                                                preferredStyle: UIAlertController.Style.alert)
+                                                preferredStyle: .alert)
         
         let getAuthAction: UIAlertAction
         getAuthAction = UIAlertAction(title: "네 허용하겠습니다",
-                                      style: UIAlertAction.Style.default,
+                                      style: .default,
                                       handler: { _ in
             if let appSettings = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)


### PR DESCRIPTION
### 📕 Issue Number

Close #39 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 현재 위치정보 허용하지 않았을 때 설정창 띄우기


https://user-images.githubusercontent.com/41044154/140648958-f0e0286d-99cd-4e66-bda1-853d085b8c4c.mov


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 늦은 시간에 PR 죄송합니다 ,, 소소한 기능이라 코드는 길지 않지만 리뷰는 천천히 해주시고 칼로리 관련 기능은 구현을 해뒀는데 리팩토링을 하며 뭔가 잘 안되어서 내일 아침에 바로 PR 올리겠습니다! 🥲
