### PR TITLE
이모지 컬렉션뷰 DataSource -> rx 및 메이트 화면 코디네이터 연결

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		AE6A6F562730E450005A3A5C /* UIView+ShadowEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F552730E450005A3A5C /* UIView+ShadowEffect.swift */; };
 		AE6A6F582730FAEB005A3A5C /* RunningModeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F572730FAEB005A3A5C /* RunningModeSettingViewModel.swift */; };
 		AE6A6F5A2732B940005A3A5C /* DefaultRunningSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F592732B940005A3A5C /* DefaultRunningSettingUseCase.swift */; };
+		AE77C1EF27429FC8005EDEE0 /* DefaultMateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */; };
+		AE77C1F32742A39F005EDEE0 /* MateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */; };
 		AEA8C559273D53360066E0E1 /* DefaultEmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */; };
 		AEA8C55C273D538A0066E0E1 /* EmojiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */; };
 		AEA8C55F273D6E690066E0E1 /* EmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */; };
@@ -288,13 +290,15 @@
 		AE6A6F46272FCDA2005A3A5C /* NotoSansKR-medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-medium.otf"; sourceTree = "<group>"; };
 		AE6A6F47272FCDA2005A3A5C /* NotoSansKR-regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-regular.otf"; sourceTree = "<group>"; };
 		AE6A6F48272FCDA2005A3A5C /* NotoSansKR-black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-black.otf"; sourceTree = "<group>"; };
-		AE6A6F49272FCDA2005A3A5C /* NotoSansKR-light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-light.otf"; sourceTree = "<group>"; };
+		AE6A6F49272FCDA2005A3A5C /* NotoSansKR-light.otf */ = {isa = PBXFileReference; lastKnownFileType = text; path = "NotoSansKR-light.otf"; sourceTree = "<group>"; };
 		AE6A6F4A272FCDA2005A3A5C /* NotoSansKR-thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-thin.otf"; sourceTree = "<group>"; };
 		AE6A6F4B272FCDA2005A3A5C /* NotoSansKR-bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-bold.otf"; sourceTree = "<group>"; };
 		AE6A6F522730423D005A3A5C /* RunningModeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningModeSettingViewController.swift; sourceTree = "<group>"; };
 		AE6A6F552730E450005A3A5C /* UIView+ShadowEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ShadowEffect.swift"; sourceTree = "<group>"; };
 		AE6A6F572730FAEB005A3A5C /* RunningModeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningModeSettingViewModel.swift; sourceTree = "<group>"; };
 		AE6A6F592732B940005A3A5C /* DefaultRunningSettingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningSettingUseCase.swift; sourceTree = "<group>"; };
+		AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateCoordinator.swift; sourceTree = "<group>"; };
+		AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateCoordinator.swift; sourceTree = "<group>"; };
 		AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEmojiUseCase.swift; sourceTree = "<group>"; };
 		AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiViewModel.swift; sourceTree = "<group>"; };
 		AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUseCase.swift; sourceTree = "<group>"; };
@@ -730,6 +734,7 @@
 		5EFABAE7272FB46300686D08 /* MateScene */ = {
 			isa = PBXGroup;
 			children = (
+				AE77C1ED27429B72005EDEE0 /*  Cooditnator */,
 				AE3D1489273A5D6A00D4A186 /* View */,
 				B0E72E12272FCEF3009E5635 /* ViewModel */,
 				5EFABAE8272FB46800686D08 /* ViewController */,
@@ -860,6 +865,23 @@
 				5EBDA079273BAAEC00FC9707 /* RaceResultView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		AE77C1ED27429B72005EDEE0 /*  Cooditnator */ = {
+			isa = PBXGroup;
+			children = (
+				AE77C1F02742A384005EDEE0 /* Protocol */,
+				AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */,
+			);
+			path = " Cooditnator";
+			sourceTree = "<group>";
+		};
+		AE77C1F02742A384005EDEE0 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		AEA8C557273D53080066E0E1 /* Common */ = {
@@ -1482,6 +1504,7 @@
 				AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */,
 				AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */,
 				5E32DC652731004D000E525B /* BehaviorRelayProperty.swift in Sources */,
+				AE77C1F32742A39F005EDEE0 /* MateCoordinator.swift in Sources */,
 				AECB9A8227356AFF00533EF7 /* RunningUseCase.swift in Sources */,
 				B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */,
 				5E7DEE7B273FA78F002E1374 /* DefaultLoginCoordinator.swift in Sources */,
@@ -1490,6 +1513,7 @@
 				AE6A6F532730423D005A3A5C /* RunningModeSettingViewController.swift in Sources */,
 				B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */,
 				5EBDA078273BA7ED00FC9707 /* RaceRunningResultViewController.swift in Sources */,
+				AE77C1EF27429FC8005EDEE0 /* DefaultMateCoordinator.swift in Sources */,
 				B00133C4273D949D004E0D1F /* MapUseCase.swift in Sources */,
 				3DFD08B627391AE300B46479 /* RunningRealTimeData.swift in Sources */,
 				5E171E61273251B4001C003B /* RunningResult.swift in Sources */,

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -74,6 +74,11 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
             homeCoordinator.finishDelegate = self
             self.childCoordinators.append(homeCoordinator)
             homeCoordinator.start()
+//        case .mate:
+//            let mateCoordinator = DefaultMateCoorditnator(tabNavigationController)
+//            mateCoordinator.finishDelegate = self
+//            self.childCoordinators.append(mateCoordinator)
+//            mateCoordinator.start()
         default:
             break
         }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -70,15 +70,17 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     private func startTabCoordinator(of page: TabBarPage, to tabNavigationController: UINavigationController) {
         switch page {
         case .home:
+            print("home")
             let homeCoordinator = DefaultHomeCoorditnator(tabNavigationController)
             homeCoordinator.finishDelegate = self
             self.childCoordinators.append(homeCoordinator)
             homeCoordinator.start()
-//        case .mate:
-//            let mateCoordinator = DefaultMateCoorditnator(tabNavigationController)
-//            mateCoordinator.finishDelegate = self
-//            self.childCoordinators.append(mateCoordinator)
-//            mateCoordinator.start()
+        case .mate:
+            print("mate")
+            let mateCoordinator = DefaultMateCoordinator(tabNavigationController)
+            mateCoordinator.finishDelegate = self
+            self.childCoordinators.append(mateCoordinator)
+            mateCoordinator.start()
         default:
             break
         }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -70,13 +70,11 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     private func startTabCoordinator(of page: TabBarPage, to tabNavigationController: UINavigationController) {
         switch page {
         case .home:
-            print("home")
             let homeCoordinator = DefaultHomeCoorditnator(tabNavigationController)
             homeCoordinator.finishDelegate = self
             self.childCoordinators.append(homeCoordinator)
             homeCoordinator.start()
         case .mate:
-            print("mate")
             let mateCoordinator = DefaultMateCoordinator(tabNavigationController)
             mateCoordinator.finishDelegate = self
             self.childCoordinators.append(mateCoordinator)

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
@@ -27,7 +27,6 @@ final class EmojiViewController: UIViewController {
         layout.minimumLineSpacing = 15
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.dataSource = self
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "default")
         return collectionView
     }()
@@ -58,6 +57,16 @@ private extension EmojiViewController {
             make.width.equalTo(250)
             make.height.equalTo(180)
         }
+        
+        self.viewModel.emojiObservable
+            .bind(to: self.collectionView.rx
+                    .items(cellIdentifier: "default", cellType: UICollectionViewCell.self)) { row, _, cell  in
+                let title = UILabel(frame: CGRect(x: 0, y: 0, width: cell.bounds.size.width, height: 40))
+                title.textAlignment = .center
+                title.text = Emoji.allCases[row].text()
+                cell.contentView.addSubview(title)
+            }
+                    .disposed(by: self.disposeBag)
     }
     
     func bindViewModel() {
@@ -65,35 +74,14 @@ private extension EmojiViewController {
             emojiCellTapEvent: self.collectionView.rx.itemSelected.asObservable()
         )
         
-        let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
+        let output = self.viewModel.transform(from: input, disposeBag: self.disposeBag)
         
-        output?.$selectedEmoji
+        output.$selectedEmoji
             .asDriver()
             .filter { $0 != nil }
             .drive(onNext: { [weak self] _ in
                 self?.dismiss(animated: true, completion: nil)
             })
             .disposed(by: self.disposeBag)
-    }
-}
-
-// MARK: - UICollectionViewDataSource
-
-extension EmojiViewController: UICollectionViewDataSource {
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "default", for: indexPath)
-        let title = UILabel(frame: CGRect(x: 0, y: 0, width: cell.bounds.size.width, height: 40))
-        title.textAlignment = .center
-        title.text = Emoji.allCases[indexPath.row].text()
-        cell.contentView.addSubview(title)
-        return cell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return Emoji.allCases.count
     }
 }

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
@@ -59,14 +59,17 @@ private extension EmojiViewController {
         }
         
         self.viewModel?.emojiObservable
