### PR TITLE
혼자 달리기 모드 좌표 저장 로직 구현

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */; };
 		B08D15C5273964880095AC00 /* SingleRunningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDAFD1527352372009BAEAA /* SingleRunningViewModel.swift */; };
 		B08D15C92739649A0095AC00 /* RunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB9A8127356AFF00533EF7 /* RunningUseCase.swift */; };
+		B0CB4D1C27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D1B27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift */; };
 		B0E72E0C272FCDEE009E5635 /* NotoSansKR-light.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F49272FCDA2005A3A5C /* NotoSansKR-light.otf */; };
 		B0E72E0D272FCDEE009E5635 /* NotoSansKR-regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F47272FCDA2005A3A5C /* NotoSansKR-regular.otf */; };
 		B0E72E0E272FCDEE009E5635 /* NotoSansKR-thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F4A272FCDA2005A3A5C /* NotoSansKR-thin.otf */; };
@@ -342,6 +343,7 @@
 		B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResult.swift; sourceTree = "<group>"; };
 		B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRunningResult.swift; sourceTree = "<group>"; };
 		B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleRunningViewController.swift; sourceTree = "<group>"; };
+		B0CB4D1B27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDidUpdateDelegate.swift; sourceTree = "<group>"; };
 		B0E72E14272FD2CC009E5635 /* DistanceSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceSettingViewModel.swift; sourceTree = "<group>"; };
 		B0F53284273A29EA005A3F11 /* TabBarPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPage.swift; sourceTree = "<group>"; };
 		B0F53288273A32E0005A3F11 /* CoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorType.swift; sourceTree = "<group>"; };
@@ -914,6 +916,7 @@
 				3D2C217F273A9A3400D00C68 /* TeamRunningUseCase.swift */,
 				3D2C2193273CBCE400D00C68 /* InvitationWaitingUseCase.swift */,
 				B00133C3273D949D004E0D1F /* MapUseCase.swift */,
+				B0CB4D1B27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1459,6 +1462,7 @@
 				B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */,
 				3DF4C86027355A3E00A4B229 /* Date+Formatter.swift in Sources */,
 				5E5FDD1A273FC9A6000F4666 /* DefaultSignUpCoordinator.swift in Sources */,
+				B0CB4D1C27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift in Sources */,
 				3D2C218E273BA07B00D00C68 /* DefaultInviteMateRepository.swift in Sources */,
 				3DF4C86C27376C9A00A4B229 /* RunningResultRepository.swift in Sources */,
 				3D2C2196273CE12600D00C68 /* Session.swift in Sources */,

