### PR TITLE
Home, Setting 코디네이터 구현 및 달리기 세팅 데이터 전달 

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -91,7 +91,7 @@
 		B0628B90273976DF004FAB0F /* DistanceSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B8C27397415004FAB0F /* DistanceSettingUseCase.swift */; };
 		B0628B9127397703004FAB0F /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		B0628B94273A1752004FAB0F /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B93273A1752004FAB0F /* Coordinator.swift */; };
-		B0628B97273A17E8004FAB0F /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */; };
+		B0628B97273A17E8004FAB0F /* RunningSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */; };
 		B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B98273A1ADD004FAB0F /* DefaultAppCoordinator.swift */; };
 		B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC327326C1C00D1EDAC /* Emoji.swift */; };
 		B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */; };
@@ -113,7 +113,7 @@
 		B0F5328D273A33D0005A3F11 /* DefaultTabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5328C273A33D0005A3F11 /* DefaultTabBarCoordinator.swift */; };
 		B0F5328F273A35E0005A3F11 /* CoordinatorFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5328E273A35DF005A3F11 /* CoordinatorFinishDelegate.swift */; };
 		B0F53291273A370B005A3F11 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53290273A370B005A3F11 /* AppCoordinator.swift */; };
-		B0F53294273A58AF005A3F11 /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53293273A58AE005A3F11 /* DefaultSettingCoordinator.swift */; };
+		B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53293273A58AE005A3F11 /* DefaultRunningSettingCoordinator.swift */; };
 		B0F53296273A5D8E005A3F11 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53295273A5D8E005A3F11 /* HomeViewModel.swift */; };
 		B0F53298273A5DCA005A3F11 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53297273A5DCA005A3F11 /* HomeUseCase.swift */; };
 		BFB9590DC444E39D242E583A /* Pods_DistanceSettingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63485622E4D462D4FDB690D9 /* Pods_DistanceSettingTests.framework */; };
@@ -242,7 +242,7 @@
 		B0628B8A27397354004FAB0F /* DefaultDistanceSettingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultDistanceSettingUseCase.swift; sourceTree = "<group>"; };
 		B0628B8C27397415004FAB0F /* DistanceSettingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistanceSettingUseCase.swift; sourceTree = "<group>"; };
 		B0628B93273A1752004FAB0F /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
-		B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
+		B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningSettingCoordinator.swift; sourceTree = "<group>"; };
 		B0628B98273A1ADD004FAB0F /* DefaultAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAppCoordinator.swift; sourceTree = "<group>"; };
 		B06E6DC327326C1C00D1EDAC /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResult.swift; sourceTree = "<group>"; };
@@ -255,7 +255,7 @@
 		B0F5328C273A33D0005A3F11 /* DefaultTabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTabBarCoordinator.swift; sourceTree = "<group>"; };
 		B0F5328E273A35DF005A3F11 /* CoordinatorFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFinishDelegate.swift; sourceTree = "<group>"; };
 		B0F53290273A370B005A3F11 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
-		B0F53293273A58AE005A3F11 /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
+		B0F53293273A58AE005A3F11 /* DefaultRunningSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningSettingCoordinator.swift; sourceTree = "<group>"; };
 		B0F53295273A5D8E005A3F11 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		B0F53297273A5DCA005A3F11 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
 		C1992193F37FCC013EC428ED /* Pods-SingleRunningTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SingleRunningTests.release.xcconfig"; path = "Target Support Files/Pods-SingleRunningTests/Pods-SingleRunningTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -733,7 +733,7 @@
 			isa = PBXGroup;
 			children = (
 				B0F53292273A589B005A3F11 /* Protocol */,
-				B0F53293273A58AE005A3F11 /* DefaultSettingCoordinator.swift */,
+				B0F53293273A58AE005A3F11 /* DefaultRunningSettingCoordinator.swift */,
 				B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */,
 			);
 			path = Coordinator;
@@ -808,7 +808,7 @@
 		B0F53292273A589B005A3F11 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
-				B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */,
+				B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */,
 				B02FCAD7273BA987001657FE /* HomeCoordinator.swift */,
 				B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */,
 			);
@@ -1176,14 +1176,14 @@
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
 				3DF4C86927376B7B00A4B229 /* NetworkService.swift in Sources */,
 				3DF4C859273104B500A4B229 /* RunningResultViewModel.swift in Sources */,
-				B0F53294273A58AF005A3F11 /* DefaultSettingCoordinator.swift in Sources */,
+				B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */,
 				3DF4C8662737687900A4B229 /* DefaultRunningResultRepository.swift in Sources */,
 				5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */,
 				3DFD08B827391BDA00B46479 /* RunningData.swift in Sources */,
 				5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */,
 				AE6A6F582730FAEB005A3A5C /* RunningModeSettingViewModel.swift in Sources */,
 				AE6A6F33272CCB74005A3A5C /* MateViewController.swift in Sources */,
-				B0628B97273A17E8004FAB0F /* SettingCoordinator.swift in Sources */,
+				B0628B97273A17E8004FAB0F /* RunningSettingCoordinator.swift in Sources */,
 				3DF4C85B2731083B00A4B229 /* DefaultResultUseCase.swift in Sources */,
 				B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */,
 				3DF4C8622735841B00A4B229 /* RunningResultUseCase.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */; };
 		B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD7273BA987001657FE /* HomeCoordinator.swift */; };
 		B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */; };
+		B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */; };
 		B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */; };
 		B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */; };
 		B04A86BE2732D4D800F46069 /* RunningPreparationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86BD2732D4D800F46069 /* RunningPreparationViewModelTests.swift */; };
@@ -227,6 +228,7 @@
 		B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewController.swift; sourceTree = "<group>"; };
 		B02FCAD7273BA987001657FE /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeCoordinator.swift; sourceTree = "<group>"; };
+		B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinatorDidFinishDelegate.swift; sourceTree = "<group>"; };
 		B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewModel.swift; sourceTree = "<group>"; };
 		B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningPreparationUseCase.swift; sourceTree = "<group>"; };
 		B04A86BB2732D4D800F46069 /* RunningPreparationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunningPreparationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -808,6 +810,7 @@
 			children = (
 				B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */,
 				B02FCAD7273BA987001657FE /* HomeCoordinator.swift */,
+				B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1230,6 +1233,7 @@
 				5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */,
 				3DF6D07E27301F1100991DC3 /* RunningResultViewController.swift in Sources */,
 				AE6A6F562730E450005A3A5C /* UIView+ShadowEffect.swift in Sources */,
+				B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */,
 				5E918A0C272BD76D00B57888 /* SceneDelegate.swift in Sources */,
 				5E171E632732536C001C003B /* Point.swift in Sources */,
 				AE6A6F31272CCB59005A3A5C /* MyPageViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		B015E86E2735864F0000AA47 /* MockSingleRunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */; };
 		B015E8712735896D0000AA47 /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */; };
+		B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD7273BA987001657FE /* HomeCoordinator.swift */; };
+		B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */; };
 		B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */; };
 		B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */; };
 		B04A86BE2732D4D800F46069 /* RunningPreparationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86BD2732D4D800F46069 /* RunningPreparationViewModelTests.swift */; };
@@ -88,7 +90,7 @@
 		B0628B90273976DF004FAB0F /* DistanceSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B8C27397415004FAB0F /* DistanceSettingUseCase.swift */; };
 		B0628B9127397703004FAB0F /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		B0628B94273A1752004FAB0F /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B93273A1752004FAB0F /* Coordinator.swift */; };
-		B0628B97273A17E8004FAB0F /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* HomeCoordinator.swift */; };
+		B0628B97273A17E8004FAB0F /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */; };
 		B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B98273A1ADD004FAB0F /* DefaultAppCoordinator.swift */; };
 		B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC327326C1C00D1EDAC /* Emoji.swift */; };
 		B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */; };
@@ -110,7 +112,7 @@
 		B0F5328D273A33D0005A3F11 /* DefaultTabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5328C273A33D0005A3F11 /* DefaultTabBarCoordinator.swift */; };
 		B0F5328F273A35E0005A3F11 /* CoordinatorFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5328E273A35DF005A3F11 /* CoordinatorFinishDelegate.swift */; };
 		B0F53291273A370B005A3F11 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53290273A370B005A3F11 /* AppCoordinator.swift */; };
-		B0F53294273A58AF005A3F11 /* DefaultHomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53293273A58AE005A3F11 /* DefaultHomeCoordinator.swift */; };
+		B0F53294273A58AF005A3F11 /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53293273A58AE005A3F11 /* DefaultSettingCoordinator.swift */; };
 		B0F53296273A5D8E005A3F11 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53295273A5D8E005A3F11 /* HomeViewModel.swift */; };
 		B0F53298273A5DCA005A3F11 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53297273A5DCA005A3F11 /* HomeUseCase.swift */; };
 		BFB9590DC444E39D242E583A /* Pods_DistanceSettingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63485622E4D462D4FDB690D9 /* Pods_DistanceSettingTests.framework */; };
@@ -223,6 +225,8 @@
 		B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleRunningViewModelTests.swift; sourceTree = "<group>"; };
 		B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSingleRunningUseCase.swift; sourceTree = "<group>"; };
 		B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewController.swift; sourceTree = "<group>"; };
