### PR TITLE
운동 중 화면 코디네이터 연결 - 혼자달리기 모드

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */; };
 		B02FCAE2273BDA8A001657FE /* RunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */; };
 		B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */; };
+		B03F2F38273CB85200BD25D7 /* RunningSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */; };
 		B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */; };
 		B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */; };
 		B04A86BE2732D4D800F46069 /* RunningPreparationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86BD2732D4D800F46069 /* RunningPreparationViewModelTests.swift */; };
@@ -112,7 +113,6 @@
 		B0628B90273976DF004FAB0F /* DistanceSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B8C27397415004FAB0F /* DistanceSettingUseCase.swift */; };
 		B0628B9127397703004FAB0F /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		B0628B94273A1752004FAB0F /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B93273A1752004FAB0F /* Coordinator.swift */; };
-		B0628B97273A17E8004FAB0F /* RunningSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */; };
 		B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B98273A1ADD004FAB0F /* DefaultAppCoordinator.swift */; };
 		B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC327326C1C00D1EDAC /* Emoji.swift */; };
 		B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */; };
@@ -1258,6 +1258,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B03F2F38273CB85200BD25D7 /* RunningSettingCoordinator.swift in Sources */,
 				B0F53291273A370B005A3F11 /* AppCoordinator.swift in Sources */,
 				5E918A14272BD76D00B57888 /* MateRunner.xcdatamodeld in Sources */,
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
@@ -1274,9 +1275,7 @@
 				5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */,
 				AE6A6F582730FAEB005A3A5C /* RunningModeSettingViewModel.swift in Sources */,
 				AE6A6F33272CCB74005A3A5C /* MateViewController.swift in Sources */,
-				B0628B97273A17E8004FAB0F /* RunningSettingCoordinator.swift in Sources */,
 				5EBDA074273B893D00FC9707 /* TeamRunningResultViewController.swift in Sources */,
-				B0628B97273A17E8004FAB0F /* RunningSettingCoordinator.swift in Sources */,
 				3DF4C85B2731083B00A4B229 /* DefaultResultUseCase.swift in Sources */,
 				B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */,
 				3D2C218A273B9E6E00D00C68 /* MockInviteMateViewModel.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD7273BA987001657FE /* HomeCoordinator.swift */; };
 		B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */; };
 		B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */; };
+		B02FCAE2273BDA8A001657FE /* RunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */; };
+		B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */; };
 		B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */; };
 		B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */; };
 		B04A86BE2732D4D800F46069 /* RunningPreparationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86BD2732D4D800F46069 /* RunningPreparationViewModelTests.swift */; };
@@ -267,6 +269,8 @@
 		B02FCAD7273BA987001657FE /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeCoordinator.swift; sourceTree = "<group>"; };
 		B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinatorDidFinishDelegate.swift; sourceTree = "<group>"; };
+		B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningCoordinator.swift; sourceTree = "<group>"; };
+		B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningCoordinator.swift; sourceTree = "<group>"; };
 		B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewModel.swift; sourceTree = "<group>"; };
 		B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningPreparationUseCase.swift; sourceTree = "<group>"; };
 		B04A86BB2732D4D800F46069 /* RunningPreparationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunningPreparationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -814,6 +818,7 @@
 				B0F53292273A589B005A3F11 /* Protocol */,
 				B0F53293273A58AE005A3F11 /* DefaultRunningSettingCoordinator.swift */,
 				B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */,
+				B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -891,6 +896,7 @@
 			children = (
 				B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */,
 				B02FCAD7273BA987001657FE /* HomeCoordinator.swift */,
+				B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */,
 				B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */,
 			);
 			path = Protocol;
@@ -1263,6 +1269,7 @@
 				5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */,
 				5EBDA07A273BAAEC00FC9707 /* RaceResultView.swift in Sources */,
 				AE3D1495273A7A8000D4A186 /* DefaultMateUseCase.swift in Sources */,
+				B02FCAE2273BDA8A001657FE /* RunningCoordinator.swift in Sources */,
 				3DFD08B827391BDA00B46479 /* RunningData.swift in Sources */,
 				5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */,
 				AE6A6F582730FAEB005A3A5C /* RunningModeSettingViewModel.swift in Sources */,
@@ -1313,6 +1320,7 @@
 				5E171E61273251B4001C003B /* RunningResult.swift in Sources */,
 				AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */,
 				5E171E67273258A4001C003B /* RunningMode.swift in Sources */,
