### PR TITLE
운동 중 화면 (경쟁 모드, 협동 모드) UI 구현

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		5E4E7A9F2730214700C6B762 /* MateRunningModeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */; };
 		5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */; };
 		5E6F3826273A0F52009686DC /* TeamRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6F3825273A0F52009686DC /* TeamRunningViewController.swift */; };
+		5E6F382A273A3DEF009686DC /* RaceRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6F3829273A3DEF009686DC /* RaceRunningViewController.swift */; };
+		5E6F382C273A50B3009686DC /* RunningCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6F382B273A50B3009686DC /* RunningCardView.swift */; };
 		5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */; };
 		5E7F1F712733A59C00F2B662 /* RunningProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7F1F702733A59C00F2B662 /* RunningProgressView.swift */; };
 		5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E918A09272BD76D00B57888 /* AppDelegate.swift */; };
@@ -153,6 +155,8 @@
 		5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewController.swift; sourceTree = "<group>"; };
 		5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewModel.swift; sourceTree = "<group>"; };
 		5E6F3825273A0F52009686DC /* TeamRunningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRunningViewController.swift; sourceTree = "<group>"; };
+		5E6F3829273A3DEF009686DC /* RaceRunningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningViewController.swift; sourceTree = "<group>"; };
+		5E6F382B273A50B3009686DC /* RunningCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningCardView.swift; sourceTree = "<group>"; };
 		5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningInfoView.swift; sourceTree = "<group>"; };
 		5E7F1F702733A59C00F2B662 /* RunningProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningProgressView.swift; sourceTree = "<group>"; };
 		5E918A06272BD76D00B57888 /* MateRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MateRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -458,6 +462,7 @@
 				5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */,
 				AE6A6F34272FC170005A3A5C /* DistanceSettingViewController.swift */,
 				B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */,
+				5E6F3829273A3DEF009686DC /* RaceRunningViewController.swift */,
 				5E6F3825273A0F52009686DC /* TeamRunningViewController.swift */,
 				3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */,
 				AE6A6F522730423D005A3A5C /* RunningModeSettingViewController.swift */,
@@ -623,6 +628,7 @@
 				B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */,
 				5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */,
 				5E7F1F702733A59C00F2B662 /* RunningProgressView.swift */,
+				5E6F382B273A50B3009686DC /* RunningCardView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1106,6 +1112,7 @@
 				B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */,
 				5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */,
 				5E6F3826273A0F52009686DC /* TeamRunningViewController.swift in Sources */,
+				5E6F382C273A50B3009686DC /* RunningCardView.swift in Sources */,
 				5E7F1F712733A59C00F2B662 /* RunningProgressView.swift in Sources */,
 				3DF4C86F27376CDA00A4B229 /* FIreStoreNetworkService.swift in Sources */,
 				AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */,
@@ -1126,6 +1133,7 @@
 				B0628B8B27397354004FAB0F /* DefaultDistanceSettingUseCase.swift in Sources */,
 				5E4E7A9F2730214700C6B762 /* MateRunningModeSettingViewController.swift in Sources */,
 				5E3B82E22738D22C00EBF39C /* BackButtonDelegate.swift in Sources */,
+				5E6F382A273A3DEF009686DC /* RaceRunningViewController.swift in Sources */,
 				AEDAFD122733DC0B009BAEAA /* RunningSettingUseCase.swift in Sources */,
 				B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */,
 				5E171E6527325691001C003B /* RunningSetting.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		5E3B82E22738D22C00EBF39C /* BackButtonDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3B82E12738D22C00EBF39C /* BackButtonDelegate.swift */; };
 		5E4E7A9F2730214700C6B762 /* MateRunningModeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */; };
 		5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */; };
+		5E6F3826273A0F52009686DC /* TeamRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6F3825273A0F52009686DC /* TeamRunningViewController.swift */; };
 		5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */; };
 		5E7F1F712733A59C00F2B662 /* RunningProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7F1F702733A59C00F2B662 /* RunningProgressView.swift */; };
 		5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E918A09272BD76D00B57888 /* AppDelegate.swift */; };
@@ -151,6 +152,7 @@
 		5E3B82E12738D22C00EBF39C /* BackButtonDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButtonDelegate.swift; sourceTree = "<group>"; };
 		5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewController.swift; sourceTree = "<group>"; };
 		5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewModel.swift; sourceTree = "<group>"; };
+		5E6F3825273A0F52009686DC /* TeamRunningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRunningViewController.swift; sourceTree = "<group>"; };
 		5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningInfoView.swift; sourceTree = "<group>"; };
 		5E7F1F702733A59C00F2B662 /* RunningProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningProgressView.swift; sourceTree = "<group>"; };
 		5E918A06272BD76D00B57888 /* MateRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MateRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -456,6 +458,7 @@
 				5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */,
 				AE6A6F34272FC170005A3A5C /* DistanceSettingViewController.swift */,
 				B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */,
+				5E6F3825273A0F52009686DC /* TeamRunningViewController.swift */,
 				3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */,
 				AE6A6F522730423D005A3A5C /* RunningModeSettingViewController.swift */,
 				B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */,
@@ -1102,6 +1105,7 @@
 				B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */,
 				B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */,
 				5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */,