+		B02FCAD7273BA987001657FE /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
+		B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeCoordinator.swift; sourceTree = "<group>"; };
 		B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewModel.swift; sourceTree = "<group>"; };
 		B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningPreparationUseCase.swift; sourceTree = "<group>"; };
 		B04A86BB2732D4D800F46069 /* RunningPreparationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunningPreparationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -236,7 +240,7 @@
 		B0628B8A27397354004FAB0F /* DefaultDistanceSettingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultDistanceSettingUseCase.swift; sourceTree = "<group>"; };
 		B0628B8C27397415004FAB0F /* DistanceSettingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistanceSettingUseCase.swift; sourceTree = "<group>"; };
 		B0628B93273A1752004FAB0F /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
-		B0628B96273A17E8004FAB0F /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
+		B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		B0628B98273A1ADD004FAB0F /* DefaultAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAppCoordinator.swift; sourceTree = "<group>"; };
 		B06E6DC327326C1C00D1EDAC /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResult.swift; sourceTree = "<group>"; };
@@ -249,7 +253,7 @@
 		B0F5328C273A33D0005A3F11 /* DefaultTabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTabBarCoordinator.swift; sourceTree = "<group>"; };
 		B0F5328E273A35DF005A3F11 /* CoordinatorFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFinishDelegate.swift; sourceTree = "<group>"; };
 		B0F53290273A370B005A3F11 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
-		B0F53293273A58AE005A3F11 /* DefaultHomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeCoordinator.swift; sourceTree = "<group>"; };
+		B0F53293273A58AE005A3F11 /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
 		B0F53295273A5D8E005A3F11 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		B0F53297273A5DCA005A3F11 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
 		C1992193F37FCC013EC428ED /* Pods-SingleRunningTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SingleRunningTests.release.xcconfig"; path = "Target Support Files/Pods-SingleRunningTests/Pods-SingleRunningTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -727,7 +731,8 @@
 			isa = PBXGroup;
 			children = (
 				B0F53292273A589B005A3F11 /* Protocol */,
-				B0F53293273A58AE005A3F11 /* DefaultHomeCoordinator.swift */,
+				B0F53293273A58AE005A3F11 /* DefaultSettingCoordinator.swift */,
+				B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -801,7 +806,8 @@
 		B0F53292273A589B005A3F11 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
-				B0628B96273A17E8004FAB0F /* HomeCoordinator.swift */,
+				B0628B96273A17E8004FAB0F /* SettingCoordinator.swift */,
+				B02FCAD7273BA987001657FE /* HomeCoordinator.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1167,14 +1173,14 @@
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
 				3DF4C86927376B7B00A4B229 /* NetworkService.swift in Sources */,
 				3DF4C859273104B500A4B229 /* RunningResultViewModel.swift in Sources */,
-				B0F53294273A58AF005A3F11 /* DefaultHomeCoordinator.swift in Sources */,
+				B0F53294273A58AF005A3F11 /* DefaultSettingCoordinator.swift in Sources */,
 				3DF4C8662737687900A4B229 /* DefaultRunningResultRepository.swift in Sources */,
 				5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */,
 				3DFD08B827391BDA00B46479 /* RunningData.swift in Sources */,
 				5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */,
 				AE6A6F582730FAEB005A3A5C /* RunningModeSettingViewModel.swift in Sources */,
 				AE6A6F33272CCB74005A3A5C /* MateViewController.swift in Sources */,
-				B0628B97273A17E8004FAB0F /* HomeCoordinator.swift in Sources */,
+				B0628B97273A17E8004FAB0F /* SettingCoordinator.swift in Sources */,
 				3DF4C85B2731083B00A4B229 /* DefaultResultUseCase.swift in Sources */,
 				B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */,
 				3DF4C8622735841B00A4B229 /* RunningResultUseCase.swift in Sources */,
@@ -1183,6 +1189,7 @@
 				B0628B8D27397415004FAB0F /* DistanceSettingUseCase.swift in Sources */,
 				AE6A6F35272FC170005A3A5C /* DistanceSettingViewController.swift in Sources */,
 				3D2C2175273A719500D00C68 /* DefaultTeamRunningUseCase.swift in Sources */,
+				B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */,
 				3DF4C86027355A3E00A4B229 /* Date+Formatter.swift in Sources */,
 				3DF4C86C27376C9A00A4B229 /* RunningResultRepository.swift in Sources */,
 				3D2C2178273A744800D00C68 /* DefaultTeamRunningRepository.swift in Sources */,
@@ -1200,6 +1207,7 @@
 				AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */,
 				5E32DC652731004D000E525B /* BehaviorRelayProperty.swift in Sources */,
 				AECB9A8227356AFF00533EF7 /* RunningUseCase.swift in Sources */,
+				B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */,
 				B04A86CD2732F48300F46069 /* RunningPreparationUseCase.swift in Sources */,
 				AE6A6F532730423D005A3A5C /* RunningModeSettingViewController.swift in Sources */,
 				B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -542,16 +542,8 @@
 			isa = PBXGroup;
 			children = (
 				B0628B92273A16C0004FAB0F /* Coordinator */,
-				5EFABAE4272FB43B00686D08 /* ViewController */,
 			);
 			path = Common;
