### PR TITLE
혼자달리기 뷰-데이터 바인딩

### DIFF
--- a/MateRunner/MateRunner/Domain/Model/RunningResult.swift
+++ b/MateRunner/MateRunner/Domain/Model/RunningResult.swift
@@ -20,6 +20,10 @@ class RunningResult {
         self.runningSetting = runningSetting
     }
     
+    var mode: RunningMode? { return self.runningSetting.mode }
+    var targetDistance: Double? { return self.runningSetting.targetDistance }
+    var dateTime: Date? { return self.runningSetting.dateTime }
+    
     init(
         runningSetting: RunningSetting,
         userElapsedDistance: Double,

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultResultUseCase.swift
@@ -10,9 +10,15 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningResultUseCase: RunningResultUseCase {
-    let runningResultRepository: RunningResultRepository = DefaultRunningResultRepository()
+    var runningResult: RunningResult
+    private let runningResultRepository: RunningResultRepository
     
-    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Bool> {
+    init(runningResultRepository: RunningResultRepository, runningResult: RunningResult) {
+        self.runningResultRepository = runningResultRepository
+        self.runningResult = runningResult
+    }
+    
+    func saveRunningResult() -> Observable<Bool> {
         return self.runningResultRepository.saveRunningResult(runningResult)
     }
  }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
@@ -10,5 +10,6 @@ import Foundation
 import RxSwift
 
 protocol RunningResultUseCase {
-    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Bool>
+    var runningResult: RunningResult { get set }
+    func saveRunningResult() -> Observable<Bool>
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -33,6 +33,7 @@ final class DefaultRunningCoordinator: RunningCoordinator {
         guard let runningResult = runningResult else { return }
         let singleRunningResultViewController = RunningResultViewController()
         singleRunningResultViewController.viewModel = RunningResultViewModel(
+            coordinator: self,
             runningResultUseCase: DefaultRunningResultUseCase(
                 runningResultRepository: DefaultRunningResultRepository(),
                 runningResult: runningResult

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -32,6 +32,12 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     func pushRunningResultViewController(with runningResult: RunningResult?) {
         guard let runningResult = runningResult else { return }
         let singleRunningResultViewController = RunningResultViewController()
+        singleRunningResultViewController.viewModel = RunningResultViewModel(
+            runningResultUseCase: DefaultRunningResultUseCase(
+                runningResultRepository: DefaultRunningResultRepository(),
+                runningResult: runningResult
+            )
+        )
         self.navigationController.pushViewController(singleRunningResultViewController, animated: true)
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -100,7 +100,6 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
     }
     
     func finish(with settingData: RunningSetting) {
-        self.finishDelegate?.coordinatorDidFinish(childCoordinator: self)
         self.settingFinishDelegate?.settingCoordinatorDidFinish(with: settingData)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
@@ -13,7 +13,7 @@ import RxCocoa
 import RxSwift
 
 class RunningResultViewController: UIViewController {
-    private let viewModel: RunningResultViewModel = RunningResultViewModel()
+    var viewModel: RunningResultViewModel?
     private let disposeBag = DisposeBag()
     
     private lazy var scrollView = UIScrollView()
@@ -246,12 +246,13 @@ private extension RunningResultViewController {
     }
     
     func bindViewModel() {
+        guard let viewModel = self.viewModel else { return }
         let input = RunningResultViewModel.Input(
             viewDidLoadEvent: Observable.just(()),
             closeButtonDidTapEvent: self.closeButton.rx.tap.asObservable()
         )
         
-        let output = self.viewModel.transform(input, disposeBag: self.disposeBag)
+        let output = viewModel.transform(input, disposeBag: self.disposeBag)
         
         output.dateTime
             .asDriver(onErrorJustReturn: "Error")

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
@@ -228,16 +228,12 @@ private extension RunningResultViewController {
         self.mapView.setRegion(locationRegion, animated: true)
     }
     
-    func popToRootViewController() {
-        self.navigationController?.popToRootViewController(animated: true)
-    }
-    
     func showAlert() {
         let message = "달리기 결과 저장 중 오류가 발생했습니다."
         
         let alert = UIAlertController(title: "오류 발생", message: message, preferredStyle: .alert)
         let cancel = UIAlertAction(title: "취소", style: .default, handler: { _ in
-            self.viewModel?.coordinator?.finish()
+            self.viewModel?.alertConfirmButtonDidTap()
         })
         alert.addAction(cancel)
         present(alert, animated: false, completion: nil)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
@@ -154,6 +154,7 @@ private extension RunningResultViewController {
     
     func configureScrollView() {
         self.view.addSubview(self.scrollView)
+        self.scrollView.showsVerticalScrollIndicator = false
         
         self.scrollView.snp.makeConstraints { make in
             make.left.right.bottom.equalToSuperview()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -10,7 +10,6 @@ import CoreLocation
 import RxRelay
 import RxSwift
 
-
 struct Region {
     private(set) var center: CLLocationCoordinate2D = CLLocationCoordinate2DMake(0, 0)
     private(set) var span: (Double, Double) = (0, 0)
@@ -18,6 +17,7 @@ struct Region {
 
 final class RunningResultViewModel {
     private let runningResultUseCase: RunningResultUseCase
+    weak var coordinator: RunningCoordinator?
     
     init(runningResultUseCase: RunningResultUseCase) {
         self.runningResultUseCase = runningResultUseCase
@@ -27,22 +27,68 @@ final class RunningResultViewModel {
         let viewDidLoadEvent: Observable<Void>
         let closeButtonDidTapEvent: Observable<Void>
     }
-
+    
     struct Output {
-        var dateTime: PublishRelay<String>
-        var korDateTime: PublishRelay<String>
-        var mode: PublishRelay<String>
-        var distance: PublishRelay<String>
-        var calorie: PublishRelay<String>
-        var time: PublishRelay<String>
-        var isClosable: PublishRelay<Bool>
-        @BehaviorRelayProperty var points: [CLLocationCoordinate2D] = []
-        @BehaviorRelayProperty var region: Region = Region()
+        var dateTime = BehaviorRelay<String>(value: "")
+        var dayOfWeekAndTime = BehaviorRelay<String>(value: "")
+        var mode = BehaviorRelay<String>(value: "")
+        var distance = BehaviorRelay<String>(value: "")
+        var calorie = BehaviorRelay<String>(value: "")
+        var time = BehaviorRelay<String>(value: "")
+        var points = BehaviorRelay<[CLLocationCoordinate2D]>(value: [])
+        var region = BehaviorRelay<Region>(value: Region())
+        var saveFailAlertShouldShow = PublishRelay<Bool>()
+    }
+    
+    func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
+        let runningResult = self.runningResultUseCase.runningResult
+        let output = Output()
+        
+        guard let dateTime = runningResult.dateTime,
+              let mode = runningResult.mode else { return Output() }
+        let coordinates = self.pointsToCoordinate2D(from: runningResult.points)
+        
+        input.viewDidLoadEvent.subscribe(onNext: { [weak self] _ in
+            guard let self = self else { return }
+            output.calorie.accept(String(Int(runningResult.calorie)))
+            output.dateTime.accept(dateTime.fullDateTimeString())
+            output.dayOfWeekAndTime.accept(dateTime.korDayOfTheWeekAndTimeString())
+            output.mode.accept(mode.title)
+            output.distance.accept(String(format: "%.2f", runningResult.userElapsedDistance))
+            output.time.accept(Date.secondsToTimeString(from: runningResult.userElapsedTime))
+            output.points.accept(coordinates)
+            output.region.accept(self.calculateRegion(from: coordinates))
+        })
+            .disposed(by: disposeBag)
+        
+        input.closeButtonDidTapEvent.subscribe(
+            onNext: { [weak self] _ in
+                self?.runningResultUseCase.saveRunningResult()
+                    .debug()
+                    .subscribe(
+                        onNext: { [weak self] isSaveSuccess in
+                            if isSaveSuccess { self?.coordinator?.finish() }
+                            else { output.saveFailAlertShouldShow.accept(true) }
+                        },
+                        onError: { _ in output.saveFailAlertShouldShow.accept(true) }
+                    )
+                    .disposed(by: disposeBag)
+            })
+            .disposed(by: disposeBag)
+        
+        return output
+    }
+    
+    private func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {
+        return points.map { CLLocationCoordinate2D(
+            latitude: $0.latitude,
+            longitude: $0.longitude
+        )}
     }
     
     private func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region {
         guard !points.isEmpty else { return Region() }
-
+        
         let latitudes = points.map { $0.latitude }
         let longitudes = points.map { $0.longitude }
         
@@ -50,7 +96,7 @@ final class RunningResultViewModel {
               let minLatitude = latitudes.min(),
               let maxLongitude = longitudes.max(),
               let minLongitude = longitudes.min() else { return Region() }
-
+        
         let meanLatitude = (maxLatitude + minLatitude) / 2
         let meanLongitude = (maxLongitude + minLongitude) / 2
         let coordinate = CLLocationCoordinate2DMake(meanLatitude, meanLongitude)
@@ -60,70 +106,5 @@ final class RunningResultViewModel {
         let span = (latitudeSpan, longitudeSpan)
         
         return Region(center: coordinate, span: span)
-    }
-    
-    func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output(
-            dateTime: PublishRelay<String>(),
-            korDateTime: PublishRelay<String>(),
-            mode: PublishRelay<String>(),
-            distance: PublishRelay<String>(),
-            calorie: PublishRelay<String>(),
-            time: PublishRelay<String>(),
-            isClosable: PublishRelay<Bool>()
-        )
-        
-        let result = input.viewDidLoadEvent.map { self.runningResult }
-        
-        result.map { $0.runningSetting.dateTime ?? Date() }
-        .map { $0.fullDateTimeString() }
-        .bind(to: output.dateTime)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.runningSetting.dateTime ?? Date() }
-        .map { $0.korDayOfTheWeekAndTimeString() }
-        .bind(to: output.korDateTime)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.runningSetting.mode ?? .single }
-        .map { $0.title }
-        .bind(to: output.mode)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.userElapsedDistance }
-        .map { String(format: "%.2f", $0) }
-        .bind(to: output.distance)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.calorie }
-        .map { "\(Int($0 ) )" }
-        .bind(to: output.calorie)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.userElapsedTime }
-        .map { Date.secondsToTimeString(from: $0) }
-        .bind(to: output.time)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.points }
-        .map { $0.map { CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude) } }
-        .bind(to: output.$points)
-        .disposed(by: disposeBag)
-        
-        result.map { $0.points }
-        .map { $0.map { CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude) } }
-        .map { self.calculateRegion(from: $0) }
-        .bind(to: output.$region)
-        .disposed(by: disposeBag)
-        
-        input.closeButtonDidTapEvent
-            .flatMapLatest { [weak self] _ in
-                self?.runningResultUseCase.saveRunningResult(self?.runningResult) ?? Observable.of(false)
-            }
-            .catchAndReturn(false)
-            .bind(to: output.isClosable)
-            .disposed(by: disposeBag)
-        
-        return output
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -19,7 +19,8 @@ final class RunningResultViewModel {
     private let runningResultUseCase: RunningResultUseCase
     weak var coordinator: RunningCoordinator?
     
-    init(runningResultUseCase: RunningResultUseCase) {
+    init(coordinator: RunningCoordinator, runningResultUseCase: RunningResultUseCase) {
+        self.coordinator = coordinator
         self.runningResultUseCase = runningResultUseCase
     }
     
@@ -64,19 +65,24 @@ final class RunningResultViewModel {
         input.closeButtonDidTapEvent.subscribe(
             onNext: { [weak self] _ in
                 self?.runningResultUseCase.saveRunningResult()
-                    .debug()
-                    .subscribe(
-                        onNext: { [weak self] isSaveSuccess in
-                            if isSaveSuccess { self?.coordinator?.finish() }
-                            else { output.saveFailAlertShouldShow.accept(true) }
-                        },
-                        onError: { _ in output.saveFailAlertShouldShow.accept(true) }
-                    )
+                    .subscribe(onNext: { [weak self] isSaveSuccess in
+                        if isSaveSuccess {
+                            self?.coordinator?.finish()
+                        } else {
+                            output.saveFailAlertShouldShow.accept(true)
+                        }
+                    }, onError: { _ in
+                        output.saveFailAlertShouldShow.accept(true)
+                    })
                     .disposed(by: disposeBag)
             })
             .disposed(by: disposeBag)
         
         return output
+    }
+    
+    func alertConfirmButtonDidTap() {
+        self.coordinator?.finish()
     }
     
     private func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -7,30 +7,9 @@
 
 import CoreLocation
 
-import RxSwift
 import RxRelay
+import RxSwift
 
-let mockResult = RunningResult(
-    runningSetting:
-        RunningSetting(
-        mode: .single,
-        targetDistance: 5.0,
-        mateNickname: nil,
-        dateTime: Date()
-        ),
-    userElapsedDistance: 5.0,
-    userElapsedTime: 1200,
-    calorie: 200,
-    points: [
-        Point(latitude: 37.785834, longitude: -122.406417),
-        Point(latitude: 37.785855, longitude: -122.406466),
-        Point(latitude: 37.785777, longitude: -122.405000),
-        Point(latitude: 37.785111, longitude: -122.406411),
-        Point(latitude: 37.785700, longitude: -122.405022)
-    ],
-    emojis: [:],
-    isCanceled: false
-)
 
 struct Region {
     private(set) var center: CLLocationCoordinate2D = CLLocationCoordinate2DMake(0, 0)
@@ -38,13 +17,11 @@ struct Region {
 }
 
 final class RunningResultViewModel {
-    let runningResultUseCase: RunningResultUseCase = DefaultRunningResultUseCase()
-
-    private var runningResult = mockResult
+    private let runningResultUseCase: RunningResultUseCase
     
-//    init(runningResult: RunningResult) {
-//        self.runningResult = runningResult
-//    }
+    init(runningResultUseCase: RunningResultUseCase) {
+        self.runningResultUseCase = runningResultUseCase
+    }
     
     struct Input {
         let viewDidLoadEvent: Observable<Void>

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -55,7 +55,7 @@ final class RunningResultViewModel {
             output.dateTime.accept(dateTime.fullDateTimeString())
             output.dayOfWeekAndTime.accept(dateTime.korDayOfTheWeekAndTimeString())
             output.mode.accept(mode.title)
-            output.distance.accept(String(format: "%.2f", runningResult.userElapsedDistance))
+            output.distance.accept(self.convertToKilometerText(from: runningResult.userElapsedDistance))
             output.time.accept(Date.secondsToTimeString(from: runningResult.userElapsedTime))
             output.points.accept(coordinates)
             output.region.accept(self.calculateRegion(from: coordinates))
@@ -83,6 +83,10 @@ final class RunningResultViewModel {
     
     func alertConfirmButtonDidTap() {
         self.coordinator?.finish()
+    }
+    
+    private func convertToKilometerText(from value: Double) -> String {
+        return String(format: "%.2f", round(value / 10) / 100)
     }
     
     private func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {


### PR DESCRIPTION
### 📕 Issue Number

Close #121 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 유즈케이스, 뷰모델, 결과데이터 외부 주입 
- [x] 뷰모델 정의
- [x] 데이터 바인딩


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

![IMG_C54B9275A063-1](https://user-images.githubusercontent.com/46087477/141993331-d98fdccb-dba5-47c1-ac6e-ec9c39e57a44.jpeg)

- 조금 다른 뷰모델 구현
다른 파일들과 다르게 뷰모델 구현이 조금 다른데요, RunningResult 데이터는 한번 주입된 이후로 바뀌지 않는 데이터라서 어떻게 input/output으로 정리할지 고민을 하다가 BehaviourRelay로 ouput 프로퍼티들을 정의하고 viewdidload단계에서 유즈케이스의 데이터를 읽어 방출해주는 방식으로 구현했습니다.

    ```swift
    input.viewDidLoadEvent.subscribe(onNext: { [weak self] _ in
                guard let self = self else { return }
                output.calorie.accept(String(Int(runningResult.calorie)))
                output.dateTime.accept(dateTime.fullDateTimeString())
                output.dayOfWeekAndTime.accept(dateTime.korDayOfTheWeekAndTimeString())
                output.mode.accept(mode.title)
                output.distance.accept(self.convertToKilometerText(from: runningResult.userElapsedDistance))
                output.time.accept(Date.secondsToTimeString(from: runningResult.userElapsedTime))
                output.points.accept(coordinates)
                output.region.accept(self.calculateRegion(from: coordinates))
            })
                .disposed(by: disposeBag)
    ```
    
    Ouput의 타입은 
    
    ```swift
            var dateTime = BehaviorRelay<String>(value: "")
            var dayOfWeekAndTime = BehaviorRelay<String>(value: "")
            var mode = BehaviorRelay<String>(value: "")
            var distance = BehaviorRelay<String>(value: "")
            var calorie = BehaviorRelay<String>(value: "")
            var time = BehaviorRelay<String>(value: "")
            var points = BehaviorRelay<[CLLocationCoordinate2D]>(value: [])
            var region = BehaviorRelay<Region>(value: Region())
            var saveFailAlertShouldShow = PublishRelay<Bool>()
    ```
    
    이렇게 되어있는데 PublishRelay를 사용하게 되면 transform 과정에서 방출되는 runningResult의 값이 이미 방출된 이후에 뷰 컨트롤러가 output을 받아 subscribe하기 때문에 값을 전달받을 수 없어서 subscribe 시점에 마지막 값을 구독자에게 방출하는 BehaviorRelay로 정의했습니다. 그래서 초기값이 무조건 필요해 일단 빈 값들을 넣어주었어요.

- 파이어베이스 저장 
파이어베이스 구조가 달라진 부분은 아직 수정을 안했는데 다른분들 firebase repository/service 구성하시는 것을 보고 만들겠습니다.

- 저장에 실패했을 때
저장에 실패했을 때 지금은 무조건 rootViewController로 가게 되어있는데요, 사용자가 다시 저장을 시도할 기회를 주거나, 코어데이터에 저장되었고 나중에 네트워크가 연결되면 서버와 동기화된다는 안내가 필요할 것 같아요. 사용자 입장에서는 열심히 뛰었는데 데이터가 날라가 버리면 많이 당황스러울 것 같습니다..!
 
<br/><br/>