+				B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */,
 				5E32DC6827314764000E525B /* RoundedButton.swift in Sources */,
 				AE3D14852737C5E600D4A186 /* Mets.swift in Sources */,
 				5EBDA072273B629800FC9707 /* MyResultView.swift in Sources */,

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningPreparationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningPreparationUseCase.swift
@@ -10,16 +10,10 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningPreparationUseCase: RunningPreparationUseCase {
-    var runningSetting: RunningSetting
-    
     var timeLeft = BehaviorSubject(value: 3)
     var isTimeOver = BehaviorSubject(value: false)
     var timerDisposeBag = DisposeBag()
     private let maxTime = 3
-    
-    init(runningSetting: RunningSetting) {
-        self.runningSetting = runningSetting
-    }
     
     func executeTimer() {
         Observable<Int>
@@ -33,6 +27,7 @@ final class DefaultRunningPreparationUseCase: RunningPreparationUseCase {
             })
             .disposed(by: self.timerDisposeBag)
     }
+    
     private func updateTime(with time: Int) {
         if time == self.maxTime {
             self.timerDisposeBag = DisposeBag()

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningUseCase: RunningUseCase {
+    let runningSetting: RunningSetting
     var runningData: BehaviorSubject<RunningData> = BehaviorSubject(value: RunningData())
     var cancelTimeLeft: BehaviorSubject<Int> = BehaviorSubject(value: 3)
     var popUpTimeLeft: BehaviorSubject<Int> = BehaviorSubject(value: 2)
@@ -24,6 +25,10 @@ final class DefaultRunningUseCase: RunningUseCase {
     private let coreMotionManager = CoreMotionManager()
     private var currentMETs = 0.0
   
+    init(runningSetting: RunningSetting) {
+        self.runningSetting = runningSetting
+    }
+    
     func executePedometer() {
         self.coreMotionManager.startPedometer()
             .subscribe(onNext: { [weak self] distance in

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningPreparationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningPreparationUseCase.swift
@@ -12,6 +12,5 @@ import RxSwift
 protocol RunningPreparationUseCase {
 	var timeLeft: BehaviorSubject<Int> { get set }
 	var isTimeOver: BehaviorSubject<Bool> { get set }
-    var runningSetting: RunningSetting { get set }
 	func executeTimer()
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -45,7 +45,8 @@ final class DefaultHomeCoorditnator: HomeCoordinator {
 
 extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
-        self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
+        self.childCoordinators = self.childCoordinators
+            .filter({ $0.type != childCoordinator.type })
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -46,7 +46,6 @@ final class DefaultHomeCoorditnator: HomeCoordinator {
 extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
-        self.navigationController.popToRootViewController(animated: false)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -35,8 +35,11 @@ final class DefaultHomeCoorditnator: HomeCoordinator {
         settingCoordinator.start()
     }
     
-    func showRunningFlow() {
-        // 운동중 화면 플로우
+    func showRunningFlow(with initialSettingData: RunningSetting) {
+        let runningCoordinator = DefaultRunningCoordinator(self.navigationController)
+        runningCoordinator.finishDelegate = self
+        self.childCoordinators.append(runningCoordinator)
+        runningCoordinator.pushRunningViewController(with: initialSettingData)
     }
 }
 
@@ -49,6 +52,6 @@ extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
 
 extension DefaultHomeCoorditnator: SettingCoordinatorDidFinishDelegate {
     func settingCoordinatorDidFinish(with runningSettingData: RunningSetting) {
-        print(runningSettingData)
+        self.showRunningFlow(with: runningSettingData)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -30,21 +30,28 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     }
     
     func pushRunningResultViewController(with runningResult: RunningResult) {
-        let runnningResultViewController = RunningResultViewController()
-        self.navigationController.pushViewController(runnningResultViewController, animated: true)
+        let runningResultViewController = RunningResultViewController()
+        self.navigationController.pushViewController(runningResultViewController, animated: true)
     }
     
     private func pushSingleRunningViewController(with settingData: RunningSetting) {
         let singleRunningViewController = SingleRunningViewController()
+        singleRunningViewController.viewModel = SingleRunningViewModel(
+            runningUseCase: DefaultRunningUseCase(runningSetting: settingData)
+        )
         self.navigationController.pushViewController(singleRunningViewController, animated: true)
     }
     
     private func pushTeamRunningViewController(with settingData: RunningSetting) {
-        
+        let teamRunningViewController = TeamRunningViewController()
+        self.navigationController.pushViewController(teamRunningViewController, animated: true)
+        // TODO: 뷰모델 생성 및 유즈케이스에 setting 값 주입 작성
     }
     
     private func pushRaceRunningViewController(with settingData: RunningSetting) {
-        
+        let raceRunningViewController = RaceRunningViewController()
+        self.navigationController.pushViewController(raceRunningViewController, animated: true)
+        // TODO: 뷰모델 생성 및 유즈케이스에 setting 값 주입 작성
     }
     
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -1,0 +1,50 @@
+//
+//  DefaultRunningCoordinator.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/10.
+//
+
+import UIKit
+
+final class DefaultRunningCoordinator: RunningCoordinator {
+    var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var childCoordinators: [Coordinator] = []
+    var type: CoordinatorType { .running }
+    
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {}
+    
+    func pushRunningViewController(with settingData: RunningSetting?) {
+        guard let settingData = settingData,
+              let runningMode = settingData.mode else { return }
+        switch runningMode {
+        case .single: pushSingleRunningViewController(with: settingData)
+        case .race: pushRaceRunningViewController(with: settingData)
+        case .team: pushTeamRunningViewController(with: settingData)
+        }
+    }
+    
+    func pushRunningResultViewController(with runningResult: RunningResult) {
+        
+    }
+    
+    private func pushSingleRunningViewController(with settingData: RunningSetting) {
+        
+    }
+    
+    private func pushTeamRunningViewController(with settingData: RunningSetting) {
+        
+    }
+    
+    private func pushRaceRunningViewController(with settingData: RunningSetting) {
+        
+    }
+    
+    
+    
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class DefaultRunningCoordinator: RunningCoordinator {
-    var finishDelegate: CoordinatorFinishDelegate?
+    weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
     var type: CoordinatorType { .running }
@@ -30,11 +30,13 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     }
     
     func pushRunningResultViewController(with runningResult: RunningResult) {
-        
+        let runnningResultViewController = RunningResultViewController()
+        self.navigationController.pushViewController(runnningResultViewController, animated: true)
     }
     
     private func pushSingleRunningViewController(with settingData: RunningSetting) {
-        
+        let singleRunningViewController = SingleRunningViewController()
+        self.navigationController.pushViewController(singleRunningViewController, animated: true)
     }
     
     private func pushTeamRunningViewController(with settingData: RunningSetting) {
@@ -44,7 +46,5 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     private func pushRaceRunningViewController(with settingData: RunningSetting) {
         
     }
-    
-    
     
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -59,9 +59,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
         let runningPreparationViewController = RunningPreparationViewController()
         runningPreparationViewController.viewModel = RunningPreparationViewModel(
             coordinator: self,
-            runningPreparationUseCase: DefaultRunningPreparationUseCase(
-                runningSetting: settingData
-            )
+            runningSettingUseCase: DefaultRunningSettingUseCase(runningSetting: settingData),
+            runningPreparationUseCase: DefaultRunningPreparationUseCase()
         )
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol HomeCoordinator: Coordinator {
     func showSettingFlow()
-    func showRunningFlow()
+    func showRunningFlow(with initialSettingData: RunningSetting)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/RunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/RunningCoordinator.swift
@@ -1,0 +1,13 @@
+//
+//  RunningCoordinator.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/10.
+//
+
+import Foundation
+
+protocol RunningCoordinator: Coordinator {
+    func pushRunningViewController(with settingData: RunningSetting?)
+    func pushRunningResultViewController(with runningResult: RunningResult)
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -74,6 +74,7 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
+        self.tabBarController?.tabBar.isHidden = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -71,6 +71,11 @@ final class HomeViewController: UIViewController {
         self.gradientLayer.frame = self.mapView.bounds
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.locationManager.stopUpdatingLocation()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningModeSettingViewController.swift
@@ -49,7 +49,7 @@ final class RunningModeSettingViewController: UIViewController {
 
 private extension RunningModeSettingViewController {
     func configureUI() {
-        self.hidesBottomBarWhenPushed = true
+        self.tabBarController?.tabBar.isHidden = true
         self.navigationItem.largeTitleDisplayMode = .never
         self.view.backgroundColor = .systemBackground
         

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningPreparationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningPreparationViewController.swift
@@ -52,14 +52,5 @@ private extension RunningPreparationViewController {
 				}
 			})
 			.disposed(by: self.disposeBag)
-		
-		output?.$navigateToNext
-			.asDriver()
-			.filter({ $0 == true })
-			.drive(onNext: { _ in
-				let singleRunningViewController = SingleRunningViewController()
-				self.navigationController?.pushViewController(singleRunningViewController, animated: true)
-			})
-			.disposed(by: self.disposeBag)
 	}
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -118,6 +118,8 @@ class SingleRunningViewController: UIViewController {
 // MARK: - Private Functions
 private extension SingleRunningViewController {
     func configureUI() {
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+        self.tabBarController?.tabBar.isHidden = true
         self.view.addSubview(self.scrollView)
         self.scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -12,9 +12,7 @@ import RxGesture
 import SnapKit
 
 class SingleRunningViewController: UIViewController {
-    let singleRunningViewModel = SingleRunningViewModel(
-        runningUseCase: DefaultRunningUseCase()
-    )
+    var viewModel: SingleRunningViewModel?
     private var disposeBag = DisposeBag()
     
     private lazy var scrollView: UIScrollView = {
@@ -196,37 +194,37 @@ private extension SingleRunningViewController {
             finishButtonDidTapEvent: self.cancelButton.rx.tap
                 .asObservable()
         )
-        let output = self.singleRunningViewModel.transform(from: input, disposeBag: self.disposeBag)
+        let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         
-        output.$timeSpent
+        output?.$timeSpent
             .asDriver()
             .drive(onNext: { [weak self] newValue in
                 self?.timeView.updateValue(newValue: newValue)
             })
             .disposed(by: self.disposeBag)
         
-        output.cancelTime
+        output?.cancelTime
             .asDriver(onErrorJustReturn: "종료")
             .drive(onNext: { [weak self] newValue in
                 self?.updateTimeLeftText(with: newValue)
             })
             .disposed(by: self.disposeBag)
         
-        output.$navigateToResult
+        output?.$navigateToResult
             .asDriver()
             .drive(onNext: { [weak self] navigateToResult in
                 if navigateToResult == true { self?.navigateToResultScene() }
             })
             .disposed(by: self.disposeBag)
         
-        output.isToasterNeeded
+        output?.isToasterNeeded
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: {[weak self] isNeeded in
                 self?.toggleCancelFolatingView(isNeeded: isNeeded)
             })
             .disposed(by: disposeBag)
         
-        output.$distance
+        output?.$distance
             .asDriver()
             .drive(onNext: { [weak self] distance in
                 guard let distance = distance else { return }
@@ -234,7 +232,7 @@ private extension SingleRunningViewController {
             })
             .disposed(by: self.disposeBag)
         
-        output.$progress
+        output?.$progress
             .asDriver()
             .drive(onNext: { [weak self] progress in
                 guard let progress = progress else { return }
@@ -242,7 +240,7 @@ private extension SingleRunningViewController {
             })
             .disposed(by: self.disposeBag)
 
-        output.$calorie
+        output?.$calorie
             .asDriver()
             .drive(onNext: { [weak self] calorie in
                 guard let calorie = calorie else { return }
@@ -250,7 +248,7 @@ private extension SingleRunningViewController {
             })
             .disposed(by: self.disposeBag)
         
-        output.$finishRunning
+        output?.$finishRunning
             .asDriver()
             .filter { $0 == true }
             .drive(onNext: { [weak self] _ in

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -10,44 +10,52 @@ import Foundation
 import RxSwift
 
 class RunningPreparationViewModel {
-    private weak var coordinator: RunningSettingCoordinator?
+    private weak var coordinator: SettingCoordinator?
+    private let runningSettingUseCase: RunningSettingUseCase
     private let runningPreparationUseCase: RunningPreparationUseCase
     private let maxPreparationTime = 3
     
-	struct Input {
-		let viewDidLoadEvent: Observable<Void>
-	}
-	struct Output {
-		@BehaviorRelayProperty var timeLeft: String?
-		@BehaviorRelayProperty var navigateToNext: Bool?
-	}
-	
-    init(coordinator: RunningSettingCoordinator, runningPreparationUseCase: RunningPreparationUseCase) {
+    struct Input {
+        let viewDidLoadEvent: Observable<Void>
+    }
+    struct Output {
+        @BehaviorRelayProperty var timeLeft: String?
+        @BehaviorRelayProperty var navigateToNext: Bool?
+    }
+    
+    init(
+        coordinator: SettingCoordinator,
+        runningSettingUseCase: RunningSettingUseCase,
+        runningPreparationUseCase: RunningPreparationUseCase
+    ) {
         self.coordinator = coordinator
-		self.runningPreparationUseCase = runningPreparationUseCase
-	}
-	
-	func transform(from input: Input, disposeBag: DisposeBag) -> Output {
-		let output = Output()
-		input.viewDidLoadEvent
-			.subscribe(onNext: { [weak self] _ in
+        self.runningPreparationUseCase = runningPreparationUseCase
+        self.runningSettingUseCase = runningSettingUseCase
+    }
+    
+    func transform(from input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        input.viewDidLoadEvent
+            .subscribe(onNext: { [weak self] _ in
                 self?.runningPreparationUseCase.executeTimer()
             })
-			.disposed(by: disposeBag)
-		
-		self.runningPreparationUseCase.timeLeft
-			.map({ "\($0)" })
-			.bind(to: output.$timeLeft)
-			.disposed(by: disposeBag)
-		
-		self.runningPreparationUseCase.isTimeOver
+            .disposed(by: disposeBag)
+        
+        self.runningPreparationUseCase.timeLeft
+            .map({ "\($0)" })
+            .bind(to: output.$timeLeft)
+            .disposed(by: disposeBag)
+        
+        self.runningPreparationUseCase.isTimeOver
             .subscribe(onNext: { [weak self] isOver in
-                guard isOver,
-                      let settingData = self?.runningPreparationUseCase.runningSetting else { return }
+                self?.runningSettingUseCase.updateDateTime(date: Date())
+                guard isOver, let settingData = try? self?.runningSettingUseCase.runningSetting.value() else {
+                    return
+                }
                 self?.coordinator?.finish(with: settingData)
             })
-			.disposed(by: disposeBag)
-		
-		return output
-	}
+            .disposed(by: disposeBag)
+        
+        return output
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningPreparationViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 class RunningPreparationViewModel {
-    private weak var coordinator: SettingCoordinator?
+    private weak var coordinator: RunningSettingCoordinator?
     private let runningSettingUseCase: RunningSettingUseCase
     private let runningPreparationUseCase: RunningPreparationUseCase
     private let maxPreparationTime = 3
@@ -24,7 +24,7 @@ class RunningPreparationViewModel {
     }
     
     init(
-        coordinator: SettingCoordinator,
+        coordinator: RunningSettingCoordinator,
         runningSettingUseCase: RunningSettingUseCase,
         runningPreparationUseCase: RunningPreparationUseCase
     ) {

--- a/MateRunner/MateRunner/Util/Constant/CoordinatorType.swift
+++ b/MateRunner/MateRunner/Util/Constant/CoordinatorType.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum CoordinatorType {
-    case app, login, tab, home, setting
+    case app, login, tab, home, setting, running
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #81 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 운동중 화면 전환을 담당하는 RunningCoordinator 정의
- [x] 혼자달리기 모드가 시작할 때 runningsetting 정보 주입 


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

<img width="868" alt="스크린샷 2021-11-10 오후 9 18 39" src="https://user-images.githubusercontent.com/46087477/141231027-ea9f2e7b-7118-4705-bf18-5667c0bda22d.png">

- 전체적인 흐름은 위 그림처럼 3초 카운트다운이 종료될 때 RunningSetting Coordinator가 자신이 종료했음을 델레데이트를 통해 HomeCoordinator로 알리고, HomeCoordinator는 이 델렉게이트의 구현을 RunningCoordinator를 새로 시작하는 것으로 구현해두었습니다. 이 과정에서 파라미터로 RunningSettng이 계속 넘어가서 RunningCoordinator까지 세팅정보가 전달되도록 했습니다.

   ```swift
    extension DefaultHomeCoorditnator: SettingCoordinatorDidFinishDelegate {
        func settingCoordinatorDidFinish(with runningSettingData: RunningSetting) {
            self.showRunningFlow(with: runningSettingData)
        }
    }
   ```

- 운동중 화면이 보이는게 여러모로 작업하기 편하실 것 같아서 코디네이터 구현하고 연결해 올립니다!
- 뷰모델, 유즈케이스 주입은 혼자달리기 모드까지만 되어있어요.
- 코드 검토해보시고 괜찮으시면 이 PR까지 머지한 뒤에 작업 이어나가도 될 것 같습니다!

<br/><br/>