+				5E6F3826273A0F52009686DC /* TeamRunningViewController.swift in Sources */,
 				5E7F1F712733A59C00F2B662 /* RunningProgressView.swift in Sources */,
 				3DF4C86F27376CDA00A4B229 /* FIreStoreNetworkService.swift in Sources */,
 				AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */,

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
@@ -1,0 +1,95 @@
+//
+//  RunningCardView.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/09.
+//
+
+import UIKit
+
+final class RunningCardView: UIView {
+    convenience init(distanceLabel: UILabel, progressView: UIProgressView) {
+        self.init(frame: .zero)
+        self.configureUI(distanceLabel: distanceLabel, progressView: progressView)
+        self.updateColor(isWinning: false)
+    }
+    
+    func updateColor(isWinning: Bool) {
+        guard let labelStackView = self.subviews.first?.subviews.last?.subviews.first as? UIStackView,
+              let progressView = self.subviews.first?.subviews.last?.subviews.last as? UIProgressView else { return }
+        
+        labelStackView.arrangedSubviews.forEach { subView in
+            guard let label = subView as? UILabel else { return }
+            label.textColor = isWinning ? .white: .black
+        }
+        
+        progressView.progressTintColor = isWinning ? .mrYellow : .mrPurple
+        self.backgroundColor = isWinning ? .mrPurple : .systemGray5
+    }
+}
+
+// MARK: - Private Functions
+
+private extension RunningCardView {
+    func configureUI(distanceLabel: UILabel, progressView: UIProgressView) {
+        let infoStackView = self.createInfoStackView(distanceLabel: distanceLabel, progressView: progressView)
+        
+        self.layer.cornerRadius = 15
+        self.addSubview(infoStackView)
+        infoStackView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+        
+        self.snp.makeConstraints { make in
+            make.left.top.equalTo(infoStackView).offset(-15)
+            make.right.bottom.equalTo(infoStackView).offset(15)
+        }
+    }
+    
+    func createInfoStackView(distanceLabel: UILabel, progressView: UIProgressView) -> UIStackView {
+        let labelStackView = self.createLabelStackView(distanceLabel: distanceLabel)
+        
+        let verticalStackView = UIStackView()
+        verticalStackView.axis = .vertical
+        verticalStackView.alignment = .leading
+        
+        verticalStackView.addArrangedSubview(labelStackView)
+        verticalStackView.addArrangedSubview(progressView)
+        
+        let profileImageView = self.createProfileImageView()
+        
+        let horizontalStackView = UIStackView()
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.alignment = .center
+        horizontalStackView.spacing = 25
+        
+        horizontalStackView.addArrangedSubview(profileImageView)
+        horizontalStackView.addArrangedSubview(verticalStackView)
+        return horizontalStackView
+    }
+    
+    func createProfileImageView() -> UIImageView {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .lightGray
+        imageView.layer.cornerRadius = 40
+        imageView.snp.makeConstraints { make in
+            make.width.height.equalTo(80)
+        }
+        return imageView
+    }
+    
+    func createLabelStackView(distanceLabel: UILabel) -> UIStackView {
+        let nameLabel = UILabel()
+        nameLabel.font = .notoSansBoldItalic(size: 20)
+        nameLabel.text = "KM"
+        
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .lastBaseline
+        stackView.spacing = 10
+        
+        stackView.addArrangedSubview(distanceLabel)
+        stackView.addArrangedSubview(nameLabel)
+        return stackView
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 final class RunningInfoView: UIStackView {
-    convenience init(name: String, value: String, isLarge: Bool = false) {
+    convenience init(name: String, value: String) {
         self.init(frame: .zero)
-		self.configureUI(name: name, value: value, isLarge: isLarge)
+		self.configureUI(name: name, value: value)
     }
 	
 	func updateValue(newValue: String) {
@@ -22,7 +22,7 @@ final class RunningInfoView: UIStackView {
 // MARK: - Private Functions
 
 private extension RunningInfoView {
-    func configureUI(name: String, value: String, isLarge: Bool) {
+    func configureUI(name: String, value: String) {
 		let nameLabel = UILabel()
 		let valueLabel = UILabel()
 		
@@ -30,13 +30,7 @@ private extension RunningInfoView {
 		nameLabel.textColor = .darkGray
 		nameLabel.text = name
         
-		if isLarge {
-			valueLabel.font = .notoSansBoldItalic(size: 100)
-            self.spacing = -15
-		} else {
-			valueLabel.font = .notoSans(size: 30, family: .bold)
-		}
-		
+        valueLabel.font = .notoSans(size: 30, family: .bold)
 		valueLabel.text = value
 		
         self.axis = .vertical

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
@@ -23,20 +23,20 @@ final class RunningInfoView: UIStackView {
 
 private extension RunningInfoView {
     func configureUI(name: String, value: String) {
-		let nameLabel = UILabel()
-		let valueLabel = UILabel()
-		
-		nameLabel.font = .notoSans(size: 16, family: .regular)
-		nameLabel.textColor = .darkGray
-		nameLabel.text = name
+        let nameLabel = UILabel()
+        let valueLabel = UILabel()
+        
+        nameLabel.font = .notoSans(size: 16, family: .regular)
+        nameLabel.textColor = .darkGray
+        nameLabel.text = name
         
         valueLabel.font = .notoSans(size: 30, family: .bold)
-		valueLabel.text = value
-		
+        valueLabel.text = value
+        
         self.axis = .vertical
         self.alignment = .center
-		
-		self.addArrangedSubview(valueLabel)
-		self.addArrangedSubview(nameLabel)
+        
+        self.addArrangedSubview(valueLabel)
+        self.addArrangedSubview(nameLabel)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
@@ -10,13 +10,13 @@ import UIKit
 final class RunningInfoView: UIStackView {
     convenience init(name: String, value: String) {
         self.init(frame: .zero)
-		self.configureUI(name: name, value: value)
+        self.configureUI(name: name, value: value)
     }
-	
-	func updateValue(newValue: String) {
-		guard let valueLabel = self.arrangedSubviews.first as? UILabel else { return }
-		valueLabel.text = newValue
-	}
+    
+    func updateValue(newValue: String) {
+        guard let valueLabel = self.arrangedSubviews.first as? UILabel else { return }
+        valueLabel.text = newValue
+    }
 }
 
 // MARK: - Private Functions
@@ -25,17 +25,17 @@ private extension RunningInfoView {
     func configureUI(name: String, value: String) {
         let nameLabel = UILabel()
         let valueLabel = UILabel()
-        
+
         nameLabel.font = .notoSans(size: 16, family: .regular)
         nameLabel.textColor = .darkGray
         nameLabel.text = name
-        
+
         valueLabel.font = .notoSans(size: 30, family: .bold)
         valueLabel.text = value
-        
+
         self.axis = .vertical
         self.alignment = .center
-        
+
         self.addArrangedSubview(valueLabel)
         self.addArrangedSubview(nameLabel)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningProgressView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningProgressView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class RunningProgressView: UIProgressView {
-    convenience init(width: CGFloat, color: UIColor) {
+    convenience init(width: CGFloat, color: UIColor = .mrPurple) {
         self.init(frame: .zero)
         self.configureUI(width: width, color: color)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RaceRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RaceRunningViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class RaceRunningViewController: SingleRunningViewController {
+final class RaceRunningViewController: SingleRunningViewController {
     private lazy var mateDistanceLabel = self.createDistanceLabel()
     private lazy var mateProgressView = self.createProgressView()
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RaceRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RaceRunningViewController.swift
@@ -1,0 +1,29 @@
+//
+//  RaceRunningViewController.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/09.
+//
+
+import UIKit
+
+class RaceRunningViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RaceRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RaceRunningViewController.swift
@@ -7,23 +7,49 @@
 
 import UIKit
 
-class RaceRunningViewController: UIViewController {
+import SnapKit
 
+class RaceRunningViewController: SingleRunningViewController {
+    private lazy var mateDistanceLabel = self.createDistanceLabel()
+    private lazy var mateProgressView = self.createProgressView()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func createDistanceLabel() -> UILabel {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 50)
+        return label
     }
-    */
-
+    
+    override func createProgressView() -> UIProgressView {
+        return RunningProgressView(width: 160)
+    }
+    
+    override func createDistanceStackView() -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 30
+        
+        // 임시 text, binding 후 제거해야 함
+        self.mateDistanceLabel.text = "5.00"
+        
+        let myCardView = RunningCardView(
+            distanceLabel: self.distanceLabel,
+            progressView: self.progressView
+        )
+        myCardView.updateColor(isWinning: true)
+        
+        let mateCardView = RunningCardView(
+            distanceLabel: self.mateDistanceLabel,
+            progressView: self.mateProgressView
+        )
+        mateCardView.updateColor(isWinning: false)
+        
+        stackView.addArrangedSubview(myCardView)
+        stackView.addArrangedSubview(mateCardView)
+        return stackView
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -88,7 +88,7 @@ class SingleRunningViewController: UIViewController {
     }
     
     func createProgressView() -> UIProgressView {
-        return RunningProgressView(width: 250, color: .mrPurple)
+        return RunningProgressView(width: 250)
     }
     
     func createDistanceStackView() -> UIStackView {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -12,73 +12,73 @@ import RxGesture
 import SnapKit
 
 class SingleRunningViewController: UIViewController {
-	let singleRunningViewModel = SingleRunningViewModel(
-		runningUseCase: DefaultRunningUseCase()
-	)
-	private var disposeBag = DisposeBag()
-	
-	private lazy var scrollView: UIScrollView = {
-		let scrollView = UIScrollView()
-		scrollView.contentInsetAdjustmentBehavior = .never
-		scrollView.isPagingEnabled = true
-		scrollView.showsHorizontalScrollIndicator = false
-		return scrollView
-	}()
-	
-	private lazy var contentStackView: UIStackView = {
-		let stackView = UIStackView()
-		stackView.axis = .horizontal
-		stackView.distribution = .fillEqually
-		return stackView
-	}()
-	
-	private lazy var runningView = UIView()
-	private lazy var calorieView = RunningInfoView(name: "칼로리", value: "128")
-	private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
+    let singleRunningViewModel = SingleRunningViewModel(
+        runningUseCase: DefaultRunningUseCase()
+    )
+    private var disposeBag = DisposeBag()
+    
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private lazy var contentStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+    
+    private lazy var runningView = UIView()
+    private lazy var calorieView = RunningInfoView(name: "칼로리", value: "128")
+    private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
     private lazy var mapContainerView = UIView()
     private lazy var mapViewController = MapViewController()
     private(set) lazy var distanceLabel = self.createDistanceLabel()
     private(set) lazy var progressView = self.createProgressView()
     private(set) lazy var distanceStackView = self.createDistanceStackView()
-	
-	private lazy var cancelButton: UIButton = {
-		let button = UIButton()
-		button.setTitle("종료", for: .normal)
-		button.titleLabel?.font = .notoSans(size: 20, family: .bold)
-		button.backgroundColor = .mrPurple
-		button.layer.cornerRadius = 60
-		button.addGestureRecognizer(UILongPressGestureRecognizer())
-		button.snp.makeConstraints { make in
-			make.width.height.equalTo(120)
-		}
-		return button
-	}()
-	
-	private lazy var pageControl: UIPageControl = {
-		let pageControl = UIPageControl()
-		pageControl.numberOfPages = 2
-		pageControl.pageIndicatorTintColor = .white
-		pageControl.currentPageIndicatorTintColor = .mrPurple
-		return pageControl
-	}()
-	
-	private lazy var cancelInfoFloatingView: UILabel = {
-		let label = UILabel()
-		label.text = "2초 동안 길게 탭하면 달리기가 종료돼요😉"
-		label.layer.backgroundColor = UIColor.white.cgColor.copy(alpha: 0.85)
-		label.layer.cornerRadius = 15
-		label.textAlignment = .center
-		label.isHidden = true
-		label.font = .notoSans(size: 13, family: .light)
-		label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
-		return label
-	}()
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		self.configureUI()
-		self.bindViewModel()
-	}
+    
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("종료", for: .normal)
+        button.titleLabel?.font = .notoSans(size: 20, family: .bold)
+        button.backgroundColor = .mrPurple
+        button.layer.cornerRadius = 60
+        button.addGestureRecognizer(UILongPressGestureRecognizer())
+        button.snp.makeConstraints { make in
+            make.width.height.equalTo(120)
+        }
+        return button
+    }()
+    
+    private lazy var pageControl: UIPageControl = {
+        let pageControl = UIPageControl()
+        pageControl.numberOfPages = 2
+        pageControl.pageIndicatorTintColor = .white
+        pageControl.currentPageIndicatorTintColor = .mrPurple
+        return pageControl
+    }()
+    
+    private lazy var cancelInfoFloatingView: UILabel = {
+        let label = UILabel()
+        label.text = "2초 동안 길게 탭하면 달리기가 종료돼요😉"
+        label.layer.backgroundColor = UIColor.white.cgColor.copy(alpha: 0.85)
+        label.layer.cornerRadius = 15
+        label.textAlignment = .center
+        label.isHidden = true
+        label.font = .notoSans(size: 13, family: .light)
+        label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
+        return label
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureUI()
+        self.bindViewModel()
+    }
     
     func createDistanceLabel() -> UILabel {
         let label = UILabel()
@@ -117,129 +117,129 @@ class SingleRunningViewController: UIViewController {
 
 // MARK: - Private Functions
 private extension SingleRunningViewController {
-	func configureUI() {
-		self.view.addSubview(self.scrollView)
-		self.scrollView.snp.makeConstraints { make in
-			make.edges.equalToSuperview()
-		}
-		
-		self.scrollView.addSubview(self.contentStackView)
-		self.contentStackView.snp.makeConstraints { make in
-			make.edges.equalTo(self.scrollView)
-			make.height.equalTo(self.scrollView)
-			make.width.equalTo(self.view.bounds.width * 2)
-		}
-		
-		self.runningView.backgroundColor = .mrYellow
-		self.contentStackView.addArrangedSubview(runningView)
-		self.contentStackView.addArrangedSubview(mapContainerView)
-		
-		self.addChild(self.mapViewController)
-		self.mapViewController.view.frame = self.mapContainerView.frame
-		self.mapContainerView.addSubview(self.mapViewController.view)
-		self.mapViewController.backButtonDelegate = self
-		
-		self.runningView.addSubview(self.calorieView)
-		self.calorieView.snp.makeConstraints { make in
-			make.left.equalToSuperview().inset(20)
-			make.top.equalTo(self.view.safeAreaLayoutGuide).inset(20)
-		}
-		
-		self.runningView.addSubview(self.timeView)
-		self.timeView.snp.makeConstraints { make in
-			make.right.equalToSuperview().inset(20)
-			make.top.equalTo(self.view.safeAreaLayoutGuide).inset(20)
-		}
+    func configureUI() {
+        self.view.addSubview(self.scrollView)
+        self.scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        self.scrollView.addSubview(self.contentStackView)
+        self.contentStackView.snp.makeConstraints { make in
+            make.edges.equalTo(self.scrollView)
+            make.height.equalTo(self.scrollView)
+            make.width.equalTo(self.view.bounds.width * 2)
+        }
+        
+        self.runningView.backgroundColor = .mrYellow
+        self.contentStackView.addArrangedSubview(runningView)
+        self.contentStackView.addArrangedSubview(mapContainerView)
+        
+        self.addChild(self.mapViewController)
+        self.mapViewController.view.frame = self.mapContainerView.frame
+        self.mapContainerView.addSubview(self.mapViewController.view)
+        self.mapViewController.backButtonDelegate = self
+        
+        self.runningView.addSubview(self.calorieView)
+        self.calorieView.snp.makeConstraints { make in
+            make.left.equalToSuperview().inset(20)
+            make.top.equalTo(self.view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        self.runningView.addSubview(self.timeView)
+        self.timeView.snp.makeConstraints { make in
+            make.right.equalToSuperview().inset(20)
+            make.top.equalTo(self.view.safeAreaLayoutGuide).inset(20)
+        }
         
         self.runningView.addSubview(self.distanceStackView)
         self.distanceStackView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.centerY.equalToSuperview().offset(-50)
         }
-		
-		self.runningView.addSubview(self.cancelButton)
-		self.cancelButton.snp.makeConstraints { make in
-			make.centerX.equalToSuperview()
-			make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(100)
-		}
-		
-		self.runningView.addSubview(self.pageControl)
-		self.pageControl.snp.makeConstraints { make in
-			make.centerX.equalToSuperview()
-			make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(50)
-		}
-		
-		self.view.addSubview(self.cancelInfoFloatingView)
-		self.cancelInfoFloatingView.snp.makeConstraints { make in
-			make.centerX.equalToSuperview()
-			make.centerY.equalTo(self.cancelButton.snp.top).offset(-50)
-			make.height.equalTo(40)
-			make.width.equalTo(300)
-		}
-	}
-	
-	func bindViewModel() {
-		let input = SingleRunningViewModel.Input(
-			viewDidLoadEvent: Observable.just(()),
-			finishButtonLongPressDidBeginEvent: self.cancelButton.rx
-				.longPressGesture()
-				.when(.began)
-				.map({ _ in })
-				.asObservable(),
-			finishButtonLongPressDidCancelEvent: self.cancelButton.rx
-				.longPressGesture()
-				.when(.ended, .cancelled, .failed)
-				.map({ _ in })
-				.asObservable(),
-			finishButtonDidTapEvent: self.cancelButton.rx.tap
-				.asObservable()
-		)
-		let output = self.singleRunningViewModel.transform(from: input, disposeBag: self.disposeBag)
-		
-		output.$timeSpent
-			.asDriver()
-			.drive(onNext: { [weak self] newValue in
-				self?.timeView.updateValue(newValue: newValue)
-			})
-			.disposed(by: self.disposeBag)
-		
-		output.cancelTime
-			.asDriver(onErrorJustReturn: "종료")
-			.drive(onNext: { [weak self] newValue in
-				self?.updateTimeLeftText(with: newValue)
-			})
-			.disposed(by: self.disposeBag)
-		
-		output.$navigateToResult
-			.asDriver()
-			.drive(onNext: { [weak self] navigateToResult in
-				if navigateToResult == true { self?.navigateToResultScene() }
-			})
-			.disposed(by: self.disposeBag)
-		
-		output.isToasterNeeded
-			.asDriver(onErrorJustReturn: false)
-			.drive(onNext: {[weak self] isNeeded in
-				self?.toggleCancelFolatingView(isNeeded: isNeeded)
-			})
-			.disposed(by: disposeBag)
-		
-		output.$distance
-			.asDriver()
-			.drive(onNext: { [weak self] distance in
-				guard let distance = distance else { return }
-                self?.distanceLabel.text = String(distance)
-			})
-			.disposed(by: self.disposeBag)
-		
-		output.$progress
-			.asDriver()
-			.drive(onNext: { [weak self] progress in
-				guard let progress = progress else { return }
-				self?.progressView.setProgress(Float(progress), animated: false)
-			})
-			.disposed(by: self.disposeBag)
+        
+        self.runningView.addSubview(self.cancelButton)
+        self.cancelButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(100)
+        }
+        
+        self.runningView.addSubview(self.pageControl)
+        self.pageControl.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(50)
+        }
+        
+        self.view.addSubview(self.cancelInfoFloatingView)
+        self.cancelInfoFloatingView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(self.cancelButton.snp.top).offset(-50)
+            make.height.equalTo(40)
+            make.width.equalTo(300)
+        }
+    }
     
+    func bindViewModel() {
+        let input = SingleRunningViewModel.Input(
+            viewDidLoadEvent: Observable.just(()),
+            finishButtonLongPressDidBeginEvent: self.cancelButton.rx
+                .longPressGesture()
+                .when(.began)
+                .map({ _ in })
+                .asObservable(),
+            finishButtonLongPressDidCancelEvent: self.cancelButton.rx
+                .longPressGesture()
+                .when(.ended, .cancelled, .failed)
+                .map({ _ in })
+                .asObservable(),
+            finishButtonDidTapEvent: self.cancelButton.rx.tap
+                .asObservable()
+        )
+        let output = self.singleRunningViewModel.transform(from: input, disposeBag: self.disposeBag)
+        
+        output.$timeSpent
+            .asDriver()
+            .drive(onNext: { [weak self] newValue in
+                self?.timeView.updateValue(newValue: newValue)
+            })
+            .disposed(by: self.disposeBag)
+        
+        output.cancelTime
+            .asDriver(onErrorJustReturn: "종료")
+            .drive(onNext: { [weak self] newValue in
+                self?.updateTimeLeftText(with: newValue)
+            })
+            .disposed(by: self.disposeBag)
+        
+        output.$navigateToResult
+            .asDriver()
+            .drive(onNext: { [weak self] navigateToResult in
+                if navigateToResult == true { self?.navigateToResultScene() }
+            })
+            .disposed(by: self.disposeBag)
+        
+        output.isToasterNeeded
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: {[weak self] isNeeded in
+                self?.toggleCancelFolatingView(isNeeded: isNeeded)
+            })
+            .disposed(by: disposeBag)
+        
+        output.$distance
+            .asDriver()
+            .drive(onNext: { [weak self] distance in
+                guard let distance = distance else { return }
+                self?.distanceLabel.text = String(distance)
+            })
+            .disposed(by: self.disposeBag)
+        
+        output.$progress
+            .asDriver()
+            .drive(onNext: { [weak self] progress in
+                guard let progress = progress else { return }
+                self?.progressView.setProgress(Float(progress), animated: false)
+            })
+            .disposed(by: self.disposeBag)
+
         output.$calorie
             .asDriver()
             .drive(onNext: { [weak self] calorie in
@@ -247,54 +247,54 @@ private extension SingleRunningViewController {
                 self?.calorieView.updateValue(newValue: "\(calorie)")
             })
             .disposed(by: self.disposeBag)
-		
-		output.$finishRunning
-			.asDriver()
-			.filter { $0 == true }
-			.drive(onNext: { [weak self] _ in
-				self?.navigateToResultScene()
-			})
-			.disposed(by: self.disposeBag)
-	}
-	
-	func navigateToResultScene() {
-		let runningResultViewController = RunningResultViewController()
-		self.navigationController?.pushViewController(runningResultViewController, animated: true)
-	}
-    
-	func toggleCancelFolatingView(isNeeded: Bool) {
-		func showCancelFloatingView() {
-			guard self.cancelInfoFloatingView.isHidden == true else { return }
-			self.cancelInfoFloatingView.alpha = 0.1
-			self.cancelInfoFloatingView.isHidden = false
-			UIView.animate(withDuration: 0.2) {
-				self.cancelInfoFloatingView.alpha = 1
-			}
-		}
         
-		func hideCancelFloatingView() {
-			UIView.animate(withDuration: 0.2, animations: {
-				self.cancelInfoFloatingView.alpha = 0.1
-			}, completion: { _ in
-				self.cancelInfoFloatingView.isHidden = true
-			})
-		}
-		isNeeded ? showCancelFloatingView() : hideCancelFloatingView()
-	}
-	
-	func updateTimeLeftText(with text: String) {
-		self.cancelButton.setTitle(text, for: .normal)
-		self.cancelButton.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
-		UIView.animate(withDuration: 0.7) {
-			self.cancelButton.transform = CGAffineTransform.identity
-		}
-	}
+        output.$finishRunning
+            .asDriver()
+            .filter { $0 == true }
+            .drive(onNext: { [weak self] _ in
+                self?.navigateToResultScene()
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func navigateToResultScene() {
+        let runningResultViewController = RunningResultViewController()
+        self.navigationController?.pushViewController(runningResultViewController, animated: true)
+    }
+    
+    func toggleCancelFolatingView(isNeeded: Bool) {
+        func showCancelFloatingView() {
+            guard self.cancelInfoFloatingView.isHidden == true else { return }
+            self.cancelInfoFloatingView.alpha = 0.1
+            self.cancelInfoFloatingView.isHidden = false
+            UIView.animate(withDuration: 0.2) {
+                self.cancelInfoFloatingView.alpha = 1
+            }
+        }
+        
+        func hideCancelFloatingView() {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.cancelInfoFloatingView.alpha = 0.1
+            }, completion: { _ in
+                self.cancelInfoFloatingView.isHidden = true
+            })
+        }
+        isNeeded ? showCancelFloatingView() : hideCancelFloatingView()
+    }
+    
+    func updateTimeLeftText(with text: String) {
+        self.cancelButton.setTitle(text, for: .normal)
+        self.cancelButton.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+        UIView.animate(withDuration: 0.7) {
+            self.cancelButton.transform = CGAffineTransform.identity
+        }
+    }
 }
 
 extension SingleRunningViewController: BackButtonDelegate {
-	func backButtonDidTap() {
-		let toX = self.scrollView.contentOffset.x - self.scrollView.bounds.width
-		let toY = self.scrollView.contentOffset.y
-		self.scrollView.setContentOffset(CGPoint(x: toX, y: toY), animated: true)
-	}
+    func backButtonDidTap() {
+        let toX = self.scrollView.contentOffset.x - self.scrollView.bounds.width
+        let toY = self.scrollView.contentOffset.y
+        self.scrollView.setContentOffset(CGPoint(x: toX, y: toY), animated: true)
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -37,10 +37,9 @@ class SingleRunningViewController: UIViewController {
 	private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
     private lazy var mapContainerView = UIView()
     private lazy var mapViewController = MapViewController()
-    
     private(set) lazy var distanceLabel = self.createDistanceLabel()
     private(set) lazy var progressView = self.createProgressView()
-    private lazy var distanceStackView = self.createDistanceStackView()
+    private(set) lazy var distanceStackView = self.createDistanceStackView()
 	
 	private lazy var cancelButton: UIButton = {
 		let button = UIButton()
@@ -155,7 +154,7 @@ private extension SingleRunningViewController {
         self.runningView.addSubview(self.distanceStackView)
         self.distanceStackView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.bottom.equalTo(self.runningView.snp.centerY)
+            make.centerY.equalToSuperview().offset(-50)
         }
 		
 		self.runningView.addSubview(self.cancelButton)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -38,14 +38,9 @@ class SingleRunningViewController: UIViewController {
     private lazy var mapContainerView = UIView()
     private lazy var mapViewController = MapViewController()
     
-    lazy var distanceLabel: UILabel = {
-        let label = UILabel()
-        label.font = .notoSansBoldItalic(size: 100)
-        return label
-    }()
-    
-	lazy var progressView = RunningProgressView(width: 250, color: .mrPurple)
-    lazy var distanceStackView = self.createDistanceStackView()
+    private(set) lazy var distanceLabel = self.createDistanceLabel()
+    private(set) lazy var progressView = self.createProgressView()
+    private lazy var distanceStackView = self.createDistanceStackView()
 	
 	private lazy var cancelButton: UIButton = {
 		let button = UIButton()
@@ -85,6 +80,40 @@ class SingleRunningViewController: UIViewController {
 		self.configureUI()
 		self.bindViewModel()
 	}
+    
+    func createDistanceLabel() -> UILabel {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 100)
+        return label
+    }
+    
+    func createProgressView() -> UIProgressView {
+        return RunningProgressView(width: 250, color: .mrPurple)
+    }
+    
+    func createDistanceStackView() -> UIStackView {
+        let nameLabel = UILabel()
+        nameLabel.font = .notoSans(size: 16, family: .regular)
+        nameLabel.textColor = .darkGray
+        nameLabel.text = "킬로미터"
+        
+        let innerStackView = UIStackView()
+        innerStackView.axis = .vertical
+        innerStackView.alignment = .center
+        innerStackView.spacing = -15
+        
+        innerStackView.addArrangedSubview(self.distanceLabel)
+        innerStackView.addArrangedSubview(nameLabel)
+        
+        let outerStackView = UIStackView()
+        outerStackView.axis = .vertical
+        outerStackView.alignment = .center
+        outerStackView.spacing = 30
+        
+        outerStackView.addArrangedSubview(innerStackView)
+        outerStackView.addArrangedSubview(self.progressView)
+        return outerStackView
+    }
 }
 
 // MARK: - Private Functions
@@ -261,30 +290,6 @@ private extension SingleRunningViewController {
 			self.cancelButton.transform = CGAffineTransform.identity
 		}
 	}
-    
-    func createDistanceStackView() -> UIStackView {
-        let nameLabel = UILabel()
-        nameLabel.font = .notoSans(size: 16, family: .regular)
-        nameLabel.textColor = .darkGray
-        nameLabel.text = "킬로미터"
-        
-        let innerStackView = UIStackView()
-        innerStackView.axis = .vertical
-        innerStackView.alignment = .center
-        innerStackView.spacing = -15
-        
-        innerStackView.addArrangedSubview(self.distanceLabel)
-        innerStackView.addArrangedSubview(nameLabel)
-        
-        let outerStackView = UIStackView()
-        outerStackView.axis = .vertical
-        outerStackView.alignment = .center
-        outerStackView.spacing = 15
-        
-        outerStackView.addArrangedSubview(innerStackView)
-        outerStackView.addArrangedSubview(self.progressView)
-        return outerStackView
-    }
 }
 
 extension SingleRunningViewController: BackButtonDelegate {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxGesture
 import SnapKit
 
-final class SingleRunningViewController: UIViewController {
+class SingleRunningViewController: UIViewController {
 	let singleRunningViewModel = SingleRunningViewModel(
 		runningUseCase: DefaultRunningUseCase()
 	)
@@ -35,11 +35,21 @@ final class SingleRunningViewController: UIViewController {
 	private lazy var runningView = UIView()
 	private lazy var calorieView = RunningInfoView(name: "칼로리", value: "128")
 	private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
-	private lazy var distanceView = RunningInfoView(name: "킬로미터", value: "5.00", isLarge: true)
+    lazy var distanceView = RunningInfoView(name: "킬로미터", value: "5.00", isLarge: true)
 	private lazy var progressView = RunningProgressView(width: 250, color: .mrPurple)
 	
 	private lazy var mapContainerView = UIView()
 	private lazy var mapViewController = MapViewController()
+    
+    lazy var distanceStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 15
+        stackView.addArrangedSubview(distanceView)
+        stackView.addArrangedSubview(progressView)
+        return stackView
+    }()
 	
 	private lazy var cancelButton: UIButton = {
 		let button = UIButton()
@@ -116,18 +126,12 @@ private extension SingleRunningViewController {
 			make.right.equalToSuperview().inset(20)
 			make.top.equalTo(self.view.safeAreaLayoutGuide).inset(20)
 		}
-		
-		self.runningView.addSubview(self.distanceView)
-		self.distanceView.snp.makeConstraints { make in
-			make.centerX.equalToSuperview()
-			make.bottom.equalTo(self.runningView.snp.centerY).offset(-50)
-		}
-		
-		self.runningView.addSubview(self.progressView)
-		self.progressView.snp.makeConstraints { make in
-			make.centerX.equalToSuperview()
-			make.top.equalTo(self.runningView.snp.centerY).offset(-20)
-		}
+        
+        self.runningView.addSubview(self.distanceStackView)
+        self.distanceStackView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(self.runningView.snp.centerY)
+        }
 		
 		self.runningView.addSubview(self.cancelButton)
 		self.cancelButton.snp.makeConstraints { make in
@@ -212,7 +216,7 @@ private extension SingleRunningViewController {
 			})
 			.disposed(by: self.disposeBag)
     
-    output.$calorie
+        output.$calorie
             .asDriver()
             .drive(onNext: { [weak self] calorie in
                 guard let calorie = calorie else { return }
@@ -233,6 +237,7 @@ private extension SingleRunningViewController {
 		let runningResultViewController = RunningResultViewController()
 		self.navigationController?.pushViewController(runningResultViewController, animated: true)
 	}
+    
 	func toggleCancelFolatingView(isNeeded: Bool) {
 		func showCancelFloatingView() {
 			guard self.cancelInfoFloatingView.isHidden == true else { return }
@@ -242,6 +247,7 @@ private extension SingleRunningViewController {
 				self.cancelInfoFloatingView.alpha = 1
 			}
 		}
+        
 		func hideCancelFloatingView() {
 			UIView.animate(withDuration: 0.2, animations: {
 				self.cancelInfoFloatingView.alpha = 0.1

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -35,21 +35,17 @@ class SingleRunningViewController: UIViewController {
 	private lazy var runningView = UIView()
 	private lazy var calorieView = RunningInfoView(name: "칼로리", value: "128")
 	private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
-    lazy var distanceView = RunningInfoView(name: "킬로미터", value: "5.00", isLarge: true)
-	private lazy var progressView = RunningProgressView(width: 250, color: .mrPurple)
-	
-	private lazy var mapContainerView = UIView()
-	private lazy var mapViewController = MapViewController()
+    private lazy var mapContainerView = UIView()
+    private lazy var mapViewController = MapViewController()
     
-    lazy var distanceStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.spacing = 15
-        stackView.addArrangedSubview(distanceView)
-        stackView.addArrangedSubview(progressView)
-        return stackView
+    lazy var distanceLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 100)
+        return label
     }()
+    
+	lazy var progressView = RunningProgressView(width: 250, color: .mrPurple)
+    lazy var distanceStackView = self.createDistanceStackView()
 	
 	private lazy var cancelButton: UIButton = {
 		let button = UIButton()
@@ -204,7 +200,7 @@ private extension SingleRunningViewController {
 			.asDriver()
 			.drive(onNext: { [weak self] distance in
 				guard let distance = distance else { return }
-				self?.distanceView.updateValue(newValue: String(distance))
+                self?.distanceLabel.text = String(distance)
 			})
 			.disposed(by: self.disposeBag)
 		
@@ -265,6 +261,30 @@ private extension SingleRunningViewController {
 			self.cancelButton.transform = CGAffineTransform.identity
 		}
 	}
+    
+    func createDistanceStackView() -> UIStackView {
+        let nameLabel = UILabel()
+        nameLabel.font = .notoSans(size: 16, family: .regular)
+        nameLabel.textColor = .darkGray
+        nameLabel.text = "킬로미터"
+        
+        let innerStackView = UIStackView()
+        innerStackView.axis = .vertical
+        innerStackView.alignment = .center
+        innerStackView.spacing = -15
+        
+        innerStackView.addArrangedSubview(self.distanceLabel)
+        innerStackView.addArrangedSubview(nameLabel)
+        
+        let outerStackView = UIStackView()
+        outerStackView.axis = .vertical
+        outerStackView.alignment = .center
+        outerStackView.spacing = 15
+        
+        outerStackView.addArrangedSubview(innerStackView)
+        outerStackView.addArrangedSubview(self.progressView)
+        return outerStackView
+    }
 }
 
 extension SingleRunningViewController: BackButtonDelegate {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/TeamRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/TeamRunningViewController.swift
@@ -7,23 +7,80 @@
 
 import UIKit
 
-class TeamRunningViewController: UIViewController {
-
+final class TeamRunningViewController: SingleRunningViewController {
+    private lazy var totalDistanceLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 100)
+        return label
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        print("hello")
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func createDistanceLabel() -> UILabel {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 30)
+        return label
     }
-    */
+    
+    override func createDistanceStackView() -> UIStackView {
+        let myDistanceStackView = self.createMyDistanceStackView()
+        let totalDistanceStackView = self.createTotalDistanceStackView()
+        
+        let innerStackView = UIStackView()
+        innerStackView.axis = .vertical
+        innerStackView.alignment = .trailing
+        innerStackView.spacing = -20
+        
+        innerStackView.addArrangedSubview(myDistanceStackView)
+        innerStackView.addArrangedSubview(totalDistanceStackView)
+        
+        let outerStackView = UIStackView()
+        outerStackView.axis = .vertical
+        outerStackView.alignment = .center
+        outerStackView.spacing = 30
+        
+        outerStackView.addArrangedSubview(innerStackView)
+        outerStackView.addArrangedSubview(self.progressView)
+        return outerStackView
+    }
+}
 
+// MARK: - Private Functions
+
+private extension TeamRunningViewController {
+    func createMyDistanceStackView() -> UIStackView {
+        let nameLabel = UILabel()
+        nameLabel.font = .notoSans(size: 16, family: .regular)
+        nameLabel.textColor = .darkGray
+        nameLabel.text = "내가 뛴 거리"
+        
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .lastBaseline
+        stackView.spacing = 10
+        
+        stackView.addArrangedSubview(nameLabel)
+        stackView.addArrangedSubview(self.distanceLabel)
+        return stackView
+    }
+    
+    func createTotalDistanceStackView() -> UIStackView {
+        let nameLabel = UILabel()
+        nameLabel.font = .notoSans(size: 16, family: .regular)
+        nameLabel.textColor = .darkGray
+        nameLabel.text = "킬로미터"
+        self.totalDistanceLabel.text = "9.99"
+        
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = -15
+        
+        stackView.addArrangedSubview(self.totalDistanceLabel)
+        stackView.addArrangedSubview(nameLabel)
+        return stackView
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/TeamRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/TeamRunningViewController.swift
@@ -16,7 +16,6 @@ final class TeamRunningViewController: SingleRunningViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print("hello")
     }
     
     override func createDistanceLabel() -> UILabel {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/TeamRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/TeamRunningViewController.swift
@@ -1,0 +1,29 @@
+//
+//  TeamRunningViewController.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/09.
+//
+
+import UIKit
+
+class TeamRunningViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #60 #61 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 협동 모드, 경쟁 모드일 때의 운동 중 화면 구현
- [x] `SingleRunningViewController`를 상속 받아 메소드를 override함 

<img  src="https://user-images.githubusercontent.com/77449223/140888651-be0db8a8-0ca7-4566-b27f-4f36a7c8396f.png"  width="50%"  height="50%">
<img  src="https://user-images.githubusercontent.com/77449223/140888730-e7d8f224-aeb7-4c16-ba7e-8640be89658d.png"  width="50%"  height="50%">

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 경쟁 모드는 나의 현재 거리, 나의 progress 모두 binding이 되어있고, 협동 모드는 나의 현재 거리만 binding이 되어있습니다. 추가적인 요소에 대한 binding 역시 overriding을 통해 구현할 수 있을 것 같습니다.
- 경쟁 모드의 RunningCardView의 경우 구성이 복잡하여 custom class로 분리하였습니다.
- override하기 위해서는 private을 해제해야 하며, extension의 function은 override할 수 없습니다. 이미 코드가 긴 configureUI, bindViewModel을 분리하는 방법을 같이 고민해보면 좋을 것 같습니다.

<br/><br/>
