### PR TITLE
LocationService 구현, MapViewController에 LocationService 적용

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		B00133BE273D63D7004E0D1F /* DefaultLocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */; };
 		B00133C0273D6E52004E0D1F /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BF273D6E52004E0D1F /* LocationService.swift */; };
 		B00133C2273D91A6004E0D1F /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133C1273D91A6004E0D1F /* MapViewModel.swift */; };
+		B00133C4273D949D004E0D1F /* MapUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133C3273D949D004E0D1F /* MapUseCase.swift */; };
+		B00133C6273D94B3004E0D1F /* DefaultMapUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133C5273D94B3004E0D1F /* DefaultMapUseCase.swift */; };
 		B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */; };
 		B015E866273585EB0000AA47 /* SingleRunningViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */; };
 		B015E86E2735864F0000AA47 /* MockSingleRunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */; };
@@ -284,6 +286,8 @@
 		B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocationRepository.swift; sourceTree = "<group>"; };
 		B00133BF273D6E52004E0D1F /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		B00133C1273D91A6004E0D1F /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		B00133C3273D949D004E0D1F /* MapUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapUseCase.swift; sourceTree = "<group>"; };
+		B00133C5273D94B3004E0D1F /* DefaultMapUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMapUseCase.swift; sourceTree = "<group>"; };
 		B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorDisabledTextField.swift; sourceTree = "<group>"; };
 		B01205CACB0E40A1BDDD081F /* Pods-RunningPreparationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunningPreparationTests.release.xcconfig"; path = "Target Support Files/Pods-RunningPreparationTests/Pods-RunningPreparationTests.release.xcconfig"; sourceTree = "<group>"; };
 		B015E863273585EB0000AA47 /* SingleRunningTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SingleRunningTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -436,6 +440,7 @@
 				3D2C2174273A719500D00C68 /* DefaultTeamRunningUseCase.swift */,
 				B0F53297273A5DCA005A3F11 /* HomeUseCase.swift */,
 				3D2C218B273B9F9B00D00C68 /* DefaultInvitationWaitingUseCase.swift */,
+				B00133C5273D94B3004E0D1F /* DefaultMapUseCase.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -801,6 +806,7 @@
 				AECB9A8127356AFF00533EF7 /* RunningUseCase.swift */,
 				3D2C217F273A9A3400D00C68 /* TeamRunningUseCase.swift */,
 				3D2C2193273CBCE400D00C68 /* InvitationWaitingUseCase.swift */,
+				B00133C3273D949D004E0D1F /* MapUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1308,6 +1314,7 @@
 				5E918A14272BD76D00B57888 /* MateRunner.xcdatamodeld in Sources */,
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
 				5EBDA07C273BC67D00FC9707 /* CancelRunningResultViewController.swift in Sources */,
+				B00133C6273D94B3004E0D1F /* DefaultMapUseCase.swift in Sources */,
 				3DF4C86927376B7B00A4B229 /* NetworkService.swift in Sources */,
 				3DF4C859273104B500A4B229 /* RunningResultViewModel.swift in Sources */,
 				B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */,
@@ -1367,6 +1374,7 @@
 				AE6A6F532730423D005A3A5C /* RunningModeSettingViewController.swift in Sources */,
 				B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */,
 				5EBDA078273BA7ED00FC9707 /* RaceRunningResultViewController.swift in Sources */,
+				B00133C4273D949D004E0D1F /* MapUseCase.swift in Sources */,
 				3DFD08B627391AE300B46479 /* RunningRealTimeData.swift in Sources */,
 				5E171E61273251B4001C003B /* RunningResult.swift in Sources */,
 				AE6A6F2F272CCB46005A3A5C /* HomeViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		B04A86CA2732E77500F46069 /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		B04A86CD2732F48300F46069 /* RunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86CC2732F48300F46069 /* RunningPreparationUseCase.swift */; };
 		B04A86CE2732F4B300F46069 /* RunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86CC2732F48300F46069 /* RunningPreparationUseCase.swift */; };
+		B05DEC2B273FBD8E00C0575B /* DefaultLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DEC2A273FBD8E00C0575B /* DefaultLocationService.swift */; };
 		B0628B87273972AB004FAB0F /* DistanceSettingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B82273970A6004FAB0F /* DistanceSettingUseCaseTests.swift */; };
 		B0628B88273972AE004FAB0F /* DistanceSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B83273970A6004FAB0F /* DistanceSettingViewModelTests.swift */; };
 		B0628B89273972B1004FAB0F /* MockDistanceSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B81273970A6004FAB0F /* MockDistanceSettingUseCase.swift */; };
@@ -305,6 +306,7 @@
 		B04A86BD2732D4D800F46069 /* RunningPreparationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewModelTests.swift; sourceTree = "<group>"; };
 		B04A86C72732D7B400F46069 /* MockRunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRunningPreparationUseCase.swift; sourceTree = "<group>"; };
 		B04A86CC2732F48300F46069 /* RunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationUseCase.swift; sourceTree = "<group>"; };
+		B05DEC2A273FBD8E00C0575B /* DefaultLocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocationService.swift; sourceTree = "<group>"; };
 		B0628B7827397089004FAB0F /* DistanceSettingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DistanceSettingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B0628B81273970A6004FAB0F /* MockDistanceSettingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDistanceSettingUseCase.swift; sourceTree = "<group>"; };
 		B0628B82273970A6004FAB0F /* DistanceSettingUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistanceSettingUseCaseTests.swift; sourceTree = "<group>"; };
@@ -386,6 +388,7 @@
 				3D2C2177273A744800D00C68 /* DefaultTeamRunningRepository.swift */,
 				3D2C218D273BA07B00D00C68 /* DefaultInviteMateRepository.swift */,
 				B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */,