--- a/MateRunner/MateRunner/Domain/Model/RunningData.swift
+++ b/MateRunner/MateRunner/Domain/Model/RunningData.swift
@@ -12,11 +12,11 @@ class RunningData {
     private(set) var calorie: Double
     
     var myElapsedDistance: Double {
-        myRunningRealTimeData.elapsedDistance
+        return self.myRunningRealTimeData.elapsedDistance
     }
     
     var myElapsedTime: Int {
-        myRunningRealTimeData.elapsedTime
+        return self.myRunningRealTimeData.elapsedTime
     }
     
     init() {
@@ -32,4 +32,12 @@ class RunningData {
 
 final class MateModeRunningData: RunningData {
     private(set) var mateRunningRealTimeData = RunningRealTimeData(elapsedDistance: 0, elapsedTime: 0)
+    
+    var mateElapsedDistance: Double {
+        return self.mateRunningRealTimeData.elapsedDistance
+    }
+    
+    var mateElapsedTime: Int {
+        return self.mateRunningRealTimeData.elapsedTime
+    }
 }

--- a/MateRunner/MateRunner/Domain/Model/RunningData.swift
+++ b/MateRunner/MateRunner/Domain/Model/RunningData.swift
@@ -8,10 +8,22 @@
 import Foundation
 
 class RunningData {
-    private(set) var myRunningRealTimeData = RunningRealTimeData(elapsedDistance: 0, elapsedTime: 0)
-    private(set) var calorie: Double = 0
+    private(set) var myRunningRealTimeData: RunningRealTimeData
+    private(set) var calorie: Double
     
-    init() {}
+    var myElapsedDistance: Double {
+        myRunningRealTimeData.elapsedDistance
+    }
+    
+    var myElapsedTime: Int {
+        myRunningRealTimeData.elapsedTime
+    }
+    
+    init() {
+        self.myRunningRealTimeData = RunningRealTimeData(elapsedDistance: 0, elapsedTime: 0)
+        self.calorie = 0
+    }
+    
     init(runningData: RunningRealTimeData, calorie: Double) {
         self.myRunningRealTimeData = runningData
         self.calorie = calorie

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
@@ -35,7 +35,6 @@ class DefaultMapUseCase: MapUseCase {
     func requestLocation() {
         self.repository.fetchUpdatedLocation()
             .compactMap({ $0.last })
-            .debounce(.seconds(3), scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
             .subscribe(onNext: { [weak self] location in
                 self?.updatedLocation.accept(location)
                 self?.delegate?.locationDidUpdate(location)

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultMapUseCase.swift
@@ -35,6 +35,7 @@ class DefaultMapUseCase: MapUseCase {
     func requestLocation() {
         self.repository.fetchUpdatedLocation()
             .compactMap({ $0.last })
+            .debounce(.seconds(3), scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
             .subscribe(onNext: { [weak self] location in
                 self?.updatedLocation.accept(location)
                 self?.delegate?.locationDidUpdate(location)
@@ -43,6 +44,3 @@ class DefaultMapUseCase: MapUseCase {
     }
 }
 
-protocol LocationDidUpdateDelegate: AnyObject {
-    func locationDidUpdate(_ location: CLLocation)
-}

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 이유진 on 2021/11/05.
 //
+
 import CoreLocation
 import Foundation
 

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultRunningUseCase.swift
@@ -174,7 +174,7 @@ final class DefaultRunningUseCase: RunningUseCase {
             userElapsedDistance: runningData.myElapsedDistance,
             userElapsedTime: runningData.myElapsedTime,
             calorie: runningData.calorie,
-            points: [],
+            points: self.points,
             emojis: [:],
             isCanceled: isCanceled
         )
@@ -187,6 +187,5 @@ extension DefaultRunningUseCase: LocationDidUpdateDelegate {
             latitude: location.coordinate.latitude,
             longitude: location.coordinate.longitude
         ))
-        print(self.points)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/LocationDidUpdateDelegate.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/LocationDidUpdateDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  LocationDidUpdateDelegate.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/15.
+//
+
+import CoreLocation
+import Foundation
+
+protocol LocationDidUpdateDelegate: AnyObject {
+    func locationDidUpdate(_ location: CLLocation)
+}

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/MapUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/MapUseCase.swift
@@ -12,7 +12,7 @@ import RxRelay
 
 protocol MapUseCase {
     var updatedLocation: PublishRelay<CLLocation> { get set }
-    init(repository: LocationRepository)
+    init(repository: LocationRepository, delegate: RunningUseCase)
     func executeLocationTracker()
     func terminateLocationTracker()
     func requestLocation()

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import RxSwift
 
-protocol RunningUseCase {
+protocol RunningUseCase: LocationDidUpdateDelegate {
     var runningSetting: RunningSetting { get set }
     var runningData: BehaviorSubject<RunningData> { get set }
     var finishRunning: BehaviorSubject<Bool> { get set }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -31,7 +31,6 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     
     func pushRunningResultViewController(with runningResult: RunningResult?) {
         guard let runningResult = runningResult else { return }
-        print(runningResult)
         runningResult.isCanceled
         ? self.pushCancelRunningResultViewController(with: runningResult)
         : self.pushRunningResultViewController(with: runningResult)

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -31,8 +31,10 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     
     func pushRunningResultViewController(with runningResult: RunningResult?) {
         guard let runningResult = runningResult else { return }
-        let runningResultViewController = RunningResultViewController()
-        self.navigationController.pushViewController(runningResultViewController, animated: true)
+        print(runningResult)
+        runningResult.isCanceled
+        ? self.pushCancelRunningResultViewController(with: runningResult)
+        : self.pushRunningResultViewController(with: runningResult)
     }
     
     func pushRaceRunningResultViewController(with runningResult: RunningResult?) {
@@ -55,12 +57,21 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     
     private func pushSingleRunningViewController(with settingData: RunningSetting) {
         let singleRunningViewController = SingleRunningViewController()
+        let runningUseCase = DefaultRunningUseCase(runningSetting: settingData)
         singleRunningViewController.viewModel = SingleRunningViewModel(
             coordinator: self,
-            runningUseCase: DefaultRunningUseCase(runningSetting: settingData)
+            runningUseCase: runningUseCase
         )
         singleRunningViewController.mapViewController = MapViewController()
-        singleRunningViewController.mapViewController?.viewModel = self.makeMapViewModel()
+        
+        let mapViewModel = MapViewModel(
+            mapUseCase: DefaultMapUseCase(
+                repository: DefaultLocationRepository(
+                    locationService: DefaultLocationService()
+                ), delegate: runningUseCase)
+        )
+        singleRunningViewController.mapViewController?.viewModel = mapViewModel
+        
         self.navigationController.pushViewController(singleRunningViewController, animated: true)
     }
     
@@ -74,15 +85,5 @@ final class DefaultRunningCoordinator: RunningCoordinator {
         let raceRunningViewController = RaceRunningViewController()
         self.navigationController.pushViewController(raceRunningViewController, animated: true)
         // TODO: 뷰모델 생성 및 유즈케이스에 setting 값 주입 작성
-    }
-    
-    private func makeMapViewModel() -> MapViewModel {
-        func makeLocationRepository() -> LocationRepository {
-            return DefaultLocationRepository(locationService: DefaultLocationService())
-        }
-        func makeMapUseCase() -> MapUseCase {
-            return  DefaultMapUseCase(repository: makeLocationRepository())
-        }
-        return MapViewModel(mapUseCase: makeMapUseCase())
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #111 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 작성


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 구현방식
MapUseCase에서 새로운 좌표정보를 받을 때 RunningUseCase의 delegate 구현체를 호출해서 좌표를 저장할 수 있게 했습니다. 이 때문에 RunningUseCase에 points:[Point] 프로퍼티를 추가했고 결과 모델을 만들 때 이 데이터를 그대로 넣어주는 방식으로 결과를 만들게 됩니다.

- Debounce의 문제점
만약 좌표를 저장하는 시간에 Debounce를 걸면 좌표에 대한 LocationService와 거리를 계산하는 CoreMotionService가 별개로 동작하기 때문에 좌표는 아직 debounce 가 값을 방출하기 전의 값을 가지는데 distance는 목표거리에 도달해서 끝 좌표를 제대로 가지지 못한 채로 달리기가 종료될 수 있는 문제가 있습니다. debounce로 시간을 정하기 보다는 소숫점 몇자리까지 절삭해서 같은 값이 들어올 때 무시하도록 하는게 더 좋을 것 같아요. 이 부분에 대해서는 논의가 필요한 것 같아서 따로 수정은 하지 않았습니다. 의견 말씀해주세요!

<br/><br/>
