### PR TITLE
초대장 뷰, 메이트 선택 뷰

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		AE3D1490273A5E4000D4A186 /* MateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148F273A5E4000D4A186 /* MateUseCase.swift */; };
 		AE3D1492273A5F5900D4A186 /* MateTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */; };
 		AE3D1495273A7A8000D4A186 /* DefaultMateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */; };
+		AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */; };
 		AE640ECF2736259C00711175 /* CoreMotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE640ECE2736259C00711175 /* CoreMotionManager.swift */; };
 		AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */; };
 		AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */; };
@@ -205,6 +206,7 @@
 		AE3D148F273A5E4000D4A186 /* MateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateUseCase.swift; sourceTree = "<group>"; };
 		AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateTableViewCell.swift; sourceTree = "<group>"; };
 		AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateUseCase.swift; sourceTree = "<group>"; };
+		AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMateViewController.swift; sourceTree = "<group>"; };
 		AE640ECE2736259C00711175 /* CoreMotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotionManager.swift; sourceTree = "<group>"; };
 		AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 				AE6A6F522730423D005A3A5C /* RunningModeSettingViewController.swift */,
 				B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */,
 				5E36992327358F7300D2A6F2 /* MapViewController.swift */,
+				AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1225,6 +1228,7 @@
 				B0628B97273A17E8004FAB0F /* HomeCoordinator.swift in Sources */,
 				3DF4C85B2731083B00A4B229 /* DefaultResultUseCase.swift in Sources */,
 				B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */,
+				AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */,
 				3DF4C8622735841B00A4B229 /* RunningResultUseCase.swift in Sources */,
 				AE3D1490273A5E4000D4A186 /* MateUseCase.swift in Sources */,
 				B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		AE3D1492273A5F5900D4A186 /* MateTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */; };
 		AE3D1495273A7A8000D4A186 /* DefaultMateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */; };
 		AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */; };
+		AE3D1499273B9E9600D4A186 /* MateEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */; };
 		AE640ECF2736259C00711175 /* CoreMotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE640ECE2736259C00711175 /* CoreMotionManager.swift */; };
 		AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */; };
 		AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */; };
@@ -207,6 +208,7 @@
 		AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateTableViewCell.swift; sourceTree = "<group>"; };
 		AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateUseCase.swift; sourceTree = "<group>"; };
 		AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMateViewController.swift; sourceTree = "<group>"; };
+		AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateEmptyView.swift; sourceTree = "<group>"; };
 		AE640ECE2736259C00711175 /* CoreMotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotionManager.swift; sourceTree = "<group>"; };
 		AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -655,6 +657,7 @@
 			children = (
 				AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */,
 				AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */,
+				AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1288,6 +1291,7 @@
 				AE6A6F37272FC723005A3A5C /* UIFont+CustomFont.swift in Sources */,
 				AE6A6F5A2732B940005A3A5C /* DefaultRunningSettingUseCase.swift in Sources */,
 				3D2C2180273A9A3400D00C68 /* TeamRunningUseCase.swift in Sources */,
+				AE3D1499273B9E9600D4A186 /* MateEmptyView.swift in Sources */,
 				AEDAFD1627352372009BAEAA /* SingleRunningViewModel.swift in Sources */,
 				B0F5328B273A3397005A3F11 /* TabBarCoordinator.swift in Sources */,
 				B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		AE3D1499273B9E9600D4A186 /* MateEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */; };
 		AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */; };
 		AE3D149D273BD67A00D4A186 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149C273BD67A00D4A186 /* InvitationView.swift */; };
+		AE3D149F273BDB5800D4A186 /* Double+Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149E273BDB5800D4A186 /* Double+Formatter.swift */; };
 		AE640ECF2736259C00711175 /* CoreMotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE640ECE2736259C00711175 /* CoreMotionManager.swift */; };
 		AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */; };
 		AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */; };
@@ -213,6 +214,7 @@
 		AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateEmptyView.swift; sourceTree = "<group>"; };
 		AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationViewController.swift; sourceTree = "<group>"; };
 		AE3D149C273BD67A00D4A186 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
+		AE3D149E273BDB5800D4A186 /* Double+Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Formatter.swift"; sourceTree = "<group>"; };
 		AE640ECE2736259C00711175 /* CoreMotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotionManager.swift; sourceTree = "<group>"; };
 		AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -642,6 +644,7 @@
 				AE6A6F36272FC723005A3A5C /* UIFont+CustomFont.swift */,
 				AE6A6F552730E450005A3A5C /* UIView+ShadowEffect.swift */,
 				3DF4C85F27355A3E00A4B229 /* Date+Formatter.swift */,
+				AE3D149E273BDB5800D4A186 /* Double+Formatter.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1284,6 +1287,7 @@
 				B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */,
 				3D2C217E273A99AC00D00C68 /* TeamRunningRepository.swift in Sources */,
 				5E171E6527325691001C003B /* RunningSetting.swift in Sources */,