+				B05DEC2A273FBD8E00C0575B /* DefaultLocationService.swift */,
 				B00133BF273D6E52004E0D1F /* LocationService.swift */,
 			);
 			path = Home;
@@ -1339,6 +1342,7 @@
 				B0F53296273A5D8E005A3F11 /* HomeViewModel.swift in Sources */,
 				3D2C2194273CBCE400D00C68 /* InvitationWaitingUseCase.swift in Sources */,
 				AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */,
+				B05DEC2B273FBD8E00C0575B /* DefaultLocationService.swift in Sources */,
 				B0628B8D27397415004FAB0F /* DistanceSettingUseCase.swift in Sources */,
 				AE6A6F35272FC170005A3A5C /* DistanceSettingViewController.swift in Sources */,
 				3D2C2198273CF0D700D00C68 /* User.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -92,6 +92,9 @@
 		AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDAFD17273526FC009BAEAA /* DefaultRunningUseCase.swift */; };
 		AEF02183273CB1600086CBF1 /* EmojiViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF02182273CB1600086CBF1 /* EmojiViewController.swift */; };
 		B00133BA273D0A90004E0D1F /* MateSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133B9273D0A90004E0D1F /* MateSettingViewModel.swift */; };
+		B00133BC273D63BC004E0D1F /* LocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BB273D63BC004E0D1F /* LocationRepository.swift */; };
+		B00133BE273D63D7004E0D1F /* DefaultLocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */; };
+		B00133C0273D6E52004E0D1F /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BF273D6E52004E0D1F /* LocationService.swift */; };
 		B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */; };
 		B015E866273585EB0000AA47 /* SingleRunningViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */; };
 		B015E86E2735864F0000AA47 /* MockSingleRunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */; };
@@ -276,6 +279,9 @@
 		AEDAFD17273526FC009BAEAA /* DefaultRunningUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningUseCase.swift; sourceTree = "<group>"; };
 		AEF02182273CB1600086CBF1 /* EmojiViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiViewController.swift; sourceTree = "<group>"; };
 		B00133B9273D0A90004E0D1F /* MateSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateSettingViewModel.swift; sourceTree = "<group>"; };
+		B00133BB273D63BC004E0D1F /* LocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRepository.swift; sourceTree = "<group>"; };
+		B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocationRepository.swift; sourceTree = "<group>"; };
+		B00133BF273D6E52004E0D1F /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorDisabledTextField.swift; sourceTree = "<group>"; };
 		B01205CACB0E40A1BDDD081F /* Pods-RunningPreparationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunningPreparationTests.release.xcconfig"; path = "Target Support Files/Pods-RunningPreparationTests/Pods-RunningPreparationTests.release.xcconfig"; sourceTree = "<group>"; };
 		B015E863273585EB0000AA47 /* SingleRunningTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SingleRunningTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -373,6 +379,8 @@
 				3DF4C8652737687900A4B229 /* DefaultRunningResultRepository.swift */,
 				3D2C2177273A744800D00C68 /* DefaultTeamRunningRepository.swift */,
 				3D2C218D273BA07B00D00C68 /* DefaultInviteMateRepository.swift */,
+				B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */,
+				B00133BF273D6E52004E0D1F /* LocationService.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -391,6 +399,7 @@
 			children = (
 				3DF4C86B27376C9A00A4B229 /* RunningResultRepository.swift */,
 				3D2C217D273A99AC00D00C68 /* TeamRunningRepository.swift */,
+				B00133BB273D63BC004E0D1F /* LocationRepository.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1292,6 +1301,7 @@
 			files = (
 				B03F2F38273CB85200BD25D7 /* RunningSettingCoordinator.swift in Sources */,
 				B0F53291273A370B005A3F11 /* AppCoordinator.swift in Sources */,
+				B00133BE273D63D7004E0D1F /* DefaultLocationRepository.swift in Sources */,
 				5E918A14272BD76D00B57888 /* MateRunner.xcdatamodeld in Sources */,
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
 				5EBDA07C273BC67D00FC9707 /* CancelRunningResultViewController.swift in Sources */,
@@ -1302,6 +1312,7 @@
 				5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */,
 				5EBDA07A273BAAEC00FC9707 /* RaceResultView.swift in Sources */,
 				AE3D1495273A7A8000D4A186 /* DefaultMateUseCase.swift in Sources */,
+				B00133C0273D6E52004E0D1F /* LocationService.swift in Sources */,
 				B02FCAE2273BDA8A001657FE /* RunningCoordinator.swift in Sources */,
 				3DFD08B827391BDA00B46479 /* RunningData.swift in Sources */,
 				5E918A0A272BD76D00B57888 /* AppDelegate.swift in Sources */,
@@ -1388,6 +1399,7 @@
 				B0F53289273A32E0005A3F11 /* CoordinatorType.swift in Sources */,
 				B0628B94273A1752004FAB0F /* Coordinator.swift in Sources */,
 				AE6A6F37272FC723005A3A5C /* UIFont+CustomFont.swift in Sources */,
