### PR TITLE
메이트 선택화면 코디네이터 연결

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		AE3D1490273A5E4000D4A186 /* MateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148F273A5E4000D4A186 /* MateUseCase.swift */; };
 		AE3D1492273A5F5900D4A186 /* MateTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */; };
 		AE3D1495273A7A8000D4A186 /* DefaultMateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */; };
-		AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */; };
+		AE3D1497273B91AD00D4A186 /* MateSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1496273B91AD00D4A186 /* MateSettingViewController.swift */; };
 		AE3D1499273B9E9600D4A186 /* MateEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */; };
 		AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */; };
 		AE3D149D273BD67A00D4A186 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D149C273BD67A00D4A186 /* InvitationView.swift */; };
@@ -247,7 +247,7 @@
 		AE3D148F273A5E4000D4A186 /* MateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateUseCase.swift; sourceTree = "<group>"; };
 		AE3D1491273A5F5900D4A186 /* MateTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateTableViewCell.swift; sourceTree = "<group>"; };
 		AE3D1494273A7A8000D4A186 /* DefaultMateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateUseCase.swift; sourceTree = "<group>"; };
-		AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMateViewController.swift; sourceTree = "<group>"; };
+		AE3D1496273B91AD00D4A186 /* MateSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateSettingViewController.swift; sourceTree = "<group>"; };
 		AE3D1498273B9E9600D4A186 /* MateEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateEmptyView.swift; sourceTree = "<group>"; };
 		AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationViewController.swift; sourceTree = "<group>"; };
 		AE3D149C273BD67A00D4A186 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
@@ -576,7 +576,7 @@
 				B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */,
 				5E36992327358F7300D2A6F2 /* MapViewController.swift */,
 				3D2C2187273B995700D00C68 /* InvitationWaitingViewController.swift */,
-				AE3D1496273B91AD00D4A186 /* InviteMateViewController.swift */,
+				AE3D1496273B91AD00D4A186 /* MateSettingViewController.swift */,
 				AE3D149A273BAEDD00D4A186 /* InvitationViewController.swift */,
 				5EBDA073273B893D00FC9707 /* TeamRunningResultViewController.swift */,
 				5EBDA077273BA7ED00FC9707 /* RaceRunningResultViewController.swift */,
@@ -1311,7 +1311,7 @@
 				3DF4C85B2731083B00A4B229 /* DefaultResultUseCase.swift in Sources */,
 				B0628B99273A1ADD004FAB0F /* DefaultAppCoordinator.swift in Sources */,
 				3D2C218A273B9E6E00D00C68 /* InvitationWaitingViewModel.swift in Sources */,
-				AE3D1497273B91AD00D4A186 /* InviteMateViewController.swift in Sources */,
+				AE3D1497273B91AD00D4A186 /* MateSettingViewController.swift in Sources */,
 				3DF4C8622735841B00A4B229 /* RunningResultUseCase.swift in Sources */,
 				AE3D1490273A5E4000D4A186 /* MateUseCase.swift in Sources */,
 				B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */,

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -91,7 +91,7 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
     
     func pushMateSettingViewController(with settingData: RunningSetting?) {
         guard let settingData = settingData else { return }
-        let inviteMateViewController = InviteMateViewController()
+        let inviteMateViewController = MateSettingViewController()
         inviteMateViewController.viewModel = MateSettingViewModel(
             coordinator: self,
             runningSettingUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateRunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateRunningModeSettingViewController.swift
@@ -135,7 +135,7 @@ private extension MateRunningModeSettingViewController {
     }
     
     func nextButtonDidTap() {
-        let inviteMateViewController = InviteMateViewController()
+        let inviteMateViewController = MateSettingViewController()
         self.navigationController?.pushViewController(inviteMateViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateSettingViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class InviteMateViewController: MateViewController {
+final class MateSettingViewController: MateViewController {
     var viewModel: MateSettingViewModel?
     
     override func viewDidLoad() {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateSettingViewModel.swift
@@ -11,7 +11,10 @@ class MateSettingViewModel {
     weak var coordinator: RunningSettingCoordinator?
     private let runningSettingUseCase: RunningSettingUseCase
     
-    init(coordinator: RunningSettingCoordinator, runningSettingUseCase: RunningSettingUseCase) {
+    init(
+        coordinator: RunningSettingCoordinator,
+        runningSettingUseCase: RunningSettingUseCase
+    ) {
         self.coordinator = coordinator
         self.runningSettingUseCase = runningSettingUseCase
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateSettingViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class MateSettingViewModel {
+final class MateSettingViewModel {
     weak var coordinator: RunningSettingCoordinator?
     private let runningSettingUseCase: RunningSettingUseCase
     

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -36,8 +36,14 @@ class MateViewController: UIViewController {
         tableView.separatorStyle = .none
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.register(MateTableViewCell.self, forCellReuseIdentifier: MateTableViewCell.identifier)
-        tableView.register(MateHeaderView.self, forHeaderFooterViewReuseIdentifier: MateHeaderView.identifier)
+        tableView.register(
+            MateTableViewCell.self,
+            forCellReuseIdentifier: MateTableViewCell.identifier
+        )
+        tableView.register(
+            MateHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: MateHeaderView.identifier
+        )
         return tableView
     }()
     
@@ -49,10 +55,12 @@ class MateViewController: UIViewController {
     
     func configureNavigation() {
         self.navigationItem.title = "친구 목록"
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "person.badge.plus"),
-                                                                 style: .plain,
-                                                                 target: self,
-                                                                 action: nil)
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "person.badge.plus"),
+            style: .plain,
+            target: self,
+            action: nil
+        )
     }
     
     func moveToNext(mate: String) {


### PR DESCRIPTION
### 📕 Issue Number

Close #72 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 작성


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 제가 이전 커밋에서 이미 연결을 해뒀더라구요.. 그래서 코드스타일만 수정했어요..! 아래는 코드 보면서 생각이 드는걸 적어놨습니다!

- Input, Output 미사용
이 작업에서는 Input, Output을 사용하지 않았습니다. 뷰 컨틀롤러 자체가 MateViewController를 상속받고 있어서 테이블 자체를 이 클래스에서 관리하지 않기도 하고, 이 화면에서는 지속적인 인터렉션 없이 셀 하나를 선택하면 바로 다음 화면으로 이동하기 때문에 정의할 Output이 없기도 했습니다. 다른 의견이 있으시면 알려주세요!

- 메서드 이름
지금 슈퍼클래스에서 moveToNext(nickname) 메서드가 didSelectRowAt 메서드가 불리면서 함께 불리도록 되어 있고 MateSetting 뷰컨에서는 movetoNext를 오버라이드 해서 사용하고 있습니다. 그런데 친구탭에서는 친구를 탭했을 때 친구 프로필로 이동하고, 여기서는 거리설정 화면으로 이동합니다. 그래서 두 메서드가 목적이 다른데 지금 이름이 조금 추상적인 것 같아서 바꾸면 좋을 것 같은데 어떻게 바꿔야할지 모르겠네요

- 테이블 뷰 datasource 위치
아까 멘토링하면서 느낀건데 데이터소스가 뷰컨에 있으면 안될 것 같은데 어떠세요..?

<br/><br/>