+				AE3D149F273BDB5800D4A186 /* Double+Formatter.swift in Sources */,
 				B0F53298273A5DCA005A3F11 /* HomeUseCase.swift in Sources */,
 				5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */,
 				3DF6D07E27301F1100991DC3 /* RunningResultViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */; };
 		AE3D1499273B9E9600D4A186 /* MateEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */; };
 		AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */; };
+		AE3D149D273BD67A00D4A186 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149C273BD67A00D4A186 /* InvitationView.swift */; };
 		AE640ECF2736259C00711175 /* CoreMotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE640ECE2736259C00711175 /* CoreMotionManager.swift */; };
 		AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */; };
 		AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */; };
@@ -211,6 +212,7 @@
 		AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMateViewController.swift; sourceTree = "<group>"; };
 		AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateEmptyView.swift; sourceTree = "<group>"; };
 		AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationViewController.swift; sourceTree = "<group>"; };
+		AE3D149C273BD67A00D4A186 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
 		AE640ECE2736259C00711175 /* CoreMotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotionManager.swift; sourceTree = "<group>"; };
 		AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -713,6 +715,7 @@
 				5E7F1F6E2733A37600F2B662 /* RunningInfoView.swift */,
 				5E7F1F702733A59C00F2B662 /* RunningProgressView.swift */,
 				5E6F382B273A50B3009686DC /* RunningCardView.swift */,
+				AE3D149C273BD67A00D4A186 /* InvitationView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1256,6 +1259,7 @@
 				5E6F382C273A50B3009686DC /* RunningCardView.swift in Sources */,
 				5E7F1F712733A59C00F2B662 /* RunningProgressView.swift in Sources */,
 				3DF4C86F27376CDA00A4B229 /* FIreStoreNetworkService.swift in Sources */,
+				AE3D149D273BD67A00D4A186 /* InvitationView.swift in Sources */,
 				AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */,
 				AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */,
 				AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		AE3D1495273A7A8000D4A186 /* DefaultMateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */; };
 		AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */; };
 		AE3D1499273B9E9600D4A186 /* MateEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */; };
+		AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */; };
 		AE640ECF2736259C00711175 /* CoreMotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE640ECE2736259C00711175 /* CoreMotionManager.swift */; };
 		AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */; };
 		AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */; };
@@ -209,6 +210,7 @@
 		AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateUseCase.swift; sourceTree = "<group>"; };
 		AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMateViewController.swift; sourceTree = "<group>"; };
 		AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateEmptyView.swift; sourceTree = "<group>"; };
+		AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationViewController.swift; sourceTree = "<group>"; };
 		AE640ECE2736259C00711175 /* CoreMotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotionManager.swift; sourceTree = "<group>"; };
 		AE6A6F2C272CCB2A005A3A5C /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		AE6A6F2E272CCB46005A3A5C /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 				B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */,
 				5E36992327358F7300D2A6F2 /* MapViewController.swift */,
 				AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */,
+				AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1236,6 +1239,7 @@
 				AE3D1490273A5E4000D4A186 /* MateUseCase.swift in Sources */,
 				B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */,
 				B0F53296273A5D8E005A3F11 /* HomeViewModel.swift in Sources */,
+				AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */,
 				B0628B8D27397415004FAB0F /* DistanceSettingUseCase.swift in Sources */,
 				AE6A6F35272FC170005A3A5C /* DistanceSettingViewController.swift in Sources */,
 				3D2C2175273A719500D00C68 /* DefaultTeamRunningUseCase.swift in Sources */,

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -82,7 +82,7 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
                 return HomeViewController()
             }
             return homeViewController
-        case .record: return InvitationViewController(mate: "jk", mode: .race, distance: 5.00)
+        case .record: return HomeViewController()
         case .mate: return MateViewController()
         case .mypage: return HomeViewController()
         }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -82,7 +82,7 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
                 return HomeViewController()
             }
             return homeViewController