+				B00133BC273D63BC004E0D1F /* LocationRepository.swift in Sources */,
 				AE6A6F5A2732B940005A3A5C /* DefaultRunningSettingUseCase.swift in Sources */,
 				3D2C2180273A9A3400D00C68 /* TeamRunningUseCase.swift in Sources */,
 				3D2C2188273B995700D00C68 /* InvitationWaitingViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		B00133BC273D63BC004E0D1F /* LocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BB273D63BC004E0D1F /* LocationRepository.swift */; };
 		B00133BE273D63D7004E0D1F /* DefaultLocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */; };
 		B00133C0273D6E52004E0D1F /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133BF273D6E52004E0D1F /* LocationService.swift */; };
+		B00133C2273D91A6004E0D1F /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133C1273D91A6004E0D1F /* MapViewModel.swift */; };
 		B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */; };
 		B015E866273585EB0000AA47 /* SingleRunningViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */; };
 		B015E86E2735864F0000AA47 /* MockSingleRunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */; };
@@ -282,6 +283,7 @@
 		B00133BB273D63BC004E0D1F /* LocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRepository.swift; sourceTree = "<group>"; };
 		B00133BD273D63D7004E0D1F /* DefaultLocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocationRepository.swift; sourceTree = "<group>"; };
 		B00133BF273D6E52004E0D1F /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
+		B00133C1273D91A6004E0D1F /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorDisabledTextField.swift; sourceTree = "<group>"; };
 		B01205CACB0E40A1BDDD081F /* Pods-RunningPreparationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunningPreparationTests.release.xcconfig"; path = "Target Support Files/Pods-RunningPreparationTests/Pods-RunningPreparationTests.release.xcconfig"; sourceTree = "<group>"; };
 		B015E863273585EB0000AA47 /* SingleRunningTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SingleRunningTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -896,6 +898,7 @@
 				B0F53295273A5D8E005A3F11 /* HomeViewModel.swift */,
 				3D2C2189273B9E6E00D00C68 /* InvitationWaitingViewModel.swift */,
 				B00133B9273D0A90004E0D1F /* MateSettingViewModel.swift */,
+				B00133C1273D91A6004E0D1F /* MapViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1338,6 +1341,7 @@
 				3D2C218E273BA07B00D00C68 /* DefaultInviteMateRepository.swift in Sources */,
 				3DF4C86C27376C9A00A4B229 /* RunningResultRepository.swift in Sources */,
 				3D2C2196273CE12600D00C68 /* Session.swift in Sources */,