-            .bind(to: self.collectionView.rx
-                    .items(cellIdentifier: "default", cellType: UICollectionViewCell.self)) { row, _, cell  in
+            .bind(
+                to: self.collectionView.rx.items(
+                    cellIdentifier: "default", cellType: UICollectionViewCell.self
+                )
+            ) { row, _, cell  in
                 let title = UILabel(frame: CGRect(x: 0, y: 0, width: cell.bounds.size.width, height: 40))
                 title.textAlignment = .center
                 title.text = Emoji.allCases[row].text()
                 cell.contentView.addSubview(title)
             }
-                    .disposed(by: self.disposeBag)
+            .disposed(by: self.disposeBag)
     }
     
     func bindViewModel() {

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
@@ -58,7 +58,7 @@ private extension EmojiViewController {
             make.height.equalTo(180)
         }
         
-        self.viewModel.emojiObservable
+        self.viewModel?.emojiObservable
             .bind(to: self.collectionView.rx
                     .items(cellIdentifier: "default", cellType: UICollectionViewCell.self)) { row, _, cell  in
                 let title = UILabel(frame: CGRect(x: 0, y: 0, width: cell.bounds.size.width, height: 40))
@@ -74,9 +74,9 @@ private extension EmojiViewController {
             emojiCellTapEvent: self.collectionView.rx.itemSelected.asObservable()
         )
         
-        let output = self.viewModel.transform(from: input, disposeBag: self.disposeBag)
+        let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         
-        output.$selectedEmoji
+        output?.$selectedEmoji
             .asDriver()
             .filter { $0 != nil }
             .drive(onNext: { [weak self] _ in

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
@@ -11,8 +11,9 @@ import RxSwift
 import RxCocoa
 
 final class EmojiViewModel {
+    let emojiObservable = Observable.of(Emoji.allCases)
     private let emojiUseCase: EmojiUseCase
-//    private weak var coordinator: RunningSettingCoordinator? //코디네이터는 이름이 어떨지 몰라서 일단 주석처리 해둡니다!
+    private weak var coordinator: RunningCoordinator?
     
     struct Input {
       let emojiCellTapEvent: Observable<IndexPath>
@@ -24,10 +25,10 @@ final class EmojiViewModel {
     }
     
     init(
-        //        coordinator: RunningSettingCoordinator,
-        emojiUseCase: EmojiUseCase
+        coordinator: RunningCoordinator,
+        emojiUseCase: DefaultEmojiUseCase
     ) {
-        //        self.coordinator = coordinator
+        self.coordinator = coordinator
         self.emojiUseCase = emojiUseCase
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/MateSettingViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxSwift
+
 final class MateSettingViewController: MateViewController {
     var viewModel: MateSettingViewModel?
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateSettingViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/MateSettingViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import RxSwift
+
 final class MateSettingViewModel {
     weak var coordinator: RunningSettingCoordinator?
     private let runningSettingUseCase: RunningSettingUseCase

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -1,0 +1,8 @@
+//
+//  DefaultMateCoordinator.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/15.
+//
+
+import Foundation

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -5,4 +5,32 @@
 //  Created by 이유진 on 2021/11/15.
 //
 
-import Foundation
+import UIKit
+
+final class DefaultMateCoordinator: MateCoordinator {
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var mateViewController: MateViewController
+    var childCoordinators: [Coordinator] = []
+    var type: CoordinatorType = .mate
+    
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+        self.mateViewController = MateViewController()
+    }
+    
+    func start() {
+        self.mateViewController.mateViewModel = MateViewModel(
+            coordinator: self,
+            mateUseCase: DefaultMateUseCase()
+        )
+        self.navigationController.pushViewController(self.mateViewController, animated: true)
+    }
+}
+
+extension DefaultMateCoordinator: CoordinatorFinishDelegate {
+    func coordinatorDidFinish(childCoordinator: Coordinator) {
+        self.childCoordinators = self.childCoordinators
+            .filter({ $0.type != childCoordinator.type })
+    }
+}

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -31,6 +31,6 @@ final class DefaultMateCoordinator: MateCoordinator {
 extension DefaultMateCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators
-            .filter({ $0.type != childCoordinator.type })
+            .filter { $0.type != childCoordinator.type }
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateCoordinator.swift
@@ -6,3 +6,6 @@
 //
 
 import Foundation
+
+protocol MateCoordinator: Coordinator {
+}

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateCoordinator.swift
@@ -1,0 +1,8 @@
+//
+//  MateCoordinator.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/15.
+//
+
+import Foundation

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 final class MateViewModel {
     weak var coordinator: MateCoordinator?
-    let mateUseCase: MateUseCase
+    private let mateUseCase: MateUseCase
     var mate: [String: String] = [:] // usecase에서 fetch 받고 순서맞춘 딕셔너리, 필터링 되는 것을 기준으로 잡을 원래의 딕셔너리
     var filteredMate: [String: String] = [:] // searchBar input으로 인해 필터링된 딕셔너리
     

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -16,6 +16,7 @@ final class MateViewModel {
     struct Input {
         let viewDidLoadEvent: Observable<Void>
         let searchBarEvent: Observable<String>
+        let mateCellTapEvent: Observable<IndexPath>
     }
     
     struct Output {
@@ -46,6 +47,14 @@ final class MateViewModel {
                 self?.filterText(from: text)
                 self?.sortMate(from: self?.filteredMate ?? [:])
                 output.filterData = true
+            })
+            .disposed(by: disposeBag)
+        
+        input.mateCellTapEvent
+            .subscribe(onNext: { [weak self] indexPath in
+                let mate = self?.mateNickname(at: indexPath.row)
+                print(mate)
+                // 화면 전환
             })
             .disposed(by: disposeBag)
         
@@ -81,5 +90,12 @@ private extension MateViewModel {
             tempDictionary[$0.0] = $0.1
         }
         self.filteredMate = tempDictionary
+    }
+    
+    func mateNickname(at index: Int) -> String {
+        let mateDictionary = self.filteredMate
+        let mateKey = Array(mateDictionary)[index]
+        let mateNickname = mateKey.value
+        return mateNickname
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -9,6 +9,8 @@ import Foundation
 import RxSwift
 
 final class MateViewModel {
+    weak var coordinator: MateCoordinator?
+    let mateUseCase: MateUseCase
     var mate: [String: String] = [:] // usecase에서 fetch 받고 순서맞춘 딕셔너리, 필터링 되는 것을 기준으로 잡을 원래의 딕셔너리
     var filteredMate: [String: String] = [:] // searchBar input으로 인해 필터링된 딕셔너리
     
@@ -22,9 +24,8 @@ final class MateViewModel {
         @BehaviorRelayProperty var filterData: Bool = false
     }
     
-    let mateUseCase: MateUseCase
-    
-    init(mateUseCase: MateUseCase) {
+    init(coordinator: MateCoordinator, mateUseCase: MateUseCase) {
+        self.coordinator = coordinator
         self.mateUseCase = mateUseCase
     }
     

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -4,7 +4,6 @@
 //
 //  Created by 이유진 on 2021/11/09.
 //
-
 import Foundation
 
 import RxSwift
@@ -16,7 +15,6 @@ final class MateViewModel {
     struct Input {
         let viewDidLoadEvent: Observable<Void>
         let searchBarEvent: Observable<String>
-        let mateCellTapEvent: Observable<IndexPath>
     }
     
     struct Output {
@@ -50,14 +48,6 @@ final class MateViewModel {
             })
             .disposed(by: disposeBag)
         
-        input.mateCellTapEvent
-            .subscribe(onNext: { [weak self] indexPath in
-                let mate = self?.mateNickname(at: indexPath.row)
-                print(mate)
-                // 화면 전환
-            })
-            .disposed(by: disposeBag)
-        
         self.mateUseCase.mate
             .subscribe(onNext: { [weak self] mate in
                 self?.mate = mate
@@ -72,7 +62,6 @@ final class MateViewModel {
 }
 
 // MARK: - Private Functions
-
 private extension MateViewModel {
     func filterText(from text: String) {
         self.filteredMate = self.mate.filter { _, value in // 초기 mate를 기준으로 filter
@@ -90,12 +79,5 @@ private extension MateViewModel {
             tempDictionary[$0.0] = $0.1
         }
         self.filteredMate = tempDictionary
-    }
-    
-    func mateNickname(at index: Int) -> String {
-        let mateDictionary = self.filteredMate
-        let mateKey = Array(mateDictionary)[index]
-        let mateNickname = mateKey.value
-        return mateNickname
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -4,7 +4,6 @@
 //
 //  Created by 이유진 on 2021/10/30.
 //
-
 import UIKit
 
 import RxSwift
@@ -27,7 +26,7 @@ class MateViewController: UIViewController {
     private lazy var mateSearchBar: UISearchBar = {
         let searchBar = UISearchBar()
         searchBar.placeholder = "닉네임을 입력해주세요."
-        searchBar.backgroundImage = UIImage()
+        searchBar.backgroundImage = UIImage() // searchBar Border 없애기 위해
         return searchBar
     }()
     
@@ -69,7 +68,6 @@ class MateViewController: UIViewController {
 }
 
 // MARK: - Private Functions
-
 private extension MateViewController {
     func configureUI() {
         self.configureNavigation()
@@ -89,8 +87,7 @@ private extension MateViewController {
     func bindViewModel() {
         let input = MateViewModel.Input(
             viewDidLoadEvent: Observable.just(()),
-            searchBarEvent: self.mateSearchBar.rx.text.orEmpty.asObservable(),
-            mateCellTapEvent: self.mateTableView.rx.itemSelected.asObservable()
+            searchBarEvent: self.mateSearchBar.rx.text.orEmpty.asObservable()
         )
         
         let output = self.mateViewModel.transform(from: input, disposeBag: self.disposeBag)
@@ -138,7 +135,6 @@ private extension MateViewController {
 }
 
 // MARK: - UITableViewDelegate
-
 extension MateViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return TableViewValue.tableViewCellHeight.value()
@@ -146,7 +142,6 @@ extension MateViewController: UITableViewDelegate {
 }
 
 // MARK: - UITableViewDataSource
-
 extension MateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return TableViewValue.tableViewHeaderHeight.value()
@@ -177,13 +172,13 @@ extension MateViewController: UITableViewDataSource {
         return cell
     }
     
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        tableView.deselectRow(at: indexPath, animated: true)
-//        // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
-//        // 친구 초대 - 닉네임 가지고 초대장 보내야함
-//        let mateDictionary = self.mateViewModel.filteredMate
-//        let mateKey = Array(mateDictionary)[indexPath.row]
-//        let mateNickname = mateKey.value
-//        self.moveToNext(mate: mateNickname)
-//    }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
+        // 친구 초대 - 닉네임 가지고 초대장 보내야함
+        let mateDictionary = self.mateViewModel.filteredMate
+        let mateKey = Array(mateDictionary)[indexPath.row]
+        let mateNickname = mateKey.value
+        self.moveToNext(mate: mateNickname)
+    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -27,7 +27,7 @@ class MateViewController: UIViewController {
     private lazy var mateSearchBar: UISearchBar = {
         let searchBar = UISearchBar()
         searchBar.placeholder = "닉네임을 입력해주세요."
-        searchBar.backgroundImage = UIImage() // searchBar Border 없애기 위해
+        searchBar.backgroundImage = UIImage()
         return searchBar
     }()
     
@@ -89,7 +89,8 @@ private extension MateViewController {
     func bindViewModel() {
         let input = MateViewModel.Input(
             viewDidLoadEvent: Observable.just(()),
-            searchBarEvent: self.mateSearchBar.rx.text.orEmpty.asObservable()
+            searchBarEvent: self.mateSearchBar.rx.text.orEmpty.asObservable(),
+            mateCellTapEvent: self.mateTableView.rx.itemSelected.asObservable()
         )
         
         let output = self.mateViewModel.transform(from: input, disposeBag: self.disposeBag)
@@ -176,13 +177,13 @@ extension MateViewController: UITableViewDataSource {
         return cell
     }
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
-        // 친구 초대 - 닉네임 가지고 초대장 보내야함
-        let mateDictionary = self.mateViewModel.filteredMate
-        let mateKey = Array(mateDictionary)[indexPath.row]
-        let mateNickname = mateKey.value
-        self.moveToNext(mate: mateNickname)
-    }
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        tableView.deselectRow(at: indexPath, animated: true)
+//        // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
+//        // 친구 초대 - 닉네임 가지고 초대장 보내야함
+//        let mateDictionary = self.mateViewModel.filteredMate
+//        let mateKey = Array(mateDictionary)[indexPath.row]
+//        let mateNickname = mateKey.value
+//        self.moveToNext(mate: mateNickname)
+//    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -18,9 +18,7 @@ enum TableViewValue: CGFloat {
 }
 
 class MateViewController: UIViewController {
-    let mateViewModel = MateViewModel(
-        mateUseCase: DefaultMateUseCase()
-    )
+    var mateViewModel: MateViewModel?
     private var disposeBag = DisposeBag()
     
     private lazy var mateSearchBar: UISearchBar = {
@@ -90,9 +88,9 @@ private extension MateViewController {
             searchBarEvent: self.mateSearchBar.rx.text.orEmpty.asObservable()
         )
         
-        let output = self.mateViewModel.transform(from: input, disposeBag: self.disposeBag)
+        let output = self.mateViewModel?.transform(from: input, disposeBag: self.disposeBag)
         
-        output.$loadData
+        output?.$loadData
             .asDriver()
             .filter { $0 == true }
             .drive(onNext: { [weak self] _ in
@@ -100,7 +98,7 @@ private extension MateViewController {
             })
             .disposed(by: self.disposeBag)
         
-        output.$filterData
+        output?.$filterData
             .asDriver()
             .filter { $0 == true }
             .drive(onNext: { [weak self] _ in
@@ -114,7 +112,7 @@ private extension MateViewController {
     }
     
     func checkMateCount() {
-        if self.mateViewModel.filteredMate.count == 0 {
+        if self.mateViewModel?.filteredMate.count == 0 {
             self.addEmptyView()
         } else {
             self.removeEmptyView()
@@ -150,14 +148,14 @@ extension MateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: MateHeaderView.identifier) as? MateHeaderView else { return UITableViewHeaderFooterView() }
-        header.updateUI(value: self.mateViewModel.filteredMate.count)
+        header.updateUI(value: self.mateViewModel?.filteredMate.count ?? 0)
         
         return header
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         self.checkMateCount()
-        return self.mateViewModel.filteredMate.count
+        return self.mateViewModel?.filteredMate.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -165,7 +163,7 @@ extension MateViewController: UITableViewDataSource {
             withIdentifier: MateTableViewCell.identifier,
             for: indexPath) as? MateTableViewCell else { return UITableViewCell() }
         
-        let mateDictionary = self.mateViewModel.filteredMate
+        let mateDictionary = self.mateViewModel?.filteredMate ?? [:]
         let mateKey = Array(mateDictionary)[indexPath.row]
         cell.updateUI(image: mateKey.key, name: mateKey.value)
         
@@ -176,7 +174,7 @@ extension MateViewController: UITableViewDataSource {
         tableView.deselectRow(at: indexPath, animated: true)
         // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
         // 친구 초대 - 닉네임 가지고 초대장 보내야함
-        let mateDictionary = self.mateViewModel.filteredMate
+        let mateDictionary = self.mateViewModel?.filteredMate ?? [:]
         let mateKey = Array(mateDictionary)[indexPath.row]
         let mateNickname = mateKey.value
         self.moveToNext(mate: mateNickname)

--- a/MateRunner/MateRunner/Util/Constant/CoordinatorType.swift
+++ b/MateRunner/MateRunner/Util/Constant/CoordinatorType.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum CoordinatorType {
-    case app, login, tab, home, setting, running, signUp
+    case app, login, tab, home, setting, running, signUp, mate
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #114 #100 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 이모지 모달 컬렉션 뷰 datasource -> rx로 변경
- [x] 메이트 화면 코디네이터 연결

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 뷰모델 상속
낮에도 간단하게 말씀드렸듯 바인딩하는 메서드를 오버라이딩 해보거나 뷰모델 안에서 호출되는 메서드 자체를 오버라이딩 하는 등 여러 시도를 해보았으나.. 부모의 것이(?) 호출이 됩니다,, 즉 무조건 친구프로필로 이동하는 문제가 발생하여서 결국에는 input,output 구조를 포기하고 원래 방식(didSelectRowAt)으로 돌아갔답니다 🥲 이 부분에 대해서 좀 더 알아보겠습니다!

<br/><br/>