-        case .record: return HomeViewController()
+        case .record: return InvitationViewController(mate: "jk", mode: .race, distance: 5.00)
         case .mate: return MateViewController()
         case .mypage: return HomeViewController()
         }

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
@@ -1,0 +1,167 @@
+//
+//  InvitationView.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/10.
+//
+
+import UIKit
+
+final class InvitationView: UIView {
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 3
+        label.font = .notoSans(size: 18, family: .bold)
+        return label
+    }()
+    
+    private lazy var lineView: UIView = {
+        let line = UIView()
+        line.backgroundColor = .mrGray
+        return line
+    }()
+    
+    private lazy var runningModeLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSans(size: 23, family: .bold)
+        return label
+    }()
+    
+    private lazy var distanceLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 50)
+        label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
+        return label
+    }()
+    
+    private lazy var kilometerLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSans(size: 18, family: .light)
+        label.text = "킬로미터"
+        label.textColor = .gray
+        return label
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackview = UIStackView()
+        stackview.axis = .horizontal
+        stackview.spacing = 20
+        stackview.addArrangedSubview(self.refuseButton)
+        stackview.addArrangedSubview(self.acceptButton)
+        return stackview
+    }()
+    
+    private lazy var descriptionModeLabel = self.createDescriptionLabel(text: "함께할 달리기")
+    private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
+    private lazy var refuseButton = self.createInviteButton(text: "거절", color: .mrGray)
+    private lazy var acceptButton = self.createInviteButton(text: "수락", color: .mrPurple)
+    
+    convenience init(mate: String, mode: RunningMode, distance: Double) {
+        self.init(frame: .zero)
+        self.configureUI(mate: mate, mode: mode, distance: distance)
+        
+    }
+}
+
+// MARK: - Private Functions
+
+private extension InvitationView {
+    func configureUI(mate: String, mode: RunningMode, distance: Double) {
+        self.updateValue(mate: mate, mode: mode, distance: distance)
+        
+        self.layer.masksToBounds = true
+        self.layer.cornerRadius = 10
+        self.backgroundColor = .white
+        
+        self.snp.makeConstraints { make in
+            make.width.equalTo(320)
+            make.height.equalTo(490)
+        }
+        
+        self.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(25)
+        }
+        
+        self.addSubview(self.lineView)
+        self.lineView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.width.equalTo(238)
+            make.height.equalTo(1)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(30)
+        }
+        
+        self.addSubview(self.descriptionModeLabel)
+        self.descriptionModeLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.lineView).offset(18)
+            make.centerX.equalToSuperview()
+        }
+        
+        self.addSubview(self.runningModeLabel)
+        self.runningModeLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.descriptionModeLabel.snp.bottom).offset(20)
+        }
+        
+        self.addSubview(self.descriptionDistanceLabel)
+        self.descriptionDistanceLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.runningModeLabel.snp.bottom).offset(40)
+        }
+        
+        self.addSubview(self.distanceLabel)
+        self.distanceLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.descriptionDistanceLabel.snp.bottom).offset(20)
+            make.left.equalToSuperview().offset(75)
+        }
+        
+        self.addSubview(self.kilometerLabel)
+        self.kilometerLabel.snp.makeConstraints { make in
+            make.right.equalToSuperview().offset(-75)
+            make.bottom.equalTo(self.distanceLabel.snp.bottom).offset(-10)
+        }
+        
+        self.addSubview(self.stackView)
+        self.stackView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-35)
+        }
+        
+        self.acceptButton.snp.makeConstraints { make in
+            make.width.equalTo(100)
+            make.height.equalTo(50)
+        }
+        
+        self.refuseButton.snp.makeConstraints { make in
+            make.width.equalTo(100)
+            make.height.equalTo(50)
+        }
+    }
+    
+    func updateValue(mate: String, mode: RunningMode, distance: Double) {
+        self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mate)님의\n초대가 도착했습니다!"
+        self.runningModeLabel.text = "🤜 \(mode.title)"
+        self.distanceLabel.text = "\(String(format: "%.2f", distance))"
+    }
+    
+    func createDescriptionLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.font = .notoSans(size: 16, family: .bold)
+        label.text = text
+        label.textAlignment = .center
+        return label
+    }
+    
+    func createInviteButton(text: String, color: UIColor) -> UIButton {
+        let button = UIButton()
+        button.setTitle(text, for: .normal)
+        button.backgroundColor = color
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .notoSans(size: 18, family: .bold)
+        button.layer.masksToBounds = true
+        button.layer.cornerRadius = 15
+        return button
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
@@ -143,7 +143,7 @@ private extension InvitationView {
     func updateValue(mate: String, mode: RunningMode, distance: Double) {
         self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mate)님의\n초대가 도착했습니다!"
         self.runningModeLabel.text = "🤜 \(mode.title)"
-        self.distanceLabel.text = "\(String(format: "%.2f", distance))"
+        self.distanceLabel.text = distance.doubleToString()
     }
     
     func createDescriptionLabel(text: String) -> UILabel {

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
@@ -60,7 +60,6 @@ final class InvitationView: UIView {
     convenience init(mate: String, mode: RunningMode, distance: Double) {
         self.init(frame: .zero)
         self.configureUI(mate: mate, mode: mode, distance: distance)
-        
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -32,7 +32,7 @@ final class InvitationViewController: UIViewController {
     
     private lazy var runningModeLabel: UILabel = {
         let label = UILabel()
-        label.font = .notoSans(size: 20, family: .bold)
+        label.font = .notoSans(size: 23, family: .bold)
         return label
     }()
     
@@ -51,13 +51,14 @@ final class InvitationViewController: UIViewController {
         return label
     }()
     
-//    private lazy var stackView: UIStackView = {
-//        let stackview = UIStackView()
-//        stackview.axis = .horizontal
-//        stackview.addArrangedSubview(self.distanceLabel)
-//        stackview.addArrangedSubview(self.kilometerLabel)
-//        return stackview
-//    }()
+    private lazy var stackView: UIStackView = {
+        let stackview = UIStackView()
+        stackview.axis = .horizontal
+        stackview.spacing = 20
+        stackview.addArrangedSubview(self.refuseButton)
+        stackview.addArrangedSubview(self.acceptButton)
+        return stackview
+    }()
     
     private lazy var descriptionModeLabel = self.createDescriptionLabel(text: "함께할 달리기")
     private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
@@ -68,7 +69,7 @@ final class InvitationViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mate)님의\n초대가 도착했습니다!"
         self.runningModeLabel.text = "🤜 \(mode.title)"
-        self.distanceLabel.text = "\(distance)"
+        self.distanceLabel.text = "\(String(format: "%.2f", distance))"
     }
     
     required init?(coder: NSCoder) {
@@ -99,7 +100,7 @@ private extension InvitationViewController {
         self.invitationView.addSubview(self.titleLabel)
         self.titleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(15)
+            make.top.equalToSuperview().offset(25)
         }
         
         self.invitationView.addSubview(self.lineView)
@@ -107,7 +108,7 @@ private extension InvitationViewController {
             make.centerX.equalToSuperview()
             make.width.equalTo(238)
             make.height.equalTo(1)
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(25)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(30)
         }
         
         self.invitationView.addSubview(self.descriptionModeLabel)
@@ -131,20 +132,30 @@ private extension InvitationViewController {
         self.invitationView.addSubview(self.distanceLabel)
         self.distanceLabel.snp.makeConstraints { make in
             make.top.equalTo(self.descriptionDistanceLabel.snp.bottom).offset(20)
-            make.left.equalToSuperview().offset(80)
+            make.left.equalToSuperview().offset(75)
         }
         
         self.invitationView.addSubview(self.kilometerLabel)
         self.kilometerLabel.snp.makeConstraints { make in
-            make.right.equalToSuperview().offset(-80)
+            make.right.equalToSuperview().offset(-75)
             make.bottom.equalTo(self.distanceLabel.snp.bottom).offset(-10)
         }
         
-//        self.invitationView.addSubview(self.stackView)
-//        self.stackView.snp.makeConstraints { make in
-//            make.centerX.equalToSuperview()
-//            make.top.equalTo(self.descriptionDistanceLabel.snp.bottom).offset(20)
-//        }
+        self.invitationView.addSubview(self.stackView)
+        self.stackView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-35)
+        }
+        
+        self.acceptButton.snp.makeConstraints { make in
+            make.width.equalTo(100)
+            make.height.equalTo(50)
+        }
+        
+        self.refuseButton.snp.makeConstraints { make in
+            make.width.equalTo(100)
+            make.height.equalTo(50)
+        }
     }
     
     func createDescriptionLabel(text: String) -> UILabel {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -31,7 +31,8 @@ final class InvitationViewController: UIViewController {
 
 private extension InvitationViewController {
     func configureUI() {
-        self.view.backgroundColor = UIColor.clear
+        self.view.backgroundColor = UIColor.clear //이렇게 한다면 이전 뷰컨에서 addsubView로 배경의 투명도와 색을 지정해야함
+//      self.view.backgroundColor = UIColor.black.withAlphaComponent(0.5) 투명도 있는 배경 -> animated: false
         self.view.isOpaque = false
         
         self.view.addSubview(invitationView)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -31,8 +31,8 @@ final class InvitationViewController: UIViewController {
 
 private extension InvitationViewController {
     func configureUI() {
-        self.view.backgroundColor = UIColor.clear //이렇게 한다면 이전 뷰컨에서 addsubView로 배경의 투명도와 색을 지정해야함
-//      self.view.backgroundColor = UIColor.black.withAlphaComponent(0.5) 투명도 있는 배경 -> animated: false
+//        self.view.backgroundColor = UIColor.clear //이렇게 한다면 이전 뷰컨에서 addsubView로 배경의 투명도와 색을 지정해야함
+      self.view.backgroundColor = UIColor.black.withAlphaComponent(0.5) // 투명도 있는 배경 -> animated: false
         self.view.isOpaque = false
         
         self.view.addSubview(invitationView)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -31,6 +31,9 @@ final class InvitationViewController: UIViewController {
 
 private extension InvitationViewController {
     func configureUI() {
+        self.view.backgroundColor = UIColor.clear
+        self.view.isOpaque = false
+        
         self.view.addSubview(invitationView)
         self.invitationView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -8,9 +8,6 @@
 import UIKit
 
 final class InvitationViewController: UIViewController {
-    private lazy var descriptionModeLabel = self.createDescriptionLabel(text: "함께할 달리기")
-    private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
-    
     private lazy var invitationView: UIView = {
         let view = UIView()
         view.layer.masksToBounds = true
@@ -22,18 +19,18 @@ final class InvitationViewController: UIViewController {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
-        label.numberOfLines = 2
+        label.numberOfLines = 3
         label.font = .notoSans(size: 18, family: .bold)
         return label
     }()
     
     private lazy var lineView: UIView = {
         let line = UIView()
-        line.backgroundColor = .gray
+        line.backgroundColor = .mrGray
         return line
     }()
     
-    private lazy var runningMode: UILabel = {
+    private lazy var runningModeLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSans(size: 20, family: .bold)
         return label
@@ -42,28 +39,114 @@ final class InvitationViewController: UIViewController {
     private lazy var distanceLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSansBoldItalic(size: 50)
+        label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
         return label
     }()
     
     private lazy var kilometerLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSans(size: 18, family: .light)
+        label.text = "킬로미터"
         label.textColor = .gray
         return label
     }()
     
-    private lazy var stackView: UIStackView = {
-        let stackview = UIStackView()
-        return stackview
-    }()
+//    private lazy var stackView: UIStackView = {
+//        let stackview = UIStackView()
+//        stackview.axis = .horizontal
+//        stackview.addArrangedSubview(self.distanceLabel)
+//        stackview.addArrangedSubview(self.kilometerLabel)
+//        return stackview
+//    }()
     
+    private lazy var descriptionModeLabel = self.createDescriptionLabel(text: "함께할 달리기")
+    private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
     private lazy var refuseButton = self.createInviteButton(text: "거절", color: .mrGray)
     private lazy var acceptButton = self.createInviteButton(text: "수락", color: .mrPurple)
+    
+    init(mate: String, mode: RunningMode, distance: Double) {
+        super.init(nibName: nil, bundle: nil)
+        self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mate)님의\n초대가 도착했습니다!"
+        self.runningModeLabel.text = "🤜 \(mode.title)"
+        self.distanceLabel.text = "\(distance)"
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureUI()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureUI()
+    }
+    
 }
 
 // MARK: - Private Functions
 
 private extension InvitationViewController {
+    func configureUI() {
+        self.view.backgroundColor = .gray
+        
+        self.view.addSubview(self.invitationView)
+        self.invitationView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+            make.width.equalTo(320)
+            make.height.equalTo(490)
+        }
+        
+        self.invitationView.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(15)
+        }
+        
+        self.invitationView.addSubview(self.lineView)
+        self.lineView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.width.equalTo(238)
+            make.height.equalTo(1)
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(25)
+        }
+        
+        self.invitationView.addSubview(self.descriptionModeLabel)
+        self.descriptionModeLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.lineView).offset(18)
+            make.centerX.equalToSuperview()
+        }
+        
+        self.invitationView.addSubview(self.runningModeLabel)
+        self.runningModeLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.descriptionModeLabel.snp.bottom).offset(20)
+        }
+        
+        self.invitationView.addSubview(self.descriptionDistanceLabel)
+        self.descriptionDistanceLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.runningModeLabel.snp.bottom).offset(40)
+        }
+        
+        self.invitationView.addSubview(self.distanceLabel)
+        self.distanceLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.descriptionDistanceLabel.snp.bottom).offset(20)
+            make.left.equalToSuperview().offset(80)
+        }
+        
+        self.invitationView.addSubview(self.kilometerLabel)
+        self.kilometerLabel.snp.makeConstraints { make in
+            make.right.equalToSuperview().offset(-80)
+            make.bottom.equalTo(self.distanceLabel.snp.bottom).offset(-10)
+        }
+        
+//        self.invitationView.addSubview(self.stackView)
+//        self.stackView.snp.makeConstraints { make in
+//            make.centerX.equalToSuperview()
+//            make.top.equalTo(self.descriptionDistanceLabel.snp.bottom).offset(20)
+//        }
+    }
+    
     func createDescriptionLabel(text: String) -> UILabel {
         let label = UILabel()
         label.font = .notoSans(size: 16, family: .bold)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -1,0 +1,85 @@
+//
+//  InvitationViewController.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/10.
+//
+
+import UIKit
+
+final class InvitationViewController: UIViewController {
+    private lazy var descriptionModeLabel = self.createDescriptionLabel(text: "함께할 달리기")
+    private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
+    
+    private lazy var invitationView: UIView = {
+        let view = UIView()
+        view.layer.masksToBounds = true
+        view.layer.cornerRadius = 10
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        label.font = .notoSans(size: 18, family: .bold)
+        return label
+    }()
+    
+    private lazy var lineView: UIView = {
+        let line = UIView()
+        line.backgroundColor = .gray
+        return line
+    }()
+    
+    private lazy var runningMode: UILabel = {
+        let label = UILabel()
+        label.font = .notoSans(size: 20, family: .bold)
+        return label
+    }()
+    
+    private lazy var distanceLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSansBoldItalic(size: 50)
+        return label
+    }()
+    
+    private lazy var kilometerLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSans(size: 18, family: .light)
+        label.textColor = .gray
+        return label
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackview = UIStackView()
+        return stackview
+    }()
+    
+    private lazy var refuseButton = self.createInviteButton(text: "거절", color: .mrGray)
+    private lazy var acceptButton = self.createInviteButton(text: "수락", color: .mrPurple)
+}
+
+// MARK: - Private Functions
+
+private extension InvitationViewController {
+    func createDescriptionLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.font = .notoSans(size: 16, family: .bold)
+        label.text = text
+        label.textAlignment = .center
+        return label
+    }
+    
+    func createInviteButton(text: String, color: UIColor) -> UIButton {
+        let button = UIButton()
+        button.setTitle(text, for: .normal)
+        button.backgroundColor = color
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .notoSans(size: 18, family: .bold)
+        button.layer.masksToBounds = true
+        button.layer.cornerRadius = 15
+        return button
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -8,68 +8,11 @@
 import UIKit
 
 final class InvitationViewController: UIViewController {
-    private lazy var invitationView: UIView = {
-        let view = UIView()
-        view.layer.masksToBounds = true
-        view.layer.cornerRadius = 10
-        view.backgroundColor = .white
-        return view
-    }()
-    
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment = .center
-        label.numberOfLines = 3
-        label.font = .notoSans(size: 18, family: .bold)
-        return label
-    }()
-    
-    private lazy var lineView: UIView = {
-        let line = UIView()
-        line.backgroundColor = .mrGray
-        return line
-    }()
-    
-    private lazy var runningModeLabel: UILabel = {
-        let label = UILabel()
-        label.font = .notoSans(size: 23, family: .bold)
-        return label
-    }()
-    
-    private lazy var distanceLabel: UILabel = {
-        let label = UILabel()
-        label.font = .notoSansBoldItalic(size: 50)
-        label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
-        return label
-    }()
-    
-    private lazy var kilometerLabel: UILabel = {
-        let label = UILabel()
-        label.font = .notoSans(size: 18, family: .light)
-        label.text = "킬로미터"
-        label.textColor = .gray
-        return label
-    }()
-    
-    private lazy var stackView: UIStackView = {
-        let stackview = UIStackView()
-        stackview.axis = .horizontal
-        stackview.spacing = 20
-        stackview.addArrangedSubview(self.refuseButton)
-        stackview.addArrangedSubview(self.acceptButton)
-        return stackview
-    }()
-    
-    private lazy var descriptionModeLabel = self.createDescriptionLabel(text: "함께할 달리기")
-    private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
-    private lazy var refuseButton = self.createInviteButton(text: "거절", color: .mrGray)
-    private lazy var acceptButton = self.createInviteButton(text: "수락", color: .mrPurple)
+    private lazy var invitationView = InvitationView()
     
     init(mate: String, mode: RunningMode, distance: Double) {
         super.init(nibName: nil, bundle: nil)
-        self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mate)님의\n초대가 도착했습니다!"
-        self.runningModeLabel.text = "🤜 \(mode.title)"
-        self.distanceLabel.text = "\(String(format: "%.2f", distance))"
+        self.invitationView = InvitationView(mate: mate, mode: mode, distance: distance)
     }
     
     required init?(coder: NSCoder) {
@@ -88,92 +31,9 @@ final class InvitationViewController: UIViewController {
 
 private extension InvitationViewController {
     func configureUI() {
-        self.view.backgroundColor = .gray
-        
-        self.view.addSubview(self.invitationView)
+        self.view.addSubview(invitationView)
         self.invitationView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()
-            make.width.equalTo(320)
-            make.height.equalTo(490)
         }
-        
-        self.invitationView.addSubview(self.titleLabel)
-        self.titleLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(25)
-        }
-        
-        self.invitationView.addSubview(self.lineView)
-        self.lineView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.width.equalTo(238)
-            make.height.equalTo(1)
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(30)
-        }
-        
-        self.invitationView.addSubview(self.descriptionModeLabel)
-        self.descriptionModeLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.lineView).offset(18)
-            make.centerX.equalToSuperview()
-        }
-        
-        self.invitationView.addSubview(self.runningModeLabel)
-        self.runningModeLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(self.descriptionModeLabel.snp.bottom).offset(20)
-        }
-        
-        self.invitationView.addSubview(self.descriptionDistanceLabel)
-        self.descriptionDistanceLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(self.runningModeLabel.snp.bottom).offset(40)
-        }
-        
-        self.invitationView.addSubview(self.distanceLabel)
-        self.distanceLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.descriptionDistanceLabel.snp.bottom).offset(20)
-            make.left.equalToSuperview().offset(75)
-        }
-        
-        self.invitationView.addSubview(self.kilometerLabel)
-        self.kilometerLabel.snp.makeConstraints { make in
-            make.right.equalToSuperview().offset(-75)
-            make.bottom.equalTo(self.distanceLabel.snp.bottom).offset(-10)
-        }
-        
-        self.invitationView.addSubview(self.stackView)
-        self.stackView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.bottom.equalToSuperview().offset(-35)
-        }
-        
-        self.acceptButton.snp.makeConstraints { make in
-            make.width.equalTo(100)
-            make.height.equalTo(50)
-        }
-        
-        self.refuseButton.snp.makeConstraints { make in
-            make.width.equalTo(100)
-            make.height.equalTo(50)
-        }
-    }
-    
-    func createDescriptionLabel(text: String) -> UILabel {
-        let label = UILabel()
-        label.font = .notoSans(size: 16, family: .bold)
-        label.text = text
-        label.textAlignment = .center
-        return label
-    }
-    
-    func createInviteButton(text: String, color: UIColor) -> UIButton {
-        let button = UIButton()
-        button.setTitle(text, for: .normal)
-        button.backgroundColor = color
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = .notoSans(size: 18, family: .bold)
-        button.layer.masksToBounds = true
-        button.layer.cornerRadius = 15
-        return button
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InviteMateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InviteMateViewController.swift
@@ -1,0 +1,20 @@
+//
+//  InviteMateViewController.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/10.
+//
+
+import UIKit
+
+final class InviteMateViewController: MateViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureNavigation()
+    }
+        
+    override func configureNavigation() {
+        self.navigationItem.title = "친구 목록"
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InviteMateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InviteMateViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 final class InviteMateViewController: MateViewController {
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureNavigation()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InviteMateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InviteMateViewController.swift
@@ -17,4 +17,9 @@ final class InviteMateViewController: MateViewController {
     override func configureNavigation() {
         self.navigationItem.title = "친구 목록"
     }
+    
+    override func moveToNext(mate: String) {
+        let distanceSettingViewController = DistanceSettingViewController()
+        self.navigationController?.pushViewController(distanceSettingViewController, animated: true)
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateRunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateRunningModeSettingViewController.swift
@@ -142,7 +142,7 @@ private extension MateRunningModeSettingViewController {
     }
     
     func nextButtonDidTap() {
-        let distanceSettingViewController = DistanceSettingViewController()
-        self.navigationController?.pushViewController(distanceSettingViewController, animated: true)
+        let inviteMateViewController = InviteMateViewController()
+        self.navigationController?.pushViewController(inviteMateViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateEmptyView.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateEmptyView.swift
@@ -1,0 +1,37 @@
+//
+//  MateEmptyView.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/10.
+//
+
+import UIKit
+
+import SnapKit
+
+final class MateEmptyView: UIView {
+    convenience init(title: String, topOffset: Int) {
+        self.init(frame: .zero)
+        self.configureUI(title: title, topOffset: topOffset)
+    }
+}
+
+// MARK: - Private Functions
+
+private extension MateEmptyView {
+    func configureUI(title: String, topOffset: Int) {
+        let titleLabel = UILabel()
+        
+        titleLabel.font = .notoSans(size: 14, family: .medium)
+        titleLabel.textColor = .darkGray
+        titleLabel.text = title
+        titleLabel.numberOfLines = 2
+        titleLabel.textAlignment = .center
+        
+        self.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(topOffset)
+        }
+    }
+}

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -52,11 +52,17 @@ class MateViewController: UIViewController {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "person.badge.plus"),
                                                                  style: .plain,
                                                                  target: self,
-                                                                 action: nil)
+                                                                 action: #selector(test))
     }
     
     func moveToNext(mate: String) {
         // 친구 프로필로 이동
+    }
+    
+    @objc func test() {
+        let vc = InvitationViewController(mate: "jk", mode: .race, distance: 6.00)
+        vc.modalPresentationStyle = .overCurrentContext
+        self.tabBarController?.present(vc, animated: false, completion: nil)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -12,9 +12,13 @@ import RxSwift
 enum TableViewValue: CGFloat {
     case tableViewCellHeight = 80
     case tableViewHeaderHeight = 35
+    
+    func value() -> CGFloat {
+        return self.rawValue
+    }
 }
 
-final class MateViewController: UIViewController {
+class MateViewController: UIViewController {
     let mateViewModel = MateViewModel(
         mateUseCase: DefaultMateUseCase()
     )
@@ -42,17 +46,21 @@ final class MateViewController: UIViewController {
         self.configureUI()
         self.bindViewModel()
     }
+    
+    func configureNavigation() {
+        self.navigationItem.title = "친구 목록"
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "person.badge.plus"),
+                                                                 style: .plain,
+                                                                 target: self,
+                                                                 action: nil)
+    }
 }
 
 // MARK: - Private Functions
 
 private extension MateViewController {
     func configureUI() {
-        self.navigationItem.title = "친구 목록"
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "person.badge.plus"),
-                                                                 style: .plain,
-                                                                 target: self,
-                                                                 action: nil)
+        self.configureNavigation()
         
         self.view.addSubview(self.mateSearchBar)
         self.mateSearchBar.snp.makeConstraints { make in
@@ -96,7 +104,7 @@ private extension MateViewController {
 
 extension MateViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return TableViewValue.tableViewCellHeight.rawValue
+        return TableViewValue.tableViewCellHeight.value()
     }
 }
 
@@ -104,7 +112,7 @@ extension MateViewController: UITableViewDelegate {
 
 extension MateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return TableViewValue.tableViewHeaderHeight.rawValue
+        return TableViewValue.tableViewHeaderHeight.value()
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -31,7 +31,7 @@ class MateViewController: UIViewController {
         return searchBar
     }()
     
-    private lazy var mateTableView: UITableView = {
+    lazy var mateTableView: UITableView = {
         let tableView = UITableView()
         tableView.separatorStyle = .none
         tableView.delegate = self
@@ -53,6 +53,10 @@ class MateViewController: UIViewController {
                                                                  style: .plain,
                                                                  target: self,
                                                                  action: nil)
+    }
+    
+    func moveToNext(mate: String) {
+        // 친구 프로필로 이동
     }
 }
 
@@ -98,6 +102,30 @@ private extension MateViewController {
             })
             .disposed(by: self.disposeBag)
     }
+    
+    func removeEmptyView() {
+        self.mateTableView.subviews.forEach({ $0.removeFromSuperview() })
+    }
+    
+    func checkMateCount() {
+        if self.mateViewModel.filteredMate.count == 0 {
+            self.addEmptyView()
+        } else {
+            self.removeEmptyView()
+        }
+    }
+    
+    func addEmptyView() {
+        let emptyView = MateEmptyView(
+            title: "등록된 메이트가 없습니다.\n메이트를 등록하고 함께 응원하며 달려보세요!",
+            topOffset: 180
+        )
+        
+        self.mateTableView.addSubview(emptyView)
+        emptyView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+        }
+    }
 }
 
 // MARK: - UITableViewDelegate