+				B00133C2273D91A6004E0D1F /* MapViewModel.swift in Sources */,
 				3D2C2178273A744800D00C68 /* DefaultTeamRunningRepository.swift in Sources */,
 				B06E6DC927326E4E00D1EDAC /* TeamRunningResult.swift in Sources */,
 				B0F5328F273A35E0005A3F11 /* CoordinatorFinishDelegate.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
@@ -5,12 +5,12 @@
 //  Created by 전여훈 on 2021/11/11.
 //
 
-import CoreLocation
-import Foundation
+ import CoreLocation
+ import Foundation
 
-import RxSwift
+ import RxSwift
 
-class DefaultLocationRepository: LocationRepository {
+ class DefaultLocationRepository: LocationRepository {
     let locationService: LocationService
     
     init(locationService: LocationService) {
@@ -22,14 +22,14 @@ class DefaultLocationRepository: LocationRepository {
     }
     
     func fetchCurrentLocation() -> Observable<[CLLocation]> {
-        return Observable.just([CLLocation]())
+        return self.locationService.fetchCurrentLocation()
     }
     
     func executeLocationService() {
-        self.locationService.startUpdatingLocation()
+        self.locationService.start()
     }
     
     func terminateLocationService() {
-        self.locationService.stopUpdatingLocation()
+        self.locationService.stop()
     }
-}
+ }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
@@ -5,12 +5,12 @@
 //  Created by 전여훈 on 2021/11/11.
 //
 
- import CoreLocation
- import Foundation
+import CoreLocation
+import Foundation
 
- import RxSwift
+import RxSwift
 
- class DefaultLocationRepository: LocationRepository {
+final class DefaultLocationRepository: LocationRepository {
     let locationService: LocationService
     
     init(locationService: LocationService) {
@@ -32,4 +32,4 @@
     func terminateLocationService() {
         self.locationService.stop()
     }
- }
+}

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
@@ -24,4 +24,12 @@ class DefaultLocationRepository: LocationRepository {
     func fetchCurrentLocation() -> Observable<[CLLocation]> {
         return Observable.just([CLLocation]())
     }
+    
+    func executeLocationService() {
+        self.locationService.startUpdatingLocation()
+    }
+    
+    func terminateLocationService() {
+        self.locationService.stopUpdatingLocation()
+    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
@@ -5,14 +5,23 @@
 //  Created by 전여훈 on 2021/11/11.
 //
 
+import CoreLocation
 import Foundation
 
+import RxSwift
+
 class DefaultLocationRepository: LocationRepository {
-    func fetchUpdatedLocation() -> Observable<CLLocation> {
-        
+    let locationService: LocationService
+    
+    init(locationService: LocationService) {
+        self.locationService = locationService
     }
     
-    func fetchCurrentLocation() -> Observable<CLLocation> {
-        
+    func fetchUpdatedLocation() -> Observable<[CLLocation]> {
+        return self.locationService.observeUpdatedLocation()
+    }
+    
+    func fetchCurrentLocation() -> Observable<[CLLocation]> {
+        return Observable.just([CLLocation]())
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
@@ -1,0 +1,18 @@
+//
+//  DefaultLocationRepository.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/11.
+//
+
+import Foundation
+
+class DefaultLocationRepository: LocationRepository {
+    func fetchUpdatedLocation() -> Observable<CLLocation> {
+        
+    }
+    
+    func fetchCurrentLocation() -> Observable<CLLocation> {
+        
+    }
+}

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationRepository.swift
@@ -21,10 +21,6 @@ final class DefaultLocationRepository: LocationRepository {
         return self.locationService.observeUpdatedLocation()
     }
     
-    func fetchCurrentLocation() -> Observable<[CLLocation]> {
-        return self.locationService.fetchCurrentLocation()
-    }
-    
     func executeLocationService() {
         self.locationService.start()
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationService.swift
@@ -1,0 +1,64 @@
+//
+//  DefaultLocationService.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/13.
+//
+
+import CoreLocation
+import Foundation
+
+import RxRelay
+import RxSwift
+
+final class DefaultLocationService: NSObject, LocationService {
+    var locationManager: CLLocationManager?
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    override init() {
+        super.init()
+        self.locationManager = CLLocationManager()
+        self.locationManager?.delegate = self
+        self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
+    }
+    
+    func start() {
+        self.locationManager?.startUpdatingLocation()
+    }
+    
+    func stop() {
+        self.locationManager?.stopUpdatingLocation()
+    }
+    
+    func observeUpdatedLocation() -> Observable<[CLLocation]> {
+        return PublishRelay<[CLLocation]>.create({ emitter in
+            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
+                .compactMap({ $0.last as? [CLLocation] })
+                .subscribe(onNext: { location in
+                    emitter.onNext(location)
+                })
+                .disposed(by: self.disposeBag)
+            return Disposables.create()
+        })
+    }
+    
+    func fetchCurrentLocation() -> Observable<[CLLocation]> {
+        self.locationManager?.requestLocation()
+        return Observable<[CLLocation]>.create({ emitter in
+            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
+                .compactMap({ $0.last as? [CLLocation] })
+                .subscribe(onNext: { location in
+                    emitter.onNext(location)
+                    emitter.onCompleted()
+                })
+                .disposed(by: self.disposeBag)
+            return Disposables.create()
+        })
+    }
+}
+
+extension DefaultLocationService: CLLocationManagerDelegate {
+    func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]) {}
+}

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultLocationService.swift
@@ -41,20 +41,6 @@ final class DefaultLocationService: NSObject, LocationService {
             return Disposables.create()
         })
     }
-    
-    func fetchCurrentLocation() -> Observable<[CLLocation]> {
-        self.locationManager?.requestLocation()
-        return Observable<[CLLocation]>.create({ emitter in
-            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
-                .compactMap({ $0.last as? [CLLocation] })
-                .subscribe(onNext: { location in
-                    emitter.onNext(location)
-                    emitter.onCompleted()
-                })
-                .disposed(by: self.disposeBag)
-            return Disposables.create()
-        })
-    }
 }
 
 extension DefaultLocationService: CLLocationManagerDelegate {

--- a/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
@@ -1,0 +1,50 @@
+//
+//  LocationService.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/12.
+//
+
+import Foundation
+import CoreLocation
+
+import RxSwift
+import RxRelay
+
+class LocationService: NSObject, CLLocationManagerDelegate {
+    var locationManager: CLLocationManager?
+    var disposeBag: DisposeBag = DisposeBag()
+        
+    override init() {
+        super.init()
+        self.locationManager = CLLocationManager()
+        self.locationManager?.delegate = self
+        self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
+    }
+    
+    func start() {
+        self.locationManager?.startUpdatingLocation()
+    }
+    
+    func fetchUpdatedLocation() -> Observable<CLLocation> {
+        return PublishRelay<CLLocation>.create({ [weak self] emitter in
+            self?.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
+                .compactMap({ $0.first as? CLLocationManager })
+                .compactMap({ $0.location })
+                .subscribe(onNext: { location in
+                    emitter.onNext(location)
+                })
+                .disposed(by: self?.disposeBag ?? DisposeBag())
+            return Disposables.create()
+        })
+    }
+    
+    func stopUpdatingLocation() {
+        self.locationManager?.stopUpdatingLocation()
+        self.disposeBag = DisposeBag()
+    }
+    
+    func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]) {}
+}

--- a/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
@@ -8,57 +8,11 @@
 import CoreLocation
 import Foundation
 
-import RxRelay
 import RxSwift
 
-final class LocationService: NSObject {
-    var locationManager: CLLocationManager?
-    var disposeBag: DisposeBag = DisposeBag()
-    
-    override init() {
-        super.init()
-        self.locationManager = CLLocationManager()
-        self.locationManager?.delegate = self
-        self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
-    }
-    
-    func start() {
-        self.locationManager?.startUpdatingLocation()
-    }
-    
-    func stop() {
-        self.locationManager?.stopUpdatingLocation()
-    }
-    
-    func observeUpdatedLocation() -> Observable<[CLLocation]> {
-        return PublishRelay<[CLLocation]>.create({ emitter in
-            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
-                .compactMap({ $0.last as? [CLLocation] })
-                .subscribe(onNext: { location in
-                    emitter.onNext(location)
-                })
-                .disposed(by: self.disposeBag)
-            return Disposables.create()
-        })
-    }
-    
-    func fetchCurrentLocation() -> Observable<[CLLocation]> {
-        self.locationManager?.requestLocation()
-        return Observable<[CLLocation]>.create({ emitter in
-            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
-                .compactMap({ $0.last as? [CLLocation] })
-                .subscribe(onNext: { location in
-                    emitter.onNext(location)
-                    emitter.onCompleted()
-                })
-                .disposed(by: self.disposeBag)
-            return Disposables.create()
-        })
-    }
-}
-
-extension LocationService: CLLocationManagerDelegate {
-    func locationManager(
-        _ manager: CLLocationManager,
-        didUpdateLocations locations: [CLLocation]) {}
+protocol LocationService {
+    func start()
+    func stop()
+    func observeUpdatedLocation() -> Observable<[CLLocation]>
+    func fetchCurrentLocation() -> Observable<[CLLocation]>
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
@@ -27,6 +27,10 @@ class LocationService: NSObject, CLLocationManagerDelegate {
         self.locationManager?.startUpdatingLocation()
     }
     
+    func stop() {
+        self.locationManager?.stopUpdatingLocation()
+    }
+    
     func observeUpdatedLocation() -> Observable<[CLLocation]> {
         return PublishRelay<[CLLocation]>.create({ emitter in
             self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
@@ -37,10 +41,6 @@ class LocationService: NSObject, CLLocationManagerDelegate {
                 .disposed(by: self.disposeBag)
             return Disposables.create()
         })
-    }
-    
-    func stopUpdatingLocation() {
-        self.locationManager?.stopUpdatingLocation()
     }
     
     func locationManager(

--- a/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
@@ -11,10 +11,10 @@ import Foundation
 import RxRelay
 import RxSwift
 
-class LocationService: NSObject, CLLocationManagerDelegate {
+final class LocationService: NSObject {
     var locationManager: CLLocationManager?
     var disposeBag: DisposeBag = DisposeBag()
-        
+    
     override init() {
         super.init()
         self.locationManager = CLLocationManager()
@@ -55,12 +55,10 @@ class LocationService: NSObject, CLLocationManagerDelegate {
             return Disposables.create()
         })
     }
-    
+}
+
+extension LocationService: CLLocationManagerDelegate {
     func locationManager(
         _ manager: CLLocationManager,
         didUpdateLocations locations: [CLLocation]) {}
-    
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print(error)
-    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
@@ -5,11 +5,11 @@
 //  Created by 전여훈 on 2021/11/12.
 //
 
-import Foundation
 import CoreLocation
+import Foundation
 
-import RxSwift
 import RxRelay
+import RxSwift
 
 class LocationService: NSObject, CLLocationManagerDelegate {
     var locationManager: CLLocationManager?
@@ -20,28 +20,27 @@ class LocationService: NSObject, CLLocationManagerDelegate {
         self.locationManager = CLLocationManager()
         self.locationManager?.delegate = self
         self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
+        self.locationManager?.startUpdatingLocation()
     }
     
     func start() {
         self.locationManager?.startUpdatingLocation()
     }
     
-    func fetchUpdatedLocation() -> Observable<CLLocation> {
-        return PublishRelay<CLLocation>.create({ [weak self] emitter in
-            self?.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
-                .compactMap({ $0.first as? CLLocationManager })
-                .compactMap({ $0.location })
+    func observeUpdatedLocation() -> Observable<[CLLocation]> {
+        return PublishRelay<[CLLocation]>.create({ emitter in
+            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
+                .compactMap({ $0.last as? [CLLocation] })
                 .subscribe(onNext: { location in
                     emitter.onNext(location)
                 })
-                .disposed(by: self?.disposeBag ?? DisposeBag())
+                .disposed(by: self.disposeBag)
             return Disposables.create()
         })
     }
     
     func stopUpdatingLocation() {
         self.locationManager?.stopUpdatingLocation()
-        self.disposeBag = DisposeBag()
     }
     
     func locationManager(

--- a/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/LocationService.swift
@@ -14,5 +14,4 @@ protocol LocationService {
     func start()
     func stop()
     func observeUpdatedLocation() -> Observable<[CLLocation]>
-    func fetchCurrentLocation() -> Observable<[CLLocation]>
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
@@ -11,6 +11,8 @@ import Foundation
 import RxSwift
 
 protocol LocationRepository {
+    func executeLocationService()
+    func terminateLocationService()
     func fetchUpdatedLocation() -> Observable<[CLLocation]>
     func fetchCurrentLocation() -> Observable<[CLLocation]>
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
@@ -11,6 +11,6 @@ import Foundation
 import RxSwift
 
 protocol LocationRepository {
-    func fetchUpdatedLocation() -> Observable<CLLocation>
-    func fetchCurrentLocation() -> Observable<CLLocation>
+    func fetchUpdatedLocation() -> Observable<[CLLocation]>
+    func fetchCurrentLocation() -> Observable<[CLLocation]>
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
@@ -1,0 +1,16 @@
+//
+//  LocationRepository.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/11.
+//
+
+import CoreLocation
+import Foundation
+
+import RxSwift
+
+protocol LocationRepository {
+    func fetchUpdatedLocation() -> Observable<CLLocation>
+    func fetchCurrentLocation() -> Observable<CLLocation>
+}

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/LocationRepository.swift
@@ -14,5 +14,4 @@ protocol LocationRepository {
     func executeLocationService()
     func terminateLocationService()
     func fetchUpdatedLocation() -> Observable<[CLLocation]>
-    func fetchCurrentLocation() -> Observable<[CLLocation]>
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
@@ -13,12 +13,21 @@ import RxRelay
 
 class DefaultMapUseCase: MapUseCase {
     private let repository: LocationRepository
-    let updatedLocation: PublishRelay<CLLocation>
+    var updatedLocation: PublishRelay<CLLocation>
     var disposeBag: DisposeBag
     
-    init(repository: LocationRepository) {
+    required init(repository: LocationRepository) {
         self.repository = repository
+        self.updatedLocation = PublishRelay()
         self.disposeBag = DisposeBag()
+    }
+    
+    func executeLocationTracker() {
+        self.repository.executeLocationService()
+    }
+    
+    func terminateLocationTracker() {
+        self.repository.terminateLocationService()
     }
     
     func requestLocation() {

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  DefaultMapUseCase.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/12.
+//
+
+import CoreLocation
+import Foundation
+
+import RxSwift
+import RxRelay
+
+class DefaultMapUseCase: MapUseCase {
+    private let repository: LocationRepository
+    let updatedLocation: PublishRelay<CLLocation>
+    var disposeBag: DisposeBag
+    
+    init(repository: LocationRepository) {
+        self.repository = repository
+        self.disposeBag = DisposeBag()
+    }
+    
+    func requestLocation() {
+        self.repository.fetchUpdatedLocation()
+            .compactMap({ $0.last })
+            .bind(to: self.updatedLocation)
+            .disposed(by: self.disposeBag)
+    }
+}

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
@@ -8,8 +8,8 @@
 import CoreLocation
 import Foundation
 
-import RxSwift
 import RxRelay
+import RxSwift
 
 class DefaultMapUseCase: MapUseCase {
     private let repository: LocationRepository

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/MapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/MapUseCase.swift
@@ -1,0 +1,12 @@
+//
+//  MapUseCase.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/12.
+//
+
+import Foundation
+
+protocol MapUseCase {
+    
+}

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/MapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/MapUseCase.swift
@@ -5,8 +5,15 @@
 //  Created by 전여훈 on 2021/11/12.
 //
 
+import CoreLocation
 import Foundation
 
+import RxRelay
+
 protocol MapUseCase {
-    
+    var updatedLocation: PublishRelay<CLLocation> { get set }
+    init(repository: LocationRepository)
+    func executeLocationTracker()
+    func terminateLocationTracker()
+    func requestLocation()
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -59,6 +59,8 @@ final class DefaultRunningCoordinator: RunningCoordinator {
             coordinator: self,
             runningUseCase: DefaultRunningUseCase(runningSetting: settingData)
         )
+        singleRunningViewController.mapViewController = MapViewController()
+        singleRunningViewController.mapViewController?.viewModel = self.makeMapViewModel()
         self.navigationController.pushViewController(singleRunningViewController, animated: true)
     }
     
@@ -72,5 +74,15 @@ final class DefaultRunningCoordinator: RunningCoordinator {
         let raceRunningViewController = RaceRunningViewController()
         self.navigationController.pushViewController(raceRunningViewController, animated: true)
         // TODO: 뷰모델 생성 및 유즈케이스에 setting 값 주입 작성
+    }
+    
+    private func makeMapViewModel() -> MapViewModel {
+        func makeLocationRepository() -> LocationRepository {
+            return DefaultLocationRepository(locationService: DefaultLocationService())
+        }
+        func makeMapUseCase() -> MapUseCase {
+            return  DefaultMapUseCase(repository: makeLocationRepository())
+        }
+        return MapViewModel(mapUseCase: makeMapUseCase())
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -90,7 +90,7 @@ private extension MapViewController {
                 .asObservable(),
             locateButtonDidTapEvent: self.locateButton.rx.tap.asObservable(),
             backButtonDidTapEvent: self.backButton.rx.tap.asObservable(),
-            panGestureDidRecognizedEvent: self.mapView.rx.panGesture()
+            mapDidPanEvent: self.mapView.rx.panGesture()
                 .when(.recognized)
                 .map({ _ in })
                 .asObservable()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -5,7 +5,6 @@
 //  Created by 이정원 on 2021/11/06.
 //
 
-import CoreLocation
 import MapKit
 import UIKit
 
@@ -15,16 +14,8 @@ import SnapKit
 
 final class MapViewController: UIViewController {
     private var disposeBag = DisposeBag()
-    private var previousCoordinate: CLLocationCoordinate2D?
     private var shouldSetCenter = true
     weak var backButtonDelegate: BackButtonDelegate?
-    
-    private lazy var locationManager: CLLocationManager = {
-        let locationManager = CLLocationManager()
-        locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
-        return locationManager
-    }()
     
     private lazy var mapView: MKMapView = {
         let mapView = MKMapView()
@@ -45,32 +36,10 @@ final class MapViewController: UIViewController {
         super.viewDidLoad()
         self.configureUI()
         self.bindUI()
-        self.configureLocationManager()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        self.locationManager.stopUpdatingLocation()
-    }
-}
-
-// MARK: - CLLocationManagerDelegate
-
-extension MapViewController: CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let coordinate = locations.last?.coordinate else { return }
-        
-        if shouldSetCenter {
-            self.mapView.userTrackingMode = .follow
-        }
-        
-        if let previousCoordinate = self.previousCoordinate {
-            let coordinates = [previousCoordinate, coordinate]
-            let line = MKPolyline(coordinates: coordinates, count: coordinates.count)
-            self.mapView.addOverlay(line)
-        }
-        
-        self.previousCoordinate = coordinate
     }
 }
 
@@ -139,11 +108,7 @@ private extension MapViewController {
                 }).disposed(by: self.disposeBag)
         }
     }
-    
-    func configureLocationManager() {
-        self.locationManager.startUpdatingLocation()
-    }
-    
+
     func configureCurrentLocation() {
         let span = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
         let locationRegion = MKCoordinateRegion(center: self.mapView.userLocation.coordinate, span: span)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -86,12 +86,13 @@ private extension MapViewController {
     
     func bindViewModel() {
         let input = MapViewModel.Input(
-            viewDidAppearEvent: self.rx.methodInvoked(#selector(viewDidAppear(_:))).map({ _ in }) .asObservable(),
+            viewDidAppearEvent: self.rx.methodInvoked(#selector(viewDidAppear(_:)))
+                .map({ _ in })
+                .asObservable(),
             locateButtonDidTapEvent: self.locateButton.rx.tap.asObservable(),
             backButtonDidTapEvent: self.backButton.rx.tap.asObservable(),
             panGestureDidRecognizedEvent: self.mapView.rx.panGesture()
                 .when(.recognized)
-                .debug()
                 .map({ _ in })
                 .asObservable()
         )
@@ -99,9 +100,7 @@ private extension MapViewController {
         
         output.shouldSetCenter
             .asDriver(onErrorJustReturn: false)
-            .debug()
             .filter({ $0 == true })
-            .debug()
             .drive(onNext: { [weak self] _ in
                 self?.configureCenter()
             })

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -18,6 +18,8 @@ final class MapViewController: UIViewController {
     private var viewModel: MapViewModel?
     private var disposeBag = DisposeBag()
     
+    private lazy var locateButton = createCircleButton(imageName: "location")
+    private lazy var backButton = createCircleButton(imageName: "xmark")
     private lazy var mapView: MKMapView = {
         let mapView = MKMapView()
         mapView.delegate = self
@@ -27,9 +29,6 @@ final class MapViewController: UIViewController {
         mapView.addGestureRecognizer(UIPanGestureRecognizer())
         return mapView
     }()
-    
-    private lazy var locateButton = createCircleButton(imageName: "location")
-    private lazy var backButton = createCircleButton(imageName: "xmark")
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -15,7 +15,7 @@ import SnapKit
 
 final class MapViewController: UIViewController {
     weak var backButtonDelegate: BackButtonDelegate?
-    private var viewModel: MapViewModel?
+    var viewModel: MapViewModel?
     private var disposeBag = DisposeBag()
     
     private lazy var locateButton = createCircleButton(imageName: "location")
@@ -33,7 +33,6 @@ final class MapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
-        self.configureViewModel()
         self.bindViewModel()
     }
 }
@@ -53,17 +52,7 @@ extension MapViewController: MKMapViewDelegate {
 
 // MARK: - Private Functions
 
-private extension MapViewController {
-    func configureViewModel() {
-        func makeLocationRepository() -> LocationRepository {
-            return DefaultLocationRepository(locationService: DefaultLocationService())
-        }
-        func makeMapUseCase() -> MapUseCase {
-            return  DefaultMapUseCase(repository: makeLocationRepository())
-        }
-        self.viewModel = MapViewModel(mapUseCase: makeMapUseCase())
-    }
-    
+private extension MapViewController {    
     func configureUI() {
         self.view.addSubview(self.mapView)
         self.mapView.snp.makeConstraints { make in

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MapViewController.swift
@@ -56,7 +56,7 @@ extension MapViewController: MKMapViewDelegate {
 private extension MapViewController {
     func configureViewModel() {
         func makeLocationRepository() -> LocationRepository {
-            return DefaultLocationRepository(locationService: LocationService())
+            return DefaultLocationRepository(locationService: DefaultLocationService())
         }
         func makeMapUseCase() -> MapUseCase {
             return  DefaultMapUseCase(repository: makeLocationRepository())

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SingleRunningViewController.swift
@@ -13,6 +13,7 @@ import SnapKit
 
 class SingleRunningViewController: UIViewController {
     var viewModel: SingleRunningViewModel?
+    var mapViewController: MapViewController?
     private var disposeBag = DisposeBag()
     
     private lazy var scrollView: UIScrollView = {
@@ -34,7 +35,6 @@ class SingleRunningViewController: UIViewController {
     private lazy var calorieView = RunningInfoView(name: "칼로리", value: "128")
     private lazy var timeView = RunningInfoView(name: "시간", value: "24:50")
     private lazy var mapContainerView = UIView()
-    private lazy var mapViewController = MapViewController()
     private(set) lazy var distanceLabel = self.createDistanceLabel()
     private(set) lazy var progressView = self.createProgressView()
     private(set) lazy var distanceStackView = self.createDistanceStackView()
@@ -144,12 +144,13 @@ private extension SingleRunningViewController {
     }
     
     func configureMapContainerViewUI() {
+        guard let mapViewController = self.mapViewController else { return }
         self.contentStackView.addArrangedSubview(mapContainerView)
         
-        self.addChild(self.mapViewController)
-        self.mapViewController.view.frame = self.mapContainerView.frame
-        self.mapContainerView.addSubview(self.mapViewController.view)
-        self.mapViewController.backButtonDelegate = self
+        self.addChild(mapViewController)
+        mapViewController.view.frame = self.mapContainerView.frame
+        mapViewController.backButtonDelegate = self
+        self.mapContainerView.addSubview(mapViewController.view)
     }
     
     func configureRunningViewUI() {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
@@ -5,8 +5,62 @@
 //  Created by 전여훈 on 2021/11/12.
 //
 
+import CoreLocation
 import Foundation
 
+import RxSwift
+import RxRelay
+
 class MapViewModel {
+    let mapUseCase: MapUseCase
     
+    init(mapUseCase: MapUseCase) {
+        self.mapUseCase = mapUseCase
+    }
+    
+    struct Input {
+        let viewDidLoadEvent: Observable<Void>
+        let viewWillDisappearEvent: Observable<Void>
+        let locateButtonDidTapEvent: Observable<Void>
+        let backButtonDidTapEvent: Observable<Void>
+        let panGestureDidRecognizedEvent: Observable<Void>
+    }
+    
+    struct Output {
+        let shouldSetCenter: BehaviorRelay<Bool> = BehaviorRelay(value: true)
+        let shouldMoveToFirstPage: PublishRelay<Bool> = PublishRelay()
+        let updatedCoordinate: BehaviorRelay<CLLocation> = BehaviorRelay(value: CLLocation())
+    }
+    
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        input.backButtonDidTapEvent
+            .map({ true })
+            .bind(to: output.shouldMoveToFirstPage)
+            .disposed(by: disposeBag)
+        
+        input.locateButtonDidTapEvent
+            .map({ true })
+            .bind(to: output.shouldSetCenter)
+            .disposed(by: disposeBag)
+        
+        input.viewDidLoadEvent
+            .subscribe(onNext: { [weak self] _ in
+                self?.mapUseCase.executeLocationTracker()
+                self?.mapUseCase.requestLocation()
+            })
+            .disposed(by: disposeBag)
+        
+        input.panGestureDidRecognizedEvent
+            .map({ false })
+            .bind(to: output.shouldSetCenter)
+            .disposed(by: disposeBag)
+        
+        self.mapUseCase.updatedLocation
+            .bind(to: output.updatedCoordinate)
+            .disposed(by: disposeBag)
+        
+        
+        return output
+    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
@@ -18,7 +18,7 @@ final class MapViewModel {
         let viewDidAppearEvent: Observable<Void>
         let locateButtonDidTapEvent: Observable<Void>
         let backButtonDidTapEvent: Observable<Void>
-        let panGestureDidRecognizedEvent: Observable<Void>
+        let mapDidPanEvent: Observable<Void>
     }
     
     struct Output {
@@ -51,7 +51,7 @@ final class MapViewModel {
             })
             .disposed(by: disposeBag)
         
-        input.panGestureDidRecognizedEvent
+        input.mapDidPanEvent
             .map({ false })
             .bind(to: output.shouldSetCenter)
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  MapViewModel.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/12.
+//
+
+import Foundation
+
+class MapViewModel {
+    
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MapViewModel.swift
@@ -14,10 +14,6 @@ import RxSwift
 final class MapViewModel {
     let mapUseCase: MapUseCase
     
-    init(mapUseCase: MapUseCase) {
-        self.mapUseCase = mapUseCase
-    }
-    
     struct Input {
         let viewDidAppearEvent: Observable<Void>
         let locateButtonDidTapEvent: Observable<Void>
@@ -29,6 +25,10 @@ final class MapViewModel {
         let shouldSetCenter: BehaviorRelay<Bool> = BehaviorRelay(value: true)
         let shouldMoveToFirstPage: PublishRelay<Bool> = PublishRelay()
         let coordinatesToDraw: PublishRelay<(CLLocationCoordinate2D, CLLocationCoordinate2D)> = PublishRelay()
+    }
+    
+    init(mapUseCase: MapUseCase) {
+        self.mapUseCase = mapUseCase
     }
     
     func transform(input: Input, disposeBag: DisposeBag) -> Output {
@@ -55,7 +55,7 @@ final class MapViewModel {
             .map({ false })
             .bind(to: output.shouldSetCenter)
             .disposed(by: disposeBag)
-
+        
         Observable.zip(
             self.mapUseCase.updatedLocation.asObservable(),
             self.mapUseCase.updatedLocation.skip(1).asObservable()


### PR DESCRIPTION
### 📕 Issue Number

Close #54 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] LocationService 구현
- [x] LocationRepository 프로토콜, 구현체 구현
- [x] MapViewController에서 LocationService 분리 후 뷰모델-유즈케이스-레파지토리-서비스 로 연결


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 지도에 선을 그리는 과정 도식화
<img width="977" alt="스크린샷 2021-11-13 오후 6 28 04" src="https://user-images.githubusercontent.com/46087477/141613699-06d23751-ef97-4982-847b-5c8e2c2d4f90.png">

- 좌표값 저장
MapViewController가 뷰컨트롤러로 분리된 채로 RunningViewController의 스크롤뷰 페이지에 들어가 있습니다. 그래서 좌표를 값을 서비스로부터 받아와 저장하려면 Delegate로 RunningViewController의 유즈케이스로 넘겨주거나 MapViewUseCase에서 Persistent(아마도 코어데이터가 되어야겠죠..?)에 저장해두고 결과화면으로 넘어가기 직전에 코어데이터를 읽어서 결과 모델을 만들어주어야할 것 같습니다. 전자의 경우보다는 후자가 더 데이터의 흐름이 자연스러운 것 같긴해요. 어떻게 하면 좋을까요?

- MapViewController 의존성
MapViewController가 SingleRunningViewController내부에서 만들어지다보니 다른 화면들은 모두 코디네이터를 통해 의존성을 주입해주는데, MapViewController만 다른 뷰컨트롤러에서 의존성을 주입하게 되었습니다. 개인적으로는 일관성이 있지 않은 것 같은데 어떻게 하면 좋을까요..? 

- 디렉토리
제 브랜치에는 아직 Util/Service 디렉토리가 없어서 Repository 디렉토리 안에 넣어뒀습니다. 나중에 수정할게요!


<br/><br/>