-			sourceTree = "<group>";
-		};
-		5EFABAE4272FB43B00686D08 /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ViewController;
 			sourceTree = "<group>";
 		};
 		5EFABAE5272FB45000686D08 /* RecordScene */ = {

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultDistanceSettingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultDistanceSettingUseCase.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 final class DefaultDistanceSettingUseCase: DistanceSettingUseCase {
 	var validatedText: BehaviorSubject<String?> = BehaviorSubject(value: "5.00")
-	
+
     func validate(text: String) {
 		self.validatedText.onNext(self.checkValidty(of: text))
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultDistanceSettingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultDistanceSettingUseCase.swift
@@ -10,10 +10,10 @@ import Foundation
 import RxSwift
 
 final class DefaultDistanceSettingUseCase: DistanceSettingUseCase {
-	var validatedText: BehaviorSubject<String?> = BehaviorSubject(value: "5.00")
-
+    var validatedText: BehaviorSubject<String?> = BehaviorSubject(value: "5.00")
+    
     func validate(text: String) {
-		self.validatedText.onNext(self.checkValidty(of: text))
+        self.validatedText.onNext(self.checkValidty(of: text))
     }
     private func checkValidty(of distanceText: String) -> String? {
         // "." 문자는 최대 1개
@@ -25,7 +25,7 @@ final class DefaultDistanceSettingUseCase: DistanceSettingUseCase {
         // "." 이 있을 때는 앞뒤 모두 문자 최대 2개
         // 이미 .이 없을 때는 문자를 2개까지 밖에 입력하지 못하므로 앞은 확인 안해도 됨
         if distanceText.contains(".") && distanceText.components(separatedBy: ".")[1].count > 2 { return nil }
-
+        
         return distanceText
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningPreparationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningPreparationUseCase.swift
@@ -12,36 +12,36 @@ import RxSwift
 final class DefaultRunningPreparationUseCase: RunningPreparationUseCase {
     var runningSetting: RunningSetting
     
-	var timeLeft = BehaviorSubject(value: 3)
-	var isTimeOver = BehaviorSubject(value: false)
-	var timerDisposeBag = DisposeBag()
-	private let maxTime = 3
+    var timeLeft = BehaviorSubject(value: 3)
+    var isTimeOver = BehaviorSubject(value: false)
+    var timerDisposeBag = DisposeBag()
+    private let maxTime = 3
     
     init(runningSetting: RunningSetting) {
         self.runningSetting = runningSetting
     }
-	
-	func executeTimer() {
-		Observable<Int>
-			.interval(
-				RxTimeInterval.seconds(1),
-				scheduler: MainScheduler.instance
-			)
-			.map { $0 + 1 }
-			.subscribe(onNext: { [weak self] newTime in
-				self?.updateTime(with: newTime)
-			})
-			.disposed(by: self.timerDisposeBag)
-	}
-	private func updateTime(with time: Int) {
-		if time == self.maxTime {
-			self.timerDisposeBag = DisposeBag()
-			self.isTimeOver.onNext(true)
-		}
-		self.timeLeft.onNext((self.maxTime) - time)
-	}
-	
-	private func checkTimeOver(timeLeft: Int) -> Bool {
-		return timeLeft >= self.maxTime
-	}
+    
+    func executeTimer() {
+        Observable<Int>
+            .interval(
+                RxTimeInterval.seconds(1),
+                scheduler: MainScheduler.instance
+            )
+            .map { $0 + 1 }
+            .subscribe(onNext: { [weak self] newTime in
+                self?.updateTime(with: newTime)
+            })
+            .disposed(by: self.timerDisposeBag)
+    }
+    private func updateTime(with time: Int) {
+        if time == self.maxTime {
+            self.timerDisposeBag = DisposeBag()
+            self.isTimeOver.onNext(true)
+        }
+        self.timeLeft.onNext((self.maxTime) - time)
+    }
+    
+    private func checkTimeOver(timeLeft: Int) -> Bool {
+        return timeLeft >= self.maxTime
+    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningPreparationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningPreparationUseCase.swift
@@ -10,10 +10,16 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningPreparationUseCase: RunningPreparationUseCase {
+    var runningSetting: RunningSetting
+    
 	var timeLeft = BehaviorSubject(value: 3)
 	var isTimeOver = BehaviorSubject(value: false)
 	var timerDisposeBag = DisposeBag()
 	private let maxTime = 3
+    
+    init(runningSetting: RunningSetting) {
+        self.runningSetting = runningSetting
+    }
 	
 	func executeTimer() {
 		Observable<Int>

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningSettingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningSettingUseCase.swift
@@ -10,7 +10,11 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningSettingUseCase: RunningSettingUseCase {
-    var runningSetting = BehaviorSubject(value: RunningSetting())
+    var runningSetting: BehaviorSubject<RunningSetting>
+    
+    init(runningSetting: RunningSetting) {
+        self.runningSetting = BehaviorSubject(value: runningSetting)
+    }
     
     func updateMode(mode: RunningMode) {
         var newSetting = RunningSetting()

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningSettingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningSettingUseCase.swift
@@ -17,25 +17,25 @@ final class DefaultRunningSettingUseCase: RunningSettingUseCase {
     }
     
     func updateMode(mode: RunningMode) {
-        var newSetting = RunningSetting()
+        guard var newSetting = try? self.runningSetting.value() else { return }
         newSetting.mode = mode
         self.runningSetting.on(.next(newSetting))
     }
     
     func updateTargetDistance(distance: Double) {
-        var newSetting = RunningSetting()
+        guard var newSetting = try? self.runningSetting.value() else { return }
         newSetting.targetDistance = distance
         self.runningSetting.on(.next(newSetting))
     }
     
     func updateMateNickname(nickname: String) {
-        var newSetting = RunningSetting()
+        guard var newSetting = try? self.runningSetting.value() else { return }
         newSetting.mateNickname = nickname
         self.runningSetting.on(.next(newSetting))
     }
     
     func updateDateTime(date: Date) {
-        var newSetting = RunningSetting()
+        guard var newSetting = try? self.runningSetting.value() else { return }
         newSetting.dateTime = date
         self.runningSetting.on(.next(newSetting))
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
@@ -12,20 +12,20 @@ import RxSwift
 final class DefaultRunningUseCase: RunningUseCase {
     private let coreMotionManager = CoreMotionManager()
     private var currentMETs = 0.0
-	var runningTimeSpent: BehaviorSubject<Int> = BehaviorSubject(value: 0)
-	var cancelTimeLeft: BehaviorSubject<Int> = BehaviorSubject(value: 3)
-	var popUpTimeLeft: BehaviorSubject<Int> = BehaviorSubject(value: 2)
-	var inCancelled: BehaviorSubject<Bool> = BehaviorSubject(value: false)
-	var shouldShowPopUp: BehaviorSubject<Bool> = BehaviorSubject(value: false)
+    var runningTimeSpent: BehaviorSubject<Int> = BehaviorSubject(value: 0)
+    var cancelTimeLeft: BehaviorSubject<Int> = BehaviorSubject(value: 3)
+    var popUpTimeLeft: BehaviorSubject<Int> = BehaviorSubject(value: 2)
+    var inCancelled: BehaviorSubject<Bool> = BehaviorSubject(value: false)
+    var shouldShowPopUp: BehaviorSubject<Bool> = BehaviorSubject(value: false)
     var distance = BehaviorSubject(value: 0.0)
     var progress = BehaviorSubject(value: 0.0)
     var calories = BehaviorSubject(value: 0.0)
     var finishRunning = BehaviorSubject(value: false)
-	private var runningTimeDisposeBag = DisposeBag()
-	private var cancelTimeDisposeBag = DisposeBag()
-	private var popUpTimeDisposeBag = DisposeBag()
-	private let disposeBag = DisposeBag()
-
+    private var runningTimeDisposeBag = DisposeBag()
+    private var cancelTimeDisposeBag = DisposeBag()
+    private var popUpTimeDisposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
+    
     func executePedometer() {
         self.coreMotionManager.startPedometer()
             .subscribe(onNext: { [weak self] distance in
@@ -43,46 +43,46 @@ final class DefaultRunningUseCase: RunningUseCase {
             })
             .disposed(by: self.disposeBag)
     }
-	
-	func executeTimer() {
-		self.generateTimer()
-			.bind(to: self.runningTimeSpent)
-			.disposed(by: self.runningTimeDisposeBag)
-	}
-	
-	func executeCancelTimer() {
-		self.generateTimer()
-			.subscribe(onNext: { [weak self] newTime in
-				self?.shouldShowPopUp.onNext(true)
-				self?.checkTimeOver(from: newTime, with: 3, emitTarget: self?.cancelTimeLeft) {
-					self?.inCancelled.onNext(true)
-					self?.cancelTimeDisposeBag = DisposeBag()
-				}
-			})
-			.disposed(by: self.cancelTimeDisposeBag)
-	}
-	
-	func executePopUpTimer() {
-		self.generateTimer()
-			.subscribe(onNext: { [weak self] newTime in
-				self?.shouldShowPopUp.onNext(true)
-				self?.checkTimeOver(from: newTime, with: 2, emitTarget: self?.popUpTimeLeft) {
-					self?.shouldShowPopUp.onNext(false)
-					self?.popUpTimeDisposeBag = DisposeBag()
-				}
-			})
-			.disposed(by: self.popUpTimeDisposeBag)
-	}
-	
-	func invalidateCancelTimer() {
-		self.cancelTimeDisposeBag = DisposeBag()
-		self.shouldShowPopUp.onNext(false)
-		self.cancelTimeLeft.onNext(3)
-	}
-  
-  private func convertToMeter(value: Double) -> Double {
+    
+    func executeTimer() {
+        self.generateTimer()
+            .bind(to: self.runningTimeSpent)
+            .disposed(by: self.runningTimeDisposeBag)
+    }
+    
+    func executeCancelTimer() {
+        self.generateTimer()
+            .subscribe(onNext: { [weak self] newTime in
+                self?.shouldShowPopUp.onNext(true)
+                self?.checkTimeOver(from: newTime, with: 3, emitTarget: self?.cancelTimeLeft) {
+                    self?.inCancelled.onNext(true)
+                    self?.cancelTimeDisposeBag = DisposeBag()
+                }
+            })
+            .disposed(by: self.cancelTimeDisposeBag)
+    }
+    
+    func executePopUpTimer() {
+        self.generateTimer()
+            .subscribe(onNext: { [weak self] newTime in
+                self?.shouldShowPopUp.onNext(true)
+                self?.checkTimeOver(from: newTime, with: 2, emitTarget: self?.popUpTimeLeft) {
+                    self?.shouldShowPopUp.onNext(false)
+                    self?.popUpTimeDisposeBag = DisposeBag()
+                }
+            })
+            .disposed(by: self.popUpTimeDisposeBag)
+    }
+    
+    func invalidateCancelTimer() {
+        self.cancelTimeDisposeBag = DisposeBag()
+        self.shouldShowPopUp.onNext(false)
+        self.cancelTimeLeft.onNext(3)
+    }
+    
+    private func convertToMeter(value: Double) -> Double {
         return value * 1000
-  }
+    }
     
     private func checkDistance(value: Double) {
         // *Fix : 0.05 고정 값 데이터 받으면 변경해야함
@@ -106,26 +106,26 @@ final class DefaultRunningUseCase: RunningUseCase {
         guard let calorie = try? self.calories.value() + updateValue else { return }
         self.calories.onNext(calorie)
     }
-	
-	private func checkTimeOver(
-		from time: Int,
-		with limitTime: Int,
-		emitTarget: BehaviorSubject<Int>?,
-		actionAtLimit: () -> Void
-	) {
-		guard let emitTarget = emitTarget else { return }
-		emitTarget.onNext(limitTime - time)
-		if time >= limitTime {
-			actionAtLimit()
-		}
-	}
-	
-	private func generateTimer() -> Observable<Int> {
-		return Observable<Int>
-			.interval(
-				RxTimeInterval.seconds(1),
-				scheduler: MainScheduler.instance
-			)
-			.map { $0 + 1 }
-	}
+    
+    private func checkTimeOver(
+        from time: Int,
+        with limitTime: Int,
+        emitTarget: BehaviorSubject<Int>?,
+        actionAtLimit: () -> Void
+    ) {
+        guard let emitTarget = emitTarget else { return }
+        emitTarget.onNext(limitTime - time)
+        if time >= limitTime {
+            actionAtLimit()
+        }
+    }
+    
+    private func generateTimer() -> Observable<Int> {
+        return Observable<Int>
+            .interval(
+                RxTimeInterval.seconds(1),
+                scheduler: MainScheduler.instance
+            )
+            .map { $0 + 1 }
+    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningPreparationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningPreparationUseCase.swift
@@ -12,5 +12,6 @@ import RxSwift
 protocol RunningPreparationUseCase {
 	var timeLeft: BehaviorSubject<Int> { get set }
 	var isTimeOver: BehaviorSubject<Bool> { get set }
+    var runningSetting: RunningSetting { get set }
 	func executeTimer()
 }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -13,7 +13,7 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     var childCoordinators: [Coordinator] = []
     var tabBarController: UITabBarController
     var type: CoordinatorType { .tab }
-
+    
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.tabBarController = .init()

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -63,28 +63,28 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
         
         tabNavigationController.setNavigationBarHidden(false, animated: false)
         tabNavigationController.tabBarItem = self.configureTabBarItem(of: page)
-        tabNavigationController.pushViewController(
-            self.createTabViewController(of: page, to: tabNavigationController),
-            animated: true
-        )
+        self.startTabCoordinator(of: page, to: tabNavigationController)
         return tabNavigationController
     }
     
-    private func createTabViewController(
-        of page: TabBarPage,
-        to tabNavigationController: UINavigationController
-    ) -> UIViewController {
+    private func startTabCoordinator(of page: TabBarPage, to tabNavigationController: UINavigationController) {
         switch page {
         case .home:
-            let homeCoordinator = DefaultHomeCoordinator(tabNavigationController)
+            let homeCoordinator = DefaultHomeCoorditnator(tabNavigationController)
+            homeCoordinator.finishDelegate = self
             self.childCoordinators.append(homeCoordinator)
-            guard let homeViewController = homeCoordinator.createHomeViewController() as? HomeViewController else {
-                return HomeViewController()
-            }
-            return homeViewController
-        case .record: return HomeViewController()
-        case .mate: return HomeViewController()
-        case .mypage: return HomeViewController()
+            homeCoordinator.start()
+        default:
+            break
+        }
+    }
+}
+
+extension DefaultTabBarCoordinator: CoordinatorFinishDelegate {
+    func coordinatorDidFinish(childCoordinator: Coordinator) {
+        self.childCoordinators = childCoordinators.filter({ $0.type != childCoordinator.type })
+        if childCoordinator.type == .home {
+            navigationController.viewControllers.removeAll()
         }
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DefaultHomeCoordinator: HomeCoordinator {
+final class DefaultHomeCoordinator: SettingCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -52,6 +52,7 @@ final class DefaultHomeCoordinator: HomeCoordinator {
         guard let settingData = settingData else { return }
         let distanceSettingViewController = DistanceSettingViewController()
         distanceSettingViewController.viewModel = DistanceSettingViewModel(
+            coordinator: self,
             distanceSettingUseCase: DefaultDistanceSettingUseCase(),
             runningSettngUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -7,11 +7,7 @@
 
 import UIKit
 
-class DefaultHomeCoorditnator: HomeCoordinator, CoordinatorFinishDelegate {
-    func coordinatorDidFinish(childCoordinator: Coordinator) {
-        //
-    }
-    
+class DefaultHomeCoorditnator: HomeCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
     var homeViewController: HomeViewController
@@ -41,5 +37,13 @@ class DefaultHomeCoorditnator: HomeCoordinator, CoordinatorFinishDelegate {
     
     func showRunningFlow() {
         // 운동중 화면 플로우
+    }
+}
+
+extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
+    func coordinatorDidFinish(childCoordinator: Coordinator) {
+        self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
+        navigationController.popToRootViewController(animated: false)
+        print("move to running!!")
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -33,20 +33,29 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     
     func pushRunningModeSettingViewController() {
         let runningModeSettingViewController = RunningModeSettingViewController()
+        runningModeSettingViewController.viewModel = RunningModeSettingViewModel(
+            runningSettingUseCase: DefaultRunningSettingUseCase(
+                runningSetting: RunningSetting()
+            )
+        )
         self.navigationController.pushViewController(runningModeSettingViewController, animated: true)
     }
     
-    func pushMateRunningModeSettingViewController() {
+    func pushMateRunningModeSettingViewController(with settingData: RunningSetting) {
         let mateRunningModeSettingViewController = MateRunningModeSettingViewController()
         self.navigationController.pushViewController(mateRunningModeSettingViewController, animated: true)
     }
     
-    func pushDistanceSettingViewController() {
+    func pushDistanceSettingViewController(with settingData: RunningSetting) {
         let distanceSettingViewController = DistanceSettingViewController()
+        distanceSettingViewController.viewModel = DistanceSettingViewModel(
+            distanceSettingUseCase: DefaultDistanceSettingUseCase(),
+            runningSettngUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
+        )
         self.navigationController.pushViewController(distanceSettingViewController, animated: true)
     }
     
-    func pushRunningPreparationViewController() {
+    func pushRunningPreparationViewController(with settingData: RunningSetting) {
         let runningPreparationViewController = RunningPreparationViewController()
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DefaultHomeCoorditnator: HomeCoordinator {
+final class DefaultHomeCoorditnator: HomeCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
     var homeViewController: HomeViewController
@@ -31,7 +31,7 @@ class DefaultHomeCoorditnator: HomeCoordinator {
         let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self
         settingCoordinator.settingFinishDelegate = self
-        childCoordinators.append(settingCoordinator)
+        self.childCoordinators.append(settingCoordinator)
         settingCoordinator.start()
     }
     
@@ -43,7 +43,7 @@ class DefaultHomeCoorditnator: HomeCoordinator {
 extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
-        navigationController.popToRootViewController(animated: false)
+        self.navigationController.popToRootViewController(animated: false)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -2,73 +2,7 @@
 //  DefaultHomeCoordinator.swift
 //  MateRunner
 //
-//  Created by 전여훈 on 2021/11/09.
+//  Created by 전여훈 on 2021/11/10.
 //
 
-import UIKit
-
-final class DefaultHomeCoordinator: SettingCoordinator {
-    weak var finishDelegate: CoordinatorFinishDelegate?
-    var navigationController: UINavigationController
-    var childCoordinators: [Coordinator] = []
-    var type: CoordinatorType { .home }
-    
-    func start() {
-        let homeViewController = createHomeViewController()
-        self.navigationController.pushViewController(homeViewController, animated: true)
-    }
-    
-    required init(_ navigationController: UINavigationController) {
-        self.navigationController = navigationController
-    }
-    
-    func createHomeViewController() -> UIViewController {
-        let homeViewController = HomeViewController()
-        homeViewController.viewModel = HomeViewModel(
-            coordinator: self,
-            homeUseCase: HomeUseCase()
-        )
-        return homeViewController
-    }
-    
-    func pushRunningModeSettingViewController() {
-        let runningModeSettingViewController = RunningModeSettingViewController()
-        runningModeSettingViewController.viewModel = RunningModeSettingViewModel(
-            coordinator: self,
-            runningSettingUseCase: DefaultRunningSettingUseCase(
-                runningSetting: RunningSetting()
-            )
-        )
-        self.navigationController.pushViewController(runningModeSettingViewController, animated: true)
-    }
-    
-    func pushMateRunningModeSettingViewController(with settingData: RunningSetting?) {
-        guard let settingData = settingData else { return }
-        let mateRunningModeSettingViewController = MateRunningModeSettingViewController()
-        self.navigationController.pushViewController(mateRunningModeSettingViewController, animated: true)
-    }
-    
-    func pushDistanceSettingViewController(with settingData: RunningSetting?) {
-        guard let settingData = settingData else { return }
-        let distanceSettingViewController = DistanceSettingViewController()
-        distanceSettingViewController.viewModel = DistanceSettingViewModel(
-            coordinator: self,
-            distanceSettingUseCase: DefaultDistanceSettingUseCase(),
-            runningSettngUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
-        )
-        self.navigationController.pushViewController(distanceSettingViewController, animated: true)
-    }
-    
-    func pushRunningPreparationViewController(with settingData: RunningSetting?) {
-        guard let settingData = settingData else { return }
-        let runningPreparationViewController = RunningPreparationViewController()
-        runningPreparationViewController.viewModel = RunningPreparationViewModel(
-            coordinator: self,
-            runningPreparationUseCase: DefaultRunningPreparationUseCase(
-                runningSetting: settingData
-            )
-        )
-        self.navigationController.pushViewController(runningPreparationViewController, animated: true)
-    }
-
-}
+import Foundation

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -27,6 +27,7 @@ class DefaultHomeCoorditnator: HomeCoordinator {
     func showSettingFlow() {
         let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self
+        settingCoordinator.settingFinishDelegate = self
         homeViewController.viewModel = HomeViewModel(
             coordinator: settingCoordinator,
             homeUseCase: HomeUseCase()
@@ -45,5 +46,11 @@ extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
         self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
         navigationController.popToRootViewController(animated: false)
         print("move to running!!")
+    }
+}
+
+extension DefaultHomeCoorditnator: SettingCoordinatorDidFinishDelegate {
+    func settingCoordinatorDidFinish(with runningSettingData: RunningSetting) {
+        print(runningSettingData)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -34,6 +34,7 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     func pushRunningModeSettingViewController() {
         let runningModeSettingViewController = RunningModeSettingViewController()
         runningModeSettingViewController.viewModel = RunningModeSettingViewModel(
+            coordinator: self,
             runningSettingUseCase: DefaultRunningSettingUseCase(
                 runningSetting: RunningSetting()
             )
@@ -41,12 +42,14 @@ final class DefaultHomeCoordinator: HomeCoordinator {
         self.navigationController.pushViewController(runningModeSettingViewController, animated: true)
     }
     
-    func pushMateRunningModeSettingViewController(with settingData: RunningSetting) {
+    func pushMateRunningModeSettingViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData else { return }
         let mateRunningModeSettingViewController = MateRunningModeSettingViewController()
         self.navigationController.pushViewController(mateRunningModeSettingViewController, animated: true)
     }
     
-    func pushDistanceSettingViewController(with settingData: RunningSetting) {
+    func pushDistanceSettingViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData else { return }
         let distanceSettingViewController = DistanceSettingViewController()
         distanceSettingViewController.viewModel = DistanceSettingViewModel(
             distanceSettingUseCase: DefaultDistanceSettingUseCase(),
@@ -55,7 +58,8 @@ final class DefaultHomeCoordinator: HomeCoordinator {
         self.navigationController.pushViewController(distanceSettingViewController, animated: true)
     }
     
-    func pushRunningPreparationViewController(with settingData: RunningSetting) {
+    func pushRunningPreparationViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData else { return }
         let runningPreparationViewController = RunningPreparationViewController()
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -20,20 +20,19 @@ class DefaultHomeCoorditnator: HomeCoordinator {
     }
     
     func start() {
-        self.navigationController.pushViewController(homeViewController, animated: true)
-        self.showSettingFlow()
+        self.homeViewController.viewModel = HomeViewModel(
+            coordinator: self,
+            homeUseCase: HomeUseCase()
+        )
+        self.navigationController.pushViewController(self.homeViewController, animated: true)
     }
   
     func showSettingFlow() {
         let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self
         settingCoordinator.settingFinishDelegate = self
-        homeViewController.viewModel = HomeViewModel(
-            coordinator: settingCoordinator,
-            homeUseCase: HomeUseCase()
-        )
-        settingCoordinator.start()
         childCoordinators.append(settingCoordinator)
+        settingCoordinator.start()
     }
     
     func showRunningFlow() {

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -62,6 +62,13 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     func pushRunningPreparationViewController(with settingData: RunningSetting?) {
         guard let settingData = settingData else { return }
         let runningPreparationViewController = RunningPreparationViewController()
+        runningPreparationViewController.viewModel = RunningPreparationViewModel(
+            coordinator: self,
+            runningPreparationUseCase: DefaultRunningPreparationUseCase(
+                runningSetting: settingData
+            )
+        )
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
     }
+
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -26,7 +26,7 @@ final class DefaultHomeCoorditnator: HomeCoordinator {
         )
         self.navigationController.pushViewController(self.homeViewController, animated: true)
     }
-  
+    
     func showSettingFlow() {
         let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -5,4 +5,41 @@
 //  Created by 전여훈 on 2021/11/10.
 //
 
-import Foundation
+import UIKit
+
+class DefaultHomeCoorditnator: HomeCoordinator, CoordinatorFinishDelegate {
+    func coordinatorDidFinish(childCoordinator: Coordinator) {
+        //
+    }
+    
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var homeViewController: HomeViewController
+    var childCoordinators: [Coordinator] = []
+    var type: CoordinatorType = .home
+    
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+        self.homeViewController = HomeViewController()
+    }
+    
+    func start() {
+        self.navigationController.pushViewController(homeViewController, animated: true)
+        self.showSettingFlow()
+    }
+  
+    func showSettingFlow() {
+        let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
+        settingCoordinator.finishDelegate = self
+        homeViewController.viewModel = HomeViewModel(
+            coordinator: settingCoordinator,
+            homeUseCase: HomeUseCase()
+        )
+        settingCoordinator.start()
+        childCoordinators.append(settingCoordinator)
+    }
+    
+    func showRunningFlow() {
+        // 운동중 화면 플로우
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -28,7 +28,7 @@ final class DefaultHomeCoorditnator: HomeCoordinator {
     }
     
     func showSettingFlow() {
-        let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
+        let settingCoordinator = DefaultRunningSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self
         settingCoordinator.settingFinishDelegate = self
         self.childCoordinators.append(settingCoordinator)

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -45,7 +45,6 @@ extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
         navigationController.popToRootViewController(animated: false)
-        print("move to running!!")
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DefaultSettingCoordinator: SettingCoordinator {
+final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     weak var settingFinishDelegate: SettingCoordinatorDidFinishDelegate?
     var navigationController: UINavigationController

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -36,6 +36,10 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     func pushMateRunningModeSettingViewController(with settingData: RunningSetting?) {
         guard let settingData = settingData else { return }
         let mateRunningModeSettingViewController = MateRunningModeSettingViewController()
+        mateRunningModeSettingViewController.viewModel = MateRunningModeSettingViewModel(
+            coordinator: self,
+            runningSettingUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
+        )
         self.navigationController.pushViewController(mateRunningModeSettingViewController, animated: true)
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -14,21 +14,11 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     var type: CoordinatorType { .home }
     
     func start() {
-        let homeViewController = createHomeViewController()
-        self.navigationController.pushViewController(homeViewController, animated: true)
+        print("coordinator is ready")
     }
     
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
-    }
-    
-    func createHomeViewController() -> UIViewController {
-        let homeViewController = HomeViewController()
-        homeViewController.viewModel = HomeViewModel(
-            coordinator: self,
-            homeUseCase: HomeUseCase()
-        )
-        return homeViewController
     }
     
     func pushRunningModeSettingViewController() {

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -63,6 +63,8 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     }
     
     func finish(with settingData: RunningSetting) {
+        var settingData = settingData
+        settingData.dateTime = Date()
         self.finishDelegate?.coordinatorDidFinish(childCoordinator: self)
         self.settingFinishDelegate?.settingCoordinatorDidFinish(with: settingData)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -15,7 +15,7 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     var type: CoordinatorType { .setting }
     
     func start() {
-        print("coordinator is ready")
+        self.pushRunningModeSettingViewController()
     }
     
     required init(_ navigationController: UINavigationController) {

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class DefaultSettingCoordinator: SettingCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
+    weak var settingFinishDelegate: SettingCoordinatorDidFinishDelegate?
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
     var type: CoordinatorType { .setting }
@@ -59,5 +60,10 @@ final class DefaultSettingCoordinator: SettingCoordinator {
             )
         )
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
+    }
+    
+    func finish(with settingData: RunningSetting) {
+        self.finishDelegate?.coordinatorDidFinish(childCoordinator: self)
+        self.settingFinishDelegate?.settingCoordinatorDidFinish(with: settingData)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -11,7 +11,7 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
-    var type: CoordinatorType { .home }
+    var type: CoordinatorType { .setting }
     
     func start() {
         print("coordinator is ready")
@@ -60,5 +60,4 @@ final class DefaultSettingCoordinator: SettingCoordinator {
         )
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
     }
-
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -63,8 +63,6 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     }
     
     func finish(with settingData: RunningSetting) {
-        var settingData = settingData
-        settingData.dateTime = Date()
         self.finishDelegate?.coordinatorDidFinish(childCoordinator: self)
         self.settingFinishDelegate?.settingCoordinatorDidFinish(with: settingData)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultSettingCoordinator.swift
@@ -1,0 +1,74 @@
+//
+//  DefaultHomeCoordinator.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/09.
+//
+
+import UIKit
+
+final class DefaultSettingCoordinator: SettingCoordinator {
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var childCoordinators: [Coordinator] = []
+    var type: CoordinatorType { .home }
+    
+    func start() {
+        let homeViewController = createHomeViewController()
+        self.navigationController.pushViewController(homeViewController, animated: true)
+    }
+    
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func createHomeViewController() -> UIViewController {
+        let homeViewController = HomeViewController()
+        homeViewController.viewModel = HomeViewModel(
+            coordinator: self,
+            homeUseCase: HomeUseCase()
+        )
+        return homeViewController
+    }
+    
+    func pushRunningModeSettingViewController() {
+        let runningModeSettingViewController = RunningModeSettingViewController()
+        runningModeSettingViewController.viewModel = RunningModeSettingViewModel(
+            coordinator: self,
+            runningSettingUseCase: DefaultRunningSettingUseCase(
+                runningSetting: RunningSetting()
+            )
+        )
+        self.navigationController.pushViewController(runningModeSettingViewController, animated: true)
+    }
+    
+    func pushMateRunningModeSettingViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData else { return }
+        let mateRunningModeSettingViewController = MateRunningModeSettingViewController()
+        self.navigationController.pushViewController(mateRunningModeSettingViewController, animated: true)
+    }
+    
+    func pushDistanceSettingViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData else { return }
+        let distanceSettingViewController = DistanceSettingViewController()
+        distanceSettingViewController.viewModel = DistanceSettingViewModel(
+            coordinator: self,
+            distanceSettingUseCase: DefaultDistanceSettingUseCase(),
+            runningSettngUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
+        )
+        self.navigationController.pushViewController(distanceSettingViewController, animated: true)
+    }
+    
+    func pushRunningPreparationViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData else { return }
+        let runningPreparationViewController = RunningPreparationViewController()
+        runningPreparationViewController.viewModel = RunningPreparationViewModel(
+            coordinator: self,
+            runningPreparationUseCase: DefaultRunningPreparationUseCase(
+                runningSetting: settingData
+            )
+        )
+        self.navigationController.pushViewController(runningPreparationViewController, animated: true)
+    }
+
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -2,15 +2,12 @@
 //  HomeCoordinator.swift
 //  MateRunner
 //
-//  Created by 전여훈 on 2021/11/09.
+//  Created by 전여훈 on 2021/11/10.
 //
 
-import UIKit
+import Foundation
 
-protocol SettingCoordinator: Coordinator {
-    func createHomeViewController() -> UIViewController
-    func pushRunningModeSettingViewController()
-    func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)
-    func pushDistanceSettingViewController(with settingData: RunningSetting?)
-    func pushRunningPreparationViewController(with settingData: RunningSetting?)
+protocol HomeCoordinator: Coordinator {
+    func showSettingFlow()
+    func showRunningFlow()
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol HomeCoordinator: Coordinator {
     func createHomeViewController() -> UIViewController
     func pushRunningModeSettingViewController()
-    func pushMateRunningModeSettingViewController(with settingData: RunningSetting)
-    func pushDistanceSettingViewController(with settingData: RunningSetting)
-    func pushRunningPreparationViewController(with settingData: RunningSetting)
+    func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)
+    func pushDistanceSettingViewController(with settingData: RunningSetting?)
+    func pushRunningPreparationViewController(with settingData: RunningSetting?)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol HomeCoordinator: Coordinator {
     func createHomeViewController() -> UIViewController
     func pushRunningModeSettingViewController()
-    func pushMateRunningModeSettingViewController()
-    func pushDistanceSettingViewController()
-    func pushRunningPreparationViewController()
+    func pushMateRunningModeSettingViewController(with settingData: RunningSetting)
+    func pushDistanceSettingViewController(with settingData: RunningSetting)
+    func pushRunningPreparationViewController(with settingData: RunningSetting)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol HomeCoordinator: Coordinator {
+protocol SettingCoordinator: Coordinator {
     func createHomeViewController() -> UIViewController
     func pushRunningModeSettingViewController()
     func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/RunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/RunningSettingCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol SettingCoordinator: Coordinator {
+protocol RunningSettingCoordinator: Coordinator {
     func pushRunningModeSettingViewController()
     func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)
     func pushDistanceSettingViewController(with settingData: RunningSetting?)

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinator.swift
@@ -12,4 +12,5 @@ protocol SettingCoordinator: Coordinator {
     func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)
     func pushDistanceSettingViewController(with settingData: RunningSetting?)
     func pushRunningPreparationViewController(with settingData: RunningSetting?)
+    func finish(with settingData: RunningSetting)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  HomeCoordinator.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/09.
+//
+
+import UIKit
+
+protocol SettingCoordinator: Coordinator {
+    func createHomeViewController() -> UIViewController
+    func pushRunningModeSettingViewController()
+    func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)
+    func pushDistanceSettingViewController(with settingData: RunningSetting?)
+    func pushRunningPreparationViewController(with settingData: RunningSetting?)
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinator.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 protocol SettingCoordinator: Coordinator {
-    func createHomeViewController() -> UIViewController
     func pushRunningModeSettingViewController()
     func pushMateRunningModeSettingViewController(with settingData: RunningSetting?)
     func pushDistanceSettingViewController(with settingData: RunningSetting?)

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinatorDidFinishDelegate.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/SettingCoordinatorDidFinishDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  SettingCoordinatorDidFinishDelegate.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/10.
+//
+
+import Foundation
+
+protocol SettingCoordinatorDidFinishDelegate: AnyObject {
+    func settingCoordinatorDidFinish(with runningSettingData: RunningSetting)
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/DistanceSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/DistanceSettingViewController.swift
@@ -41,10 +41,10 @@ final class DistanceSettingViewController: UIViewController {
 
     private lazy var distanceTextField: CursorDisabledTextField = {
         let textField = CursorDisabledTextField()
-        textField.borderStyle = .none
-        textField.font = .notoSansBoldItalic(size: 100)
         let attributes = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue]
         let attributedString = NSAttributedString(string: "5.00", attributes: attributes)
+        textField.borderStyle = .none
+        textField.font = .notoSansBoldItalic(size: 100)
         textField.attributedText = attributedString
         textField.keyboardType = .decimalPad
 		textField.tintColor = .clear
@@ -68,31 +68,26 @@ private extension DistanceSettingViewController {
             .drive(onNext: { [weak self] in
                 self?.doneButton.title = "설정"
             }).disposed(by: self.disposeBag)
-        
-        self.doneButton.rx.tap
-            .asDriver()
-            .drive(onNext: { [weak self] in
-                self?.view.endEditing(true)
-                self?.doneButton.title = ""
-            }).disposed(by: self.disposeBag)
-        
-        self.startButton.rx.tap
-            .asDriver()
-            .drive(onNext: { [weak self] in
-                self?.startButtonDidTap()
-            }).disposed(by: self.disposeBag)
     }
     
     func bindViewModel() {
         let input = DistanceSettingViewModel.Input(
             distance: self.distanceTextField.rx.text.orEmpty.asObservable(),
-            doneButtonTapEvent: self.doneButton.rx.tap.asObservable()
+            doneButtonDidTapEvent: self.doneButton.rx.tap.asObservable(),
+            startButtonDidTapEvent: self.startButton.rx.tap.asObservable()
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         output?.$distanceFieldText
             .asDriver()
             .drive(self.distanceTextField.rx.text)
+            .disposed(by: self.disposeBag)
+        output?.keyboardShouldhide
+            .asDriver(onErrorJustReturn: true)
+            .drive(onNext: { [weak self] _ in
+                self?.view.endEditing(true)
+                self?.doneButton.title = ""
+            })
             .disposed(by: self.disposeBag)
     }
     
@@ -121,10 +116,5 @@ private extension DistanceSettingViewController {
             make.left.right.equalToSuperview().inset(20)
             make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
         }
-    }
-    
-    func startButtonDidTap() {
-        let runningPreparationViewController = RunningPreparationViewController()
-        self.navigationController?.pushViewController(runningPreparationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/DistanceSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/DistanceSettingViewController.swift
@@ -12,9 +12,7 @@ import RxSwift
 import SnapKit
 
 final class DistanceSettingViewController: UIViewController {
-	private let viewModel = DistanceSettingViewModel(
-		distanceSettingUseCase: DefaultDistanceSettingUseCase()
-	)
+    var viewModel: DistanceSettingViewModel?
     private var disposeBag = DisposeBag()
     
     private lazy var doneButton: UIBarButtonItem = {
@@ -91,8 +89,8 @@ private extension DistanceSettingViewController {
             doneButtonTapEvent: self.doneButton.rx.tap.asObservable()
         )
         
-        let output = self.viewModel.transform(from: input, disposeBag: self.disposeBag)
-        output.$distanceFieldText
+        let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
+        output?.$distanceFieldText
             .asDriver()
             .drive(self.distanceTextField.rx.text)
             .disposed(by: self.disposeBag)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateRunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateRunningModeSettingViewController.swift
@@ -79,11 +79,11 @@ private extension MateRunningModeSettingViewController {
     
     func bindViewModel() {
         let input = MateRunningModeSettingViewModel.Input(
-            raceModeButtonTapEvent: raceModeButton.rx.tapGesture()
+            raceModeButtonDidTapEvent: raceModeButton.rx.tapGesture()
                 .when(.recognized)
                 .map({_ in })
                 .asObservable(),
-            teamModeButtonTapEvent: teamModeButton.rx.tapGesture()
+            teamModeButtonDidTapEvent: teamModeButton.rx.tapGesture()
                 .when(.recognized)
                 .map({_ in })
                 .asObservable(),

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
@@ -35,7 +35,7 @@ final class RunningModeSettingViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
-        initialButton()
+        self.initialButton()
     }
     
     override func viewDidLoad() {
@@ -93,17 +93,15 @@ private extension RunningModeSettingViewController {
             singleButtonTapEvent: self.singleButton.rx.tap.asObservable(),
             mateButtonTapEvent: self.mateButton.rx.tap.asObservable()
         )
-        
         let output = self.viewModel?.transform(
             from: input,
             disposeBag: self.disposeBag
         )
-        
         output?.$runningMode
             .asDriver()
             .filter { $0 != nil }
             .drive(onNext: { [weak self] mode in
-                self?.modeButtonDidTap(mode ?? .single)
+                self?.fillButton(of: mode)
             })
             .disposed(by: self.disposeBag)
     }
@@ -113,17 +111,10 @@ private extension RunningModeSettingViewController {
         self.mateButton.backgroundColor = .white
     }
     
-    func modeButtonDidTap(_ mode: RunningMode) {
-        initialButton()
-        switch mode {
-        case .single: // ** 주입식으로 수정되면 수정해야할 곳 **  SettingResult 넘기자
-            self.singleButton.backgroundColor = .mrYellow
-            let distanceSettingViewController = DistanceSettingViewController()
-            self.navigationController?.pushViewController(distanceSettingViewController, animated: true)
-        case .race, .team:
-            self.mateButton.backgroundColor = .mrYellow
-            let mateRunningModeSettingViewController = MateRunningModeSettingViewController()
-            self.navigationController?.pushViewController(mateRunningModeSettingViewController, animated: true)
-        }
+    func fillButton(of mode: RunningMode?) {
+        guard let mode = mode else { return }
+        mode == .single
+        ? (self.singleButton.backgroundColor = .mrYellow)
+        : (self.mateButton.backgroundColor = .mrYellow)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
@@ -12,15 +12,11 @@ import RxSwift
 import SnapKit
 
 final class RunningModeSettingViewController: UIViewController {
-    var runningModeSettingviewModel = RunningModeSettingViewModel(
-        runningSettingUseCase: DefaultRunningSettingUseCase()
-    )
-    
+    var viewModel: RunningModeSettingViewModel?
     var disposeBag = DisposeBag()
     
     private lazy var singleButton = createButton("🏃‍♂️ \n 혼자 달리기")
     private lazy var mateButton = createButton("🏃‍♂️🏃‍♀️ \n같이 달리기")
-    
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -98,9 +94,12 @@ private extension RunningModeSettingViewController {
             mateButtonTapEvent: self.mateButton.rx.tap.asObservable()
         )
         
-        let output = self.runningModeSettingviewModel.transform(from: input, disposeBag: self.disposeBag)
+        let output = self.viewModel?.transform(
+            from: input,
+            disposeBag: self.disposeBag
+        )
         
-        output.$runningMode
+        output?.$runningMode
             .asDriver()
             .filter { $0 != nil }
             .drive(onNext: { [weak self] mode in

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
@@ -35,7 +35,7 @@ final class RunningModeSettingViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
-        self.initialButton()
+        self.configureButton()
     }
     
     override func viewDidLoad() {
@@ -106,7 +106,7 @@ private extension RunningModeSettingViewController {
             .disposed(by: self.disposeBag)
     }
     
-    func initialButton() {
+    func configureButton() {
         self.singleButton.backgroundColor = .white
         self.mateButton.backgroundColor = .white
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningPreparationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningPreparationViewController.swift
@@ -12,10 +12,7 @@ import RxSwift
 import SnapKit
 
 final class RunningPreparationViewController: UIViewController {
-	// TODO: Dependency injection flow should be refactored
-	let runningPreparationViewModel = RunningPreparationViewModel(
-		runningPreparationUseCase: DefaultRunningPreparationUseCase()
-	)
+    var viewModel: RunningPreparationViewModel?
 	let disposeBag = DisposeBag()
 	
 	private lazy var timeLeftLabel: UILabel = {
@@ -43,9 +40,9 @@ private extension RunningPreparationViewController {
 	
 	func bindViewModel() {
 		let input = RunningPreparationViewModel.Input(viewDidLoadEvent: Observable.just(()))
-		let output = self.runningPreparationViewModel.transform(from: input, disposeBag: self.disposeBag)
+		let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
 		
-		output.$timeLeft
+		output?.$timeLeft
 			.asDriver()
 			.drive(onNext: { [weak self] updatedTime in
 				self?.timeLeftLabel.text = updatedTime
@@ -56,7 +53,7 @@ private extension RunningPreparationViewController {
 			})
 			.disposed(by: self.disposeBag)
 		
-		output.$navigateToNext
+		output?.$navigateToNext
 			.asDriver()
 			.filter({ $0 == true })
 			.drive(onNext: { _ in

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
@@ -78,6 +78,7 @@ final class DistanceSettingViewModel {
             .subscribe(onNext: { newDistance in
                 self.runningSettngUseCase.updateTargetDistance(distance: newDistance)
             })
+            .disposed(by: disposeBag)
 		
 		return output
 	}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
@@ -82,6 +82,7 @@ final class DistanceSettingViewModel {
         
         return output
     }
+    
     private func convertToDouble(from distance: String?) -> Double? {
         guard let distance = distance else { return nil }
         return Double(distance)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
@@ -11,45 +11,45 @@ import RxCocoa
 import RxSwift
 
 final class DistanceSettingViewModel {
-	private let distanceSettingUseCase: DistanceSettingUseCase
+    private let distanceSettingUseCase: DistanceSettingUseCase
     private let runningSettngUseCase: RunningSettingUseCase
     private weak var coordinator: SettingCoordinator?
-	
-	struct Input {
-		let distance: Observable<String>
-		let doneButtonDidTapEvent: Observable<Void>
+    
+    struct Input {
+        let distance: Observable<String>
+        let doneButtonDidTapEvent: Observable<Void>
         let startButtonDidTapEvent: Observable<Void>
-	}
-	
-	struct Output {
-		@BehaviorRelayProperty var distanceFieldText: String? = "5.00"
+    }
+    
+    struct Output {
+        @BehaviorRelayProperty var distanceFieldText: String? = "5.00"
         let keyboardShouldhide = PublishRelay<Bool>()
-	}
-	
+    }
+    
     init(
         coordinator: SettingCoordinator,
         distanceSettingUseCase: DistanceSettingUseCase,
         runningSettngUseCase: RunningSettingUseCase
     ) {
         self.coordinator = coordinator
-		self.distanceSettingUseCase = distanceSettingUseCase
+        self.distanceSettingUseCase = distanceSettingUseCase
         self.runningSettngUseCase = runningSettngUseCase
-	}
-	
-	func transform(from input: Input, disposeBag: DisposeBag) -> Output {
-		let output = Output()
-		input.distance
-			.subscribe(onNext: { [weak self] distance in
+    }
+    
+    func transform(from input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        input.distance
+            .subscribe(onNext: { [weak self] distance in
                 self?.distanceSettingUseCase.validate(text: distance)
             })
-			.disposed(by: disposeBag)
-		
-		input.doneButtonDidTapEvent
-			.withLatestFrom(input.distance)
-			.map(self.padZeros)
-			.map(self.convertInvalidDistance)
+            .disposed(by: disposeBag)
+        
+        input.doneButtonDidTapEvent
+            .withLatestFrom(input.distance)
+            .map(self.padZeros)
+            .map(self.convertInvalidDistance)
             .bind(to: output.$distanceFieldText)
-			.disposed(by: disposeBag)
+            .disposed(by: disposeBag)
         
         input.doneButtonDidTapEvent
             .map {true}
@@ -63,14 +63,14 @@ final class DistanceSettingViewModel {
                 )
             })
             .disposed(by: disposeBag)
-		
-		self.distanceSettingUseCase.validatedText
-			.scan("") { oldValue, newValue in
-				newValue == nil ? oldValue : newValue
-			}
-			.map({ self.configureZeros(from: $0 ?? "0") })
-			.bind(to: output.$distanceFieldText)
-			.disposed(by: disposeBag)
+        
+        self.distanceSettingUseCase.validatedText
+            .scan("") { oldValue, newValue in
+                newValue == nil ? oldValue : newValue
+            }
+            .map({ self.configureZeros(from: $0 ?? "0") })
+            .bind(to: output.$distanceFieldText)
+            .disposed(by: disposeBag)
         
         self.distanceSettingUseCase.validatedText
             .distinctUntilChanged()
@@ -79,36 +79,36 @@ final class DistanceSettingViewModel {
                 self.runningSettngUseCase.updateTargetDistance(distance: newDistance)
             })
             .disposed(by: disposeBag)
-		
-		return output
-	}
+        
+        return output
+    }
     private func convertToDouble(from distance: String?) -> Double? {
         guard let distance = distance else { return nil }
         return Double(distance)
     }
-	
-	private func convertInvalidDistance(from text: String) -> String {
-		guard text != "0.00" else { return "5.00" }
-		return text
-	}
-	
-	private func configureZeros(from text: String) -> String {
-		guard !text.isEmpty else { return "0" }
-		guard !text.contains(".") && text.first == "0" else { return text }
-		return "\(text.last ?? "0")"
-	}
-	
-	private func padZeros(text: String) -> String {
-		var paddedText = text
-		if paddedText.isEmpty { paddedText = "0" }
-		return paddedText.contains(".") ? self.addZeros(to: paddedText) : paddedText + ".00"
-	}
-	
-	private func addZeros(to text: String) -> String {
-		var paddedText = text
-		while paddedText.components(separatedBy: ".")[1].count < 2 {
-			paddedText.append("0")
-		}
-		return paddedText
-	}
+    
+    private func convertInvalidDistance(from text: String) -> String {
+        guard text != "0.00" else { return "5.00" }
+        return text
+    }
+    
+    private func configureZeros(from text: String) -> String {
+        guard !text.isEmpty else { return "0" }
+        guard !text.contains(".") && text.first == "0" else { return text }
+        return "\(text.last ?? "0")"
+    }
+    
+    private func padZeros(text: String) -> String {
+        var paddedText = text
+        if paddedText.isEmpty { paddedText = "0" }
+        return paddedText.contains(".") ? self.addZeros(to: paddedText) : paddedText + ".00"
+    }
+    
+    private func addZeros(to text: String) -> String {
+        var paddedText = text
+        while paddedText.components(separatedBy: ".")[1].count < 2 {
+            paddedText.append("0")
+        }
+        return paddedText
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
@@ -13,7 +13,7 @@ import RxSwift
 final class DistanceSettingViewModel {
     private let distanceSettingUseCase: DistanceSettingUseCase
     private let runningSettngUseCase: RunningSettingUseCase
-    private weak var coordinator: SettingCoordinator?
+    private weak var coordinator: RunningSettingCoordinator?
     
     struct Input {
         let distance: Observable<String>
@@ -27,7 +27,7 @@ final class DistanceSettingViewModel {
     }
     
     init(
-        coordinator: SettingCoordinator,
+        coordinator: RunningSettingCoordinator,
         distanceSettingUseCase: DistanceSettingUseCase,
         runningSettngUseCase: RunningSettingUseCase
     ) {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 final class DistanceSettingViewModel {
 	private let distanceSettingUseCase: DistanceSettingUseCase
+    private let runningSettngUseCase: RunningSettingUseCase
 	
 	struct Input {
 		let distance: Observable<String>
@@ -22,8 +23,9 @@ final class DistanceSettingViewModel {
 		@BehaviorRelayProperty var distanceFieldText: String? = "5.00"
 	}
 	
-	init(distanceSettingUseCase: DistanceSettingUseCase) {
+    init(distanceSettingUseCase: DistanceSettingUseCase, runningSettngUseCase: RunningSettingUseCase) {
 		self.distanceSettingUseCase = distanceSettingUseCase
+        self.runningSettngUseCase = runningSettngUseCase
 	}
 	
 	func transform(from input: Input, disposeBag: DisposeBag) -> Output {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/DistanceSettingViewModel.swift
@@ -13,7 +13,7 @@ import RxSwift
 final class DistanceSettingViewModel {
 	private let distanceSettingUseCase: DistanceSettingUseCase
     private let runningSettngUseCase: RunningSettingUseCase
-    private weak var coordinator: HomeCoordinator?
+    private weak var coordinator: SettingCoordinator?
 	
 	struct Input {
 		let distance: Observable<String>
@@ -27,7 +27,7 @@ final class DistanceSettingViewModel {
 	}
 	
     init(
-        coordinator: HomeCoordinator,
+        coordinator: SettingCoordinator,
         distanceSettingUseCase: DistanceSettingUseCase,
         runningSettngUseCase: RunningSettingUseCase
     ) {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/HomeViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/HomeViewModel.swift
@@ -8,15 +8,15 @@
 import Foundation
 
 final class HomeViewModel {
-    weak var coordinator: SettingCoordinator?
+    weak var coordinator: HomeCoordinator?
     let homeUseCase: HomeUseCase
     
-    init(coordinator: SettingCoordinator, homeUseCase: HomeUseCase) {
+    init(coordinator: HomeCoordinator, homeUseCase: HomeUseCase) {
         self.coordinator = coordinator
         self.homeUseCase = homeUseCase
     }
     
     func startButtonDidTap() {
-        self.coordinator?.pushRunningModeSettingViewController()
+        self.coordinator?.showSettingFlow()
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/HomeViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/HomeViewModel.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 final class HomeViewModel {
-    weak var coordinator: HomeCoordinator?
+    weak var coordinator: SettingCoordinator?
     let homeUseCase: HomeUseCase
     
-    init(coordinator: HomeCoordinator, homeUseCase: HomeUseCase) {
+    init(coordinator: SettingCoordinator, homeUseCase: HomeUseCase) {
         self.coordinator = coordinator
         self.homeUseCase = homeUseCase
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateRunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateRunningModeSettingViewModel.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-import RxSwift
 import RxRelay
+import RxSwift
 
 final class MateRunningModeSettingViewModel {
     private weak var coordinator: SettingCoordinator?

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateRunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateRunningModeSettingViewModel.swift
@@ -11,7 +11,7 @@ import RxRelay
 import RxSwift
 
 final class MateRunningModeSettingViewModel {
-    private weak var coordinator: SettingCoordinator?
+    private weak var coordinator: RunningSettingCoordinator?
     private let runningSettingUseCase: RunningSettingUseCase
     
     struct Input {
@@ -26,7 +26,7 @@ final class MateRunningModeSettingViewModel {
     }
     
     init(
-        coordinator: SettingCoordinator,
+        coordinator: RunningSettingCoordinator,
         runningSettingUseCase: RunningSettingUseCase
     ) {
         self.coordinator = coordinator

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateRunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateRunningModeSettingViewModel.swift
@@ -11,12 +11,12 @@ import RxSwift
 import RxRelay
 
 final class MateRunningModeSettingViewModel {
-    weak var coordinator: SettingCoordinator?
+    private weak var coordinator: SettingCoordinator?
     private let runningSettingUseCase: RunningSettingUseCase
     
     struct Input {
-        let raceModeButtonTapEvent: Observable<Void>
-        let teamModeButtonTapEvent: Observable<Void>
+        let raceModeButtonDidTapEvent: Observable<Void>
+        let teamModeButtonDidTapEvent: Observable<Void>
         let nextButtonDidTapEvent: Observable<Void>
     }
     
@@ -36,13 +36,13 @@ final class MateRunningModeSettingViewModel {
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        input.raceModeButtonTapEvent
+        input.raceModeButtonDidTapEvent
             .subscribe(onNext: { [weak self] _ in
                 self?.runningSettingUseCase.updateMode(mode: .race)
             })
             .disposed(by: disposeBag)
         
-        input.teamModeButtonTapEvent
+        input.teamModeButtonDidTapEvent
             .subscribe(onNext: { [weak self] _ in
                 self?.runningSettingUseCase.updateMode(mode: .team)
             })

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 final class RunningModeSettingViewModel {
-    private weak var coordinator: SettingCoordinator?
+    private weak var coordinator: RunningSettingCoordinator?
     private let runningSettingUseCase: DefaultRunningSettingUseCase
     
     struct Input {
@@ -22,7 +22,7 @@ final class RunningModeSettingViewModel {
         @BehaviorRelayProperty var runningMode: RunningMode?
     }
     
-    init(coordinator: SettingCoordinator, runningSettingUseCase: DefaultRunningSettingUseCase) {
+    init(coordinator: RunningSettingCoordinator, runningSettingUseCase: DefaultRunningSettingUseCase) {
         self.coordinator = coordinator
         self.runningSettingUseCase = runningSettingUseCase
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -10,6 +10,9 @@ import Foundation
 import RxSwift
 
 final class RunningModeSettingViewModel {
+    private weak var coordinator: SettingCoordinator?
+    private let runningSettingUseCase: DefaultRunningSettingUseCase
+    
     struct Input {
         let singleButtonTapEvent: Observable<Void>
         let mateButtonTapEvent: Observable<Void>
@@ -18,9 +21,6 @@ final class RunningModeSettingViewModel {
     struct Output {
         @BehaviorRelayProperty var runningMode: RunningMode?
     }
-    
-    weak var coordinator: SettingCoordinator?
-    let runningSettingUseCase: DefaultRunningSettingUseCase
     
     init(coordinator: SettingCoordinator, runningSettingUseCase: DefaultRunningSettingUseCase) {
         self.coordinator = coordinator

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -41,7 +41,7 @@ final class RunningModeSettingViewModel {
         input.mateButtonTapEvent
             .subscribe(onNext: { [weak self] _ in
                 self?.runningSettingUseCase.updateMode(mode: .race)
-                self?.coordinator?.pushDistanceSettingViewController(
+                self?.coordinator?.pushMateRunningModeSettingViewController(
                     with: try? self?.runningSettingUseCase.runningSetting.value()
                 )
             })

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -19,10 +19,10 @@ final class RunningModeSettingViewModel {
         @BehaviorRelayProperty var runningMode: RunningMode?
     }
     
-    weak var coordinator: HomeCoordinator?
+    weak var coordinator: SettingCoordinator?
     let runningSettingUseCase: DefaultRunningSettingUseCase
     
-    init(coordinator: HomeCoordinator, runningSettingUseCase: DefaultRunningSettingUseCase) {
+    init(coordinator: SettingCoordinator, runningSettingUseCase: DefaultRunningSettingUseCase) {
         self.coordinator = coordinator
         self.runningSettingUseCase = runningSettingUseCase
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -32,13 +32,13 @@ final class RunningModeSettingViewModel {
                 self?.runningSettingUseCase.updateMode(mode: .single)
             })
             .disposed(by: disposeBag)
-
+        
         input.mateButtonTapEvent
             .subscribe(onNext: { [weak self] _ in
                 self?.runningSettingUseCase.updateMode(mode: .race)
             })
             .disposed(by: disposeBag)
-
+        
         self.runningSettingUseCase.runningSetting
             .map(self.checkRunningMode)
             .bind(to: output.$runningMode)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -19,9 +19,11 @@ final class RunningModeSettingViewModel {
         @BehaviorRelayProperty var runningMode: RunningMode?
     }
     
+    weak var coordinator: HomeCoordinator?
     let runningSettingUseCase: DefaultRunningSettingUseCase
     
-    init(runningSettingUseCase: DefaultRunningSettingUseCase) {
+    init(coordinator: HomeCoordinator, runningSettingUseCase: DefaultRunningSettingUseCase) {
+        self.coordinator = coordinator
         self.runningSettingUseCase = runningSettingUseCase
     }
     
@@ -30,12 +32,18 @@ final class RunningModeSettingViewModel {
         input.singleButtonTapEvent
             .subscribe(onNext: { [weak self] _ in
                 self?.runningSettingUseCase.updateMode(mode: .single)
+                self?.coordinator?.pushDistanceSettingViewController(
+                    with: try? self?.runningSettingUseCase.runningSetting.value()
+                )
             })
             .disposed(by: disposeBag)
         
         input.mateButtonTapEvent
             .subscribe(onNext: { [weak self] _ in
                 self?.runningSettingUseCase.updateMode(mode: .race)
+                self?.coordinator?.pushDistanceSettingViewController(
+                    with: try? self?.runningSettingUseCase.runningSetting.value()
+                )
             })
             .disposed(by: disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningModeSettingViewModel.swift
@@ -46,12 +46,8 @@ final class RunningModeSettingViewModel {
         
         return output
     }
-}
-
-// MARK: - Private Functions
-
-private extension RunningModeSettingViewModel {
-    func checkRunningMode(running: RunningSetting) -> RunningMode? {
+    
+    private func checkRunningMode(running: RunningSetting) -> RunningMode? {
         return running.mode ?? nil
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -39,7 +39,6 @@ class RunningPreparationViewModel {
 			.disposed(by: disposeBag)
 		
 		self.runningPreparationUseCase.isTimeOver
-            .debug()
             .subscribe(onNext: { [weak self] isOver in
                 isOver ? self?.coordinator?.finish(with: self?.runningPreparationUseCase.runningSetting ?? RunningSetting()) : Void()
             })

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 class RunningPreparationViewModel {
     private let runningPreparationUseCase: RunningPreparationUseCase
-    private weak var coordinator: HomeCoordinator?
+    private weak var coordinator: SettingCoordinator?
     private let maxPreparationTime = 3
     
 	struct Input {
@@ -22,7 +22,7 @@ class RunningPreparationViewModel {
 		@BehaviorRelayProperty var navigateToNext: Bool?
 	}
 	
-    init(coordinator: HomeCoordinator, runningPreparationUseCase: RunningPreparationUseCase) {
+    init(coordinator: SettingCoordinator, runningPreparationUseCase: RunningPreparationUseCase) {
         self.coordinator = coordinator
 		self.runningPreparationUseCase = runningPreparationUseCase
 	}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 class RunningPreparationViewModel {
-    private weak var coordinator: SettingCoordinator?
+    private weak var coordinator: RunningSettingCoordinator?
     private let runningPreparationUseCase: RunningPreparationUseCase
     private let maxPreparationTime = 3
     
@@ -22,7 +22,7 @@ class RunningPreparationViewModel {
 		@BehaviorRelayProperty var navigateToNext: Bool?
 	}
 	
-    init(coordinator: SettingCoordinator, runningPreparationUseCase: RunningPreparationUseCase) {
+    init(coordinator: RunningSettingCoordinator, runningPreparationUseCase: RunningPreparationUseCase) {
         self.coordinator = coordinator
 		self.runningPreparationUseCase = runningPreparationUseCase
 	}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -10,8 +10,8 @@ import Foundation
 import RxSwift
 
 class RunningPreparationViewModel {
-    private let runningPreparationUseCase: RunningPreparationUseCase
     private weak var coordinator: SettingCoordinator?
+    private let runningPreparationUseCase: RunningPreparationUseCase
     private let maxPreparationTime = 3
     
 	struct Input {
@@ -30,7 +30,9 @@ class RunningPreparationViewModel {
 	func transform(from input: Input, disposeBag: DisposeBag) -> Output {
 		let output = Output()
 		input.viewDidLoadEvent
-			.subscribe(onNext: { self.runningPreparationUseCase.executeTimer() })
+			.subscribe(onNext: { [weak self] _ in
+                self?.runningPreparationUseCase.executeTimer()
+            })
 			.disposed(by: disposeBag)
 		
 		self.runningPreparationUseCase.timeLeft
@@ -40,7 +42,9 @@ class RunningPreparationViewModel {
 		
 		self.runningPreparationUseCase.isTimeOver
             .subscribe(onNext: { [weak self] isOver in
-                isOver ? self?.coordinator?.finish(with: self?.runningPreparationUseCase.runningSetting ?? RunningSetting()) : Void()
+                guard isOver,
+                      let settingData = self?.runningPreparationUseCase.runningSetting else { return }
+                self?.coordinator?.finish(with: settingData)
             })
 			.disposed(by: disposeBag)
 		

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -10,6 +10,10 @@ import Foundation
 import RxSwift
 
 class RunningPreparationViewModel {
+    private let runningPreparationUseCase: RunningPreparationUseCase
+    private weak var coordinator: HomeCoordinator?
+    private let maxPreparationTime = 3
+    
 	struct Input {
 		let viewDidLoadEvent: Observable<Void>
 	}
@@ -17,11 +21,9 @@ class RunningPreparationViewModel {
 		@BehaviorRelayProperty var timeLeft: String?
 		@BehaviorRelayProperty var navigateToNext: Bool?
 	}
-
-	let runningPreparationUseCase: RunningPreparationUseCase
-	private let maxPreparationTime = 3
 	
-	init(runningPreparationUseCase: RunningPreparationUseCase) {
+    init(coordinator: HomeCoordinator, runningPreparationUseCase: RunningPreparationUseCase) {
+        self.coordinator = coordinator
 		self.runningPreparationUseCase = runningPreparationUseCase
 	}
 	
@@ -37,7 +39,10 @@ class RunningPreparationViewModel {
 			.disposed(by: disposeBag)
 		
 		self.runningPreparationUseCase.isTimeOver
-			.bind(to: output.$navigateToNext)
+            .debug()
+            .subscribe(onNext: { [weak self] isOver in
+                isOver ? self?.coordinator?.finish() : Void()
+            })
 			.disposed(by: disposeBag)
 		
 		return output

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -41,7 +41,7 @@ class RunningPreparationViewModel {
 		self.runningPreparationUseCase.isTimeOver
             .debug()
             .subscribe(onNext: { [weak self] isOver in
-                isOver ? self?.coordinator?.finish() : Void()
+                isOver ? self?.coordinator?.finish(with: self?.runningPreparationUseCase.runningSetting ?? RunningSetting()) : Void()
             })
 			.disposed(by: disposeBag)
 		

--- a/MateRunner/MateRunner/Util/Constant/CoordinatorType.swift
+++ b/MateRunner/MateRunner/Util/Constant/CoordinatorType.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum CoordinatorType {
-    case app, login, tab, home
+    case app, login, tab, home, setting
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #69, #70, #71, #73 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역
- [x] 코디네이터 구현
- [x] 각 화면 연결 및 데이터전달 


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

<img width="868" alt="스크린샷 2021-11-10 오후 9 18 39" src="https://user-images.githubusercontent.com/46087477/141111844-12e3c667-a255-4a88-b860-3ada71403772.png">

- 자세한 구현 사항 
    + 구조를 다시 조금 개선했습니다. HomeCoordinator를 상위에 두고 HomeCoordinator에서 기본 화면으로 HomeViewController를 가지게 했습니다.
    + HomeCoordinator의 하위에는 SettingCoordinator와 RunningCoordinator(아직 구현은 안된 상태)를 두었습니다. 
    + SettingCoordinator는 RunningSetting 데이터의 전달과 뷰모델, 뷰컨트롤러의 주입을 세팅과 관련된 뷰컨트롤러들에 대해 수행합니다.
    + RunningCoordinaot는 운동중 화면과 운동결과 화면의 전환을 담당합니다.
    + 이때 RunningSetting을 SettingCoordinator에서 RunningCoordinator 쪽으로 전달해야하는데, 이를 위해서 HomeCoordinate가 SettingCoordinator에 delegate를 받아 SettingCoordinator가 코디네이터 종료 시그널과 함께 RunningSetting 데이터를 보낼 수 있도록 했습니다. 
    + HomeCoordinator는 SettingCoordinator의 delegate를 구현하는데, SettingCoordinator에서 만들었던 뷰컨들을 모두 pop하고, RunningSetting 데이터를 가지고 RunningCoordinator flow를 시작할 수 있도록 할 예정입니다.

- 코디네이터 패턴이 생각보다 고민할 거리가 많아 시간이 오래 걸리네요 다른 화면들의 연결도 빨리 해볼 수 있도록 하겠습니다.

- RunningSetting을 BehaviorSubject로 관리하는데, 이러다보니 try runningSetting.value() 로 한번 열어야하는 번거로움이 있네요.. 모델을 어떻게 관리하면 좋을지 고민이 계속 되는데 멘토님한테 여쭤보면 좋을 것 같습니

<br/><br/>