@@ -124,6 +152,7 @@ extension MateViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        self.checkMateCount()
         return self.mateViewModel.filteredMate.count
     }
     
@@ -137,5 +166,15 @@ extension MateViewController: UITableViewDataSource {
         cell.updateUI(image: mateKey.key, name: mateKey.value)
         
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
+        // 친구 초대 - 닉네임 가지고 초대장 보내야함
+        let mateDictionary = self.mateViewModel.filteredMate
+        let mateKey = Array(mateDictionary)[indexPath.row]
+        let mateNickname = mateKey.value
+        self.moveToNext(mate: mateNickname)
     }
 }

--- a/MateRunner/MateRunner/Util/Extension/Double+Formatter.swift
+++ b/MateRunner/MateRunner/Util/Extension/Double+Formatter.swift
@@ -1,0 +1,14 @@
+//
+//  Double+Formatter.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/10.
+//
+
+import Foundation
+
+extension Double {
+    func doubleToString() -> String {
+        return "\(String(format: "%.2f", self))"
+    }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #67 #68 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 친구에게 함께 달리기 초대를 받으면 초대장을 표시한다.
- [x] 배경은 불투명한 검은색으로 표시하고, 모달 형태로 띄운다.
- [x]  친구가 없을 때는 엠티뷰를 보인다.
- [x]  화면 상단에는 검색바가 있고 닉네임을 검색할 수 있다.
- [x]  친구들의 정보 리스트를 표시한다.

    | 엠티뷰 | 초대장 |
    |:--:|:--:|
    | <img  src="https://user-images.githubusercontent.com/41044154/141105936-e51e2906-1f80-40cb-b6d2-6c44270db075.png"> |<img  src="https://user-images.githubusercontent.com/41044154/141107339-83d588c6-5c99-40c5-9afe-5648ec916724.png"  width="100%"  height="%">|

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 모달뷰를 Push 할 때 `self.present` 방식으로 띄우게 되면 탭바가 제일 상위에 올라오게 됩니다!
```swift
let vc = InvitationViewController(mate: "jk", mode: .race, distance: 6.00)
vc.modalPresentationStyle = .overCurrentContext
self.tabBarController?.present(vc, animated: true, completion: nil)
```
그래서 이런식으로 `self.tabBarController?.present` 탭바컨트롤러 위에 띄워야 탭바의 상위에 뜨더라구요! 이미 아시는 내용일수도 있지만 전 이걸 몰라서 오늘 사소한곳에서 시간을 많이 소비했네요..🥲

- 초대장 모달화면 띄울 때 방식에 대해 간단하게 이야기 해보면 좋을 것 같습니다!
`1. animated 없이 바로 띄우는 방법` : 모달뷰의 background가 투명도있는 검정색
`2. animated 있게 밑에서 올라오는 방법` : 모달뷰의 background가 clear, 모달뷰를 띄우는 뷰에서 투명도 있는 검정색 뷰를 add
개인적으로 1번보다는 2번의 방식이 보기에는 예뻐보이지만 add한 뷰를 다시 remove 하는 추가적인 작업이 필요할 것 같습니다!
```swift
//2번 방식
let view = UIView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: self.view.frame.height))
view.backgroundColor = UIColor.black.withAlphaComponent(0.5)
self.tabBarController?.view.addSubview(view)

// -> present
```
마찬가지로 view.addSubview를 `self`가 아닌 `self.tabBarController` 에서 해줘야 의도한대로 올라가더라구요!

| 1번 | 2번 |
|:--:|:--:|
| <img  src="https://user-images.githubusercontent.com/41044154/141109918-434c0855-1c71-4fbf-b8bb-a33b26904ec8.gif"  width="100%"  height="%">| <img  src="https://user-images.githubusercontent.com/41044154/141109501-0a3dea0f-a014-4cbe-922d-bacbc04f528e.gif"  width="100%"  height="%">|

<br/><br/>
