### PR TITLE
친구 목록관련 UseCase, Service, Repository

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -29,9 +29,9 @@
 		3DF4C86027355A3E00A4B229 /* Date+Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C85F27355A3E00A4B229 /* Date+Formatter.swift */; };
 		3DF4C8622735841B00A4B229 /* RunningResultUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C8612735841A00A4B229 /* RunningResultUseCase.swift */; };
 		3DF4C8662737687900A4B229 /* DefaultRunningResultRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C8652737687900A4B229 /* DefaultRunningResultRepository.swift */; };
-		3DF4C86927376B7B00A4B229 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86827376B7B00A4B229 /* NetworkService.swift */; };
+		3DF4C86927376B7B00A4B229 /* FireStoreNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86827376B7B00A4B229 /* FireStoreNetworkService.swift */; };
 		3DF4C86C27376C9A00A4B229 /* RunningResultRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86B27376C9A00A4B229 /* RunningResultRepository.swift */; };
-		3DF4C86F27376CDA00A4B229 /* FIreStoreNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86E27376CDA00A4B229 /* FIreStoreNetworkService.swift */; };
+		3DF4C86F27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86E27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift */; };
 		3DF6D07E27301F1100991DC3 /* RunningResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */; };
 		3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08A72733A39300B46479 /* RunningResultDTO+Mapping.swift */; };
 		3DFD08B627391AE300B46479 /* RunningRealTimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08B527391AE300B46479 /* RunningRealTimeData.swift */; };
@@ -228,9 +228,9 @@
 		3DF4C85F27355A3E00A4B229 /* Date+Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatter.swift"; sourceTree = "<group>"; };
 		3DF4C8612735841A00A4B229 /* RunningResultUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultUseCase.swift; sourceTree = "<group>"; };
 		3DF4C8652737687900A4B229 /* DefaultRunningResultRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningResultRepository.swift; sourceTree = "<group>"; };
-		3DF4C86827376B7B00A4B229 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		3DF4C86827376B7B00A4B229 /* FireStoreNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireStoreNetworkService.swift; sourceTree = "<group>"; };
 		3DF4C86B27376C9A00A4B229 /* RunningResultRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultRepository.swift; sourceTree = "<group>"; };
-		3DF4C86E27376CDA00A4B229 /* FIreStoreNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FIreStoreNetworkService.swift; sourceTree = "<group>"; };
+		3DF4C86E27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFireStoreNetworkService.swift; sourceTree = "<group>"; };
 		3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultViewController.swift; sourceTree = "<group>"; };
 		3DFD08A72733A39300B46479 /* RunningResultDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RunningResultDTO+Mapping.swift"; sourceTree = "<group>"; };
 		3DFD08B527391AE300B46479 /* RunningRealTimeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRealTimeData.swift; sourceTree = "<group>"; };
@@ -443,7 +443,7 @@
 			isa = PBXGroup;
 			children = (
 				3DF4C86D27376CC000A4B229 /* Protocol */,
-				3DF4C86E27376CDA00A4B229 /* FIreStoreNetworkService.swift */,
+				3DF4C86E27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -461,7 +461,7 @@
 		3DF4C86D27376CC000A4B229 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
-				3DF4C86827376B7B00A4B229 /* NetworkService.swift */,
+				3DF4C86827376B7B00A4B229 /* FireStoreNetworkService.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1524,7 +1524,7 @@
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
 				5EBDA07C273BC67D00FC9707 /* CancelRunningResultViewController.swift in Sources */,
 				B00133C6273D94B3004E0D1F /* DefaultMapUseCase.swift in Sources */,
-				3DF4C86927376B7B00A4B229 /* NetworkService.swift in Sources */,
+				3DF4C86927376B7B00A4B229 /* FireStoreNetworkService.swift in Sources */,
 				3DF4C859273104B500A4B229 /* RunningResultViewModel.swift in Sources */,
 				B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */,
 				3DF4C8662737687900A4B229 /* DefaultRunningResultRepository.swift in Sources */,
@@ -1581,7 +1581,7 @@
 				5E6F3826273A0F52009686DC /* TeamRunningViewController.swift in Sources */,
 				5E6F382C273A50B3009686DC /* RunningCardView.swift in Sources */,
 				5E7F1F712733A59C00F2B662 /* RunningProgressView.swift in Sources */,
-				3DF4C86F27376CDA00A4B229 /* FIreStoreNetworkService.swift in Sources */,
+				3DF4C86F27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift in Sources */,
 				AE3D149D273BD67A00D4A186 /* InvitationView.swift in Sources */,
 				AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */,
 				AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		AE6A6F5A2732B940005A3A5C /* DefaultRunningSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6A6F592732B940005A3A5C /* DefaultRunningSettingUseCase.swift */; };
 		AE77C1EF27429FC8005EDEE0 /* DefaultMateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */; };
 		AE77C1F32742A39F005EDEE0 /* MateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */; };
+		AE77C1FB2743DD59005EDEE0 /* DefaultMateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1FA2743DD59005EDEE0 /* DefaultMateRepository.swift */; };
 		AEA8C559273D53360066E0E1 /* DefaultEmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */; };
 		AEA8C55C273D538A0066E0E1 /* EmojiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */; };
 		AEA8C55F273D6E690066E0E1 /* EmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */; };
@@ -311,6 +312,7 @@
 		AE6A6F592732B940005A3A5C /* DefaultRunningSettingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningSettingUseCase.swift; sourceTree = "<group>"; };
 		AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateCoordinator.swift; sourceTree = "<group>"; };
 		AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateCoordinator.swift; sourceTree = "<group>"; };
+		AE77C1FA2743DD59005EDEE0 /* DefaultMateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateRepository.swift; sourceTree = "<group>"; };
 		AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEmojiUseCase.swift; sourceTree = "<group>"; };
 		AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiViewModel.swift; sourceTree = "<group>"; };
 		AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUseCase.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 		3DF4C8632737684000A4B229 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				AE77C1F82743DD2C005EDEE0 /* Mate */,
 				3DF4C8642737686200A4B229 /* Home */,
 			);
 			path = Repository;
@@ -922,6 +925,22 @@
 			isa = PBXGroup;
 			children = (
 				AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		AE77C1F82743DD2C005EDEE0 /* Mate */ = {
+			isa = PBXGroup;
+			children = (
+				AE77C1F92743DD37005EDEE0 /* Protocol */,
+				AE77C1FA2743DD59005EDEE0 /* DefaultMateRepository.swift */,
+			);
+			path = Mate;
+			sourceTree = "<group>";
+		};
+		AE77C1F92743DD37005EDEE0 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1617,6 +1636,7 @@
 				B0F53289273A32E0005A3F11 /* CoordinatorType.swift in Sources */,
 				B0628B94273A1752004FAB0F /* Coordinator.swift in Sources */,
 				5E5FDD1E273FCC24000F4666 /* SignUpViewController.swift in Sources */,
+				AE77C1FB2743DD59005EDEE0 /* DefaultMateRepository.swift in Sources */,
 				AE6A6F37272FC723005A3A5C /* UIFont+CustomFont.swift in Sources */,
 				B00133BC273D63BC004E0D1F /* LocationRepository.swift in Sources */,
 				AE6A6F5A2732B940005A3A5C /* DefaultRunningSettingUseCase.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		AE77C1EF27429FC8005EDEE0 /* DefaultMateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */; };
 		AE77C1F32742A39F005EDEE0 /* MateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */; };
 		AE77C1FB2743DD59005EDEE0 /* DefaultMateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1FA2743DD59005EDEE0 /* DefaultMateRepository.swift */; };
+		AE77C1FD274400AE005EDEE0 /* MateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE77C1FC274400AE005EDEE0 /* MateRepository.swift */; };
 		AEA8C559273D53360066E0E1 /* DefaultEmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */; };
 		AEA8C55C273D538A0066E0E1 /* EmojiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */; };
 		AEA8C55F273D6E690066E0E1 /* EmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */; };
@@ -313,6 +314,7 @@
 		AE77C1EE27429FC8005EDEE0 /* DefaultMateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateCoordinator.swift; sourceTree = "<group>"; };
 		AE77C1F22742A39F005EDEE0 /* MateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateCoordinator.swift; sourceTree = "<group>"; };
 		AE77C1FA2743DD59005EDEE0 /* DefaultMateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultMateRepository.swift; sourceTree = "<group>"; };
+		AE77C1FC274400AE005EDEE0 /* MateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRepository.swift; sourceTree = "<group>"; };
 		AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEmojiUseCase.swift; sourceTree = "<group>"; };
 		AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiViewModel.swift; sourceTree = "<group>"; };
 		AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUseCase.swift; sourceTree = "<group>"; };
@@ -941,6 +943,7 @@
 		AE77C1F92743DD37005EDEE0 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				AE77C1FC274400AE005EDEE0 /* MateRepository.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1603,6 +1606,7 @@
 				B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */,
 				5E32DC6827314764000E525B /* RoundedButton.swift in Sources */,
 				AE3D14852737C5E600D4A186 /* Mets.swift in Sources */,
+				AE77C1FD274400AE005EDEE0 /* MateRepository.swift in Sources */,
 				5EBDA072273B629800FC9707 /* MyResultView.swift in Sources */,
 				B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */,
 				AE3D1492273A5F5900D4A186 /* MateTableViewCell.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningResultRepository: RunningResultRepository {
-    let networkService = FireStoreNetworkService()
+    let networkService = DefaultFireStoreNetworkService()
     
     func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Bool> {
         guard let runningResult = runningResult else { return Observable.of(false) }

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -1,0 +1,23 @@
+//
+//  DefaultMateRepository.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/16.
+//
+
+import Foundation
+
+import RxSwift
+
+final class DefaultMateRepository {
+    let networkService = FireStoreNetworkService()
+    
+//    init(networkService: NetworkService) {
+//        self.networkService = networkService
+//    }
+    
+    func fetchMateNickname() {
+//        return self.locationService.observeUpdatedLocation()
+        self.networkService.fetchMate(collection: "User", document: "yujin")
+    }
+}

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -9,12 +9,12 @@ import Foundation
 
 import RxSwift
 
-final class DefaultMateRepository {
-    let networkService = FireStoreNetworkService()
+final class DefaultMateRepository: MateRepository {
+    let networkService: NetworkService
     
-//    init(networkService: NetworkService) {
-//        self.networkService = networkService
-//    }
+    init(networkService: NetworkService) {
+        self.networkService = networkService
+    }
     
     func fetchMateNickname() -> Observable<[String]> {
         return self.networkService.fetchData(
@@ -22,6 +22,15 @@ final class DefaultMateRepository {
             collection: "User",
             document: "yujin",
             field: "mate"
+        )
+    }
+    
+    func fetchMateProfileImage(from nickname: String) -> Observable<String> {
+        return self.networkService.fetchData(
+            type: String.self,
+            collection: "User",
+            document: nickname,
+            field: "image"
         )
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -10,9 +10,9 @@ import Foundation
 import RxSwift
 
 final class DefaultMateRepository: MateRepository {
-    let networkService: NetworkService
+    let networkService: FireStoreNetworkService
     
-    init(networkService: NetworkService) {
+    init(networkService: FireStoreNetworkService) {
         self.networkService = networkService
     }
     

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -16,8 +16,7 @@ final class DefaultMateRepository {
 //        self.networkService = networkService
 //    }
     
-    func fetchMateNickname() {
-//        return self.locationService.observeUpdatedLocation()
-        self.networkService.fetchMate(collection: "User", document: "yujin")
+    func fetchMateNickname() -> Observable<[String]> {
+        return self.networkService.fetchMate(collection: "User", document: "yujin")
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -17,6 +17,11 @@ final class DefaultMateRepository {
 //    }
     
     func fetchMateNickname() -> Observable<[String]> {
-        return self.networkService.fetchMate(collection: "User", document: "yujin")
+        return self.networkService.fetchData(
+            type: [String].self,
+            collection: "User",
+            document: "yujin",
+            field: "mate"
+        )
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
@@ -1,0 +1,15 @@
+//
+//  MateRepository.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/17.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol MateRepository {
+    func fetchMateNickname() -> Observable<[String]>
+    func fetchMateProfileImage(from nickname: String) -> Observable<String>
+}

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -11,11 +11,17 @@ import RxSwift
 
 final class DefaultMateUseCase: MateUseCase {
     let repository = DefaultMateRepository()
+    private let disposeBag = DisposeBag()
+    
+    var mateNickname: PublishSubject<[String]> = PublishSubject()
     var mate: BehaviorSubject<[String: String]> = BehaviorSubject(value: [:])
     
     func fetchMateInfo() {
-        // 파베에서 받고 순서맞춰주는 작업
-        self.mate.onNext(["2": "hunihun956", "1": "jungwon"])
         self.repository.fetchMateNickname()
+            .subscribe(onNext: { mate in
+                print(mate)
+                self.mateNickname.onNext(mate)
+            })
+            .disposed(by: self.disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -10,10 +10,12 @@ import Foundation
 import RxSwift
 
 final class DefaultMateUseCase: MateUseCase {
+    let repository = DefaultMateRepository()
     var mate: BehaviorSubject<[String: String]> = BehaviorSubject(value: [:])
     
     func fetchMateInfo() {
         // 파베에서 받고 순서맞춰주는 작업
         self.mate.onNext(["2": "hunihun956", "1": "jungwon"])
+        self.repository.fetchMateNickname()
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -12,7 +12,6 @@ import RxSwift
 final class DefaultMateUseCase: MateUseCase {
     private let repository: MateRepository
     private let disposeBag = DisposeBag()
-    private var mateList: [String: String] = [:]
     var mate: PublishSubject<[String: String]> = PublishSubject()
     
     init(repository: MateRepository) {
@@ -28,14 +27,15 @@ final class DefaultMateUseCase: MateUseCase {
     }
     
     func fetchMateImage(mate: [String]) {
+        var mateList: [String: String] = [:]
         Observable.zip( mate.map { nickname in
             self.repository.fetchMateProfileImage(from: nickname)
-                .map({ [weak self] url in
-                    self?.mateList[url] = nickname
+                .map({ url in
+                    mateList[nickname] = url
                 })
         })
             .subscribe { [weak self] _ in
-                self?.mate.onNext(self?.mateList ?? [:])
+                self?.mate.onNext(mateList)
             }
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -21,8 +21,8 @@ final class DefaultMateUseCase: MateUseCase {
     
     func fetchMateInfo() {
         self.repository.fetchMateNickname()
-            .subscribe(onNext: { mate in
-                self.fetchMateImage(mate: mate)
+            .subscribe(onNext: { [weak self] mate in
+                self?.fetchMateImage(mate: mate)
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -10,6 +10,6 @@ import Foundation
 import RxSwift
 
 protocol MateUseCase {
-    var mate: BehaviorSubject<[String: String]> { get set }
+    var mate: PublishSubject<[String: String]> { get set }
     func fetchMateInfo()
 }

--- a/MateRunner/MateRunner/Network/DefaultFireStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultFireStoreNetworkService.swift
@@ -1,5 +1,5 @@
 //
-//  FIreStoreNetworkService.swift
+//  DefaultFireStoreNetworkService.swift
 //  MateRunner
 //
 //  Created by 김민지 on 2021/11/07.
@@ -11,7 +11,7 @@ import Firebase
 import FirebaseFirestore
 import RxSwift
 
-final class FireStoreNetworkService: NetworkService {
+final class DefaultFireStoreNetworkService: FireStoreNetworkService {
     private let database: Firestore = Firestore.firestore()
     
     func updateArray<T: Codable>(

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -55,8 +55,8 @@ final class FireStoreNetworkService: NetworkService {
         return Observable<T>.create { emitter in
             documentReference.getDocument { (document, error) in
                 if let document = document {
-                    guard let mate = document.get(field) as? T else { return }
-                    emitter.onNext(mate)
+                    guard let data = document.get(field) as? T else { return }
+                    emitter.onNext(data)
                 }
                 if let error = error {
                     emitter.onError(error)

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -43,4 +43,35 @@ final class FireStoreNetworkService: NetworkService {
             return Disposables.create()
         }
     }
+    
+    func fetchMate(
+        collection: String,
+        document: String
+    ) {
+        let documentReference = self.database.collection(collection).document(document)
+        print(collection, document)
+        print(documentReference)
+        documentReference.getDocument { (document, _) in
+            if let document = document {
+                let property = document.get("mate")
+                print(property)
+            } else {
+                print(document)
+                print("document not exist")
+            }
+        }
+//        return Observable<[String]>.create { emitter in
+//            documentReference.getDocument{ document, error in
+//                if let document = document, document.exists {
+//                    let dataDescription = document.
+//                    print("Document data: \(dataDescription)")
+//                    emitter.onNext(dataDescription)
+//                } else {
+//                    print("not exist")
+//                }
+//                emitter.onCompleted()
+//            }
+//            return Disposables.create()
+//        }
+    }
 }

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -34,7 +34,7 @@ final class FireStoreNetworkService: NetworkService {
                         return
                     } else {
                         emitter.onNext(true)
-                   }
+                    }
                     emitter.onCompleted()
                 }
             } catch {
@@ -47,31 +47,21 @@ final class FireStoreNetworkService: NetworkService {
     func fetchMate(
         collection: String,
         document: String
-    ) {
+    ) -> Observable<[String]> {
         let documentReference = self.database.collection(collection).document(document)
-        print(collection, document)
-        print(documentReference)
-        documentReference.getDocument { (document, _) in
-            if let document = document {
-                let property = document.get("mate")
-                print(property)
-            } else {
-                print(document)
-                print("document not exist")
+        
+        return Observable<[String]>.create { emitter in
+            documentReference.getDocument { (document, error) in
+                if let document = document {
+                    let mate = document.get("mate") as? [String] ?? []
+                    emitter.onNext(mate)
+                }
+                if let error = error {
+                    emitter.onError(error)
+                }
+                emitter.onCompleted()
             }
+            return Disposables.create()
         }
-//        return Observable<[String]>.create { emitter in
-//            documentReference.getDocument{ document, error in
-//                if let document = document, document.exists {
-//                    let dataDescription = document.
-//                    print("Document data: \(dataDescription)")
-//                    emitter.onNext(dataDescription)
-//                } else {
-//                    print("not exist")
-//                }
-//                emitter.onCompleted()
-//            }
-//            return Disposables.create()
-//        }
     }
 }

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -44,16 +44,18 @@ final class FireStoreNetworkService: NetworkService {
         }
     }
     
-    func fetchMate(
+    func fetchData<T>(
+        type: T.Type,
         collection: String,
-        document: String
-    ) -> Observable<[String]> {
+        document: String,
+        field: String
+    ) -> Observable<T> {
         let documentReference = self.database.collection(collection).document(document)
         
-        return Observable<[String]>.create { emitter in
+        return Observable<T>.create { emitter in
             documentReference.getDocument { (document, error) in
                 if let document = document {
-                    let mate = document.get("mate") as? [String] ?? []
+                    guard let mate = document.get(field) as? T else { return }
                     emitter.onNext(mate)
                 }
                 if let error = error {

--- a/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkService.swift
+//  FireStoreNetworkService.swift
 //  MateRunner
 //
 //  Created by 김민지 on 2021/11/07.
@@ -9,7 +9,7 @@ import Foundation
 
 import RxSwift
 
-protocol NetworkService {
+protocol FireStoreNetworkService {
     func fetchData<T>(
         type: T.Type,
         collection: String,

--- a/MateRunner/MateRunner/Network/Protocol/NetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/NetworkService.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+import RxSwift
+
 protocol NetworkService {
-    
+    func fetchData<T>(
+        type: T.Type,
+        collection: String,
+        document: String,
+        field: String
+    ) -> Observable<T>
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -96,7 +96,7 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             coordinator: self,
             mateUseCase: DefaultMateUseCase(
                 repository: DefaultMateRepository(
-                    networkService: FireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -94,7 +94,11 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
         let inviteMateViewController = MateSettingViewController()
         inviteMateViewController.mateViewModel = MateViewModel( // 부모
             coordinator: self,
-            mateUseCase: DefaultMateUseCase()
+            mateUseCase: DefaultMateUseCase(
+                repository: DefaultMateRepository(
+                    networkService: FireStoreNetworkService()
+                )
+            )
         )
         inviteMateViewController.viewModel = MateSettingViewModel( // 자식 자기자신
             coordinator: self,

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -92,7 +92,7 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
     func pushMateSettingViewController(with settingData: RunningSetting?) {
         guard let settingData = settingData else { return }
         let inviteMateViewController = MateSettingViewController()
-        inviteMateViewController.mateViewModel = MateViewModel( // 부모
+        inviteMateViewController.mateViewModel = MateViewModel(
             coordinator: self,
             mateUseCase: DefaultMateUseCase(
                 repository: DefaultMateRepository(
@@ -100,7 +100,7 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
                 )
             )
         )
-        inviteMateViewController.viewModel = MateSettingViewModel( // 자식 자기자신
+        inviteMateViewController.viewModel = MateSettingViewModel(
             coordinator: self,
             runningSettingUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -92,7 +92,11 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
     func pushMateSettingViewController(with settingData: RunningSetting?) {
         guard let settingData = settingData else { return }
         let inviteMateViewController = MateSettingViewController()
-        inviteMateViewController.viewModel = MateSettingViewModel(
+        inviteMateViewController.mateViewModel = MateViewModel( // 부모
+            coordinator: self,
+            mateUseCase: DefaultMateUseCase()
+        )
+        inviteMateViewController.viewModel = MateSettingViewModel( // 자식 자기자신
             coordinator: self,
             runningSettingUseCase: DefaultRunningSettingUseCase(runningSetting: settingData)
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -25,7 +25,7 @@ final class DefaultMateCoordinator: MateCoordinator {
             mateUseCase: DefaultMateUseCase(
                 repository: DefaultMateRepository(
                     networkService:
-                        FireStoreNetworkService()
+                        DefaultFireStoreNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -22,7 +22,12 @@ final class DefaultMateCoordinator: MateCoordinator {
     func start() {
         self.mateViewController.mateViewModel = MateViewModel(
             coordinator: self,
-            mateUseCase: DefaultMateUseCase()
+            mateUseCase: DefaultMateUseCase(
+                repository: DefaultMateRepository(
+                    networkService:
+                        FireStoreNetworkService()
+                )
+            )
         )
         self.navigationController.pushViewController(self.mateViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -74,7 +74,7 @@ private extension MateViewModel {
         if mate.isEmpty {
             return
         }
-        let sortedMate = self.filteredMate.sorted(by: {$0.1 < $1.1})
+        let sortedMate = self.filteredMate.sorted(by: {$0.0 < $1.0})
         var tempDictionary = [String: String]()
         sortedMate.forEach {
             tempDictionary[$0.0] = $0.1

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -8,8 +8,8 @@ import Foundation
 
 import RxSwift
 
-final class MateViewModel {
-    weak var coordinator: MateCoordinator?
+class MateViewModel {
+    weak var coordinator: Coordinator?
     private let mateUseCase: MateUseCase
     var mate: [String: String] = [:] // usecase에서 fetch 받고 순서맞춘 딕셔너리, 필터링 되는 것을 기준으로 잡을 원래의 딕셔너리
     var filteredMate: [String: String] = [:] // searchBar input으로 인해 필터링된 딕셔너리
@@ -24,7 +24,7 @@ final class MateViewModel {
         @BehaviorRelayProperty var filterData: Bool = false
     }
     
-    init(coordinator: MateCoordinator, mateUseCase: MateUseCase) {
+    init(coordinator: Coordinator, mateUseCase: MateUseCase) {
         self.coordinator = coordinator
         self.mateUseCase = mateUseCase
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateViewModel.swift
@@ -8,7 +8,7 @@ import Foundation
 
 import RxSwift
 
-class MateViewModel {
+final class MateViewModel {
     weak var coordinator: Coordinator?
     private let mateUseCase: MateUseCase
     var mate: [String: String] = [:] // usecase에서 fetch 받고 순서맞춘 딕셔너리, 필터링 되는 것을 기준으로 잡을 원래의 딕셔너리

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -19,7 +19,7 @@ enum TableViewValue: CGFloat {
 
 class MateViewController: UIViewController {
     var mateViewModel: MateViewModel?
-    private var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
     
     private lazy var mateSearchBar: UISearchBar = {
         let searchBar = UISearchBar()

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -18,9 +18,7 @@ enum TableViewValue: CGFloat {
 }
 
 class MateViewController: UIViewController {
-    var mateViewModel = MateViewModel(
-        mateUseCase: DefaultMateUseCase()
-    )
+    var mateViewModel: MateViewModel?
     private var disposeBag = DisposeBag()
     
     private lazy var mateSearchBar: UISearchBar = {
@@ -82,9 +80,9 @@ private extension MateViewController {
             searchBarEvent: self.mateSearchBar.rx.text.orEmpty.asObservable()
         )
         
-        let output = self.mateViewModel.transform(from: input, disposeBag: self.disposeBag)
+        let output = self.mateViewModel?.transform(from: input, disposeBag: self.disposeBag)
         
-        output.$loadData
+        output?.$loadData
             .asDriver()
             .filter { $0 == true }
             .drive(onNext: { [weak self] _ in
@@ -92,7 +90,7 @@ private extension MateViewController {
             })
             .disposed(by: self.disposeBag)
         
-        output.$filterData
+        output?.$filterData
             .asDriver()
             .filter { $0 == true }
             .drive(onNext: { [weak self] _ in
@@ -106,7 +104,7 @@ private extension MateViewController {
     }
     
     func checkMateCount() {
-        if self.mateViewModel.filteredMate.count == 0 {
+        if self.mateViewModel?.filteredMate.count == 0 {
             self.addEmptyView()
         } else {
             self.removeEmptyView()
@@ -142,14 +140,14 @@ extension MateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: MateHeaderView.identifier) as? MateHeaderView else { return UITableViewHeaderFooterView() }
-        header.updateUI(value: self.mateViewModel.filteredMate.count)
+        header.updateUI(value: self.mateViewModel?.filteredMate.count ?? 0)
         
         return header
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         self.checkMateCount()
-        return self.mateViewModel.filteredMate.count
+        return self.mateViewModel?.filteredMate.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -157,7 +155,7 @@ extension MateViewController: UITableViewDataSource {
             withIdentifier: MateTableViewCell.identifier,
             for: indexPath) as? MateTableViewCell else { return UITableViewCell() }
         
-        let mateDictionary = self.mateViewModel.filteredMate
+        let mateDictionary = self.mateViewModel?.filteredMate ?? [:]
         let mateKey = Array(mateDictionary)[indexPath.row]
         cell.updateUI(image: mateKey.key, name: mateKey.value)
         
@@ -166,9 +164,7 @@ extension MateViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        // 친구 탭바 - 닉네임 가지고 프로필 페이지로 이동
-        // 친구 초대 - 닉네임 가지고 초대장 보내야함
-        let mateDictionary = self.mateViewModel.filteredMate
+        let mateDictionary = self.mateViewModel?.filteredMate ?? [:]
         let mateKey = Array(mateDictionary)[indexPath.row]
         let mateNickname = mateKey.value
         self.moveToNext(mate: mateNickname)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -157,7 +157,7 @@ extension MateViewController: UITableViewDataSource {
         
         let mateDictionary = self.mateViewModel?.filteredMate ?? [:]
         let mateKey = Array(mateDictionary)[indexPath.row]
-        cell.updateUI(image: mateKey.key, name: mateKey.value)
+        cell.updateUI(image: mateKey.value, name: mateKey.key)
         
         return cell
     }
@@ -166,7 +166,7 @@ extension MateViewController: UITableViewDataSource {
         tableView.deselectRow(at: indexPath, animated: true)
         let mateDictionary = self.mateViewModel?.filteredMate ?? [:]
         let mateKey = Array(mateDictionary)[indexPath.row]
-        let mateNickname = mateKey.value
+        let mateNickname = mateKey.key
         self.moveToNext(mate: mateNickname)
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #122 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 친구 목록 UseCase -> 닉네임 fetch -> 닉네임 별 image fetch 순서맞추기
- [x] Service fetch관련 메서드 추가
- [x] MateRepository 추가

![Simulator Screen Recording - iPhone 13 - 2021-11-17 at 00 50 54](https://user-images.githubusercontent.com/41044154/142019227-3d5dd86a-7773-45a5-8522-694a19575a4e.gif)


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- DefaultMateUseCase 
image url과 닉네임의 순서를 맞추기 위해 DispatchGroup과 같은 역할을 현재 zip오퍼레이터를 사용해 구현한 상태입니다. 모든 메이트의 닉네임 별로 image url을 fetch해오고 모두 fetch가 된다면 PublishSubject에 onNext 되어 화면에 뿌려지는 구조입니다!
Service에서 가져올때는 Observable의 타입이 String이고 onNext 되어질때는 [String:String] 이 되어야 하다보니 중간 역할을 해주는 mateList 라는 딕셔너리가 있는 상태인데 뭔가 이 딕셔너리 없이 바로 Subject에 넣어줄 수 있는 방법은 없을까요..! 현재 이렇게 되어있다보니 사실 Observable 리턴받고 그 형태로 쓰는 의미가 없는것 같아서 고민입니다..

- 데이터 로딩이 뭔가 딜레이(?) 되는듯한 느낌
뭔가 친구탭에 들어갔을때 데이터가 fetch 되는 속도가 느린것 같은..? 느낌은 저만 드는 걸까요?
뷰에 바인딩 안하고 콘솔창에서 확인했을때 (Service부분만 구현했을 때) 부터 조금 느리게 찍히는 기분이 들었는데 파베가 원래 이런걸까요👀

- 이미지 캐싱
일단 아까 줌에서 회의했던것 처럼 프로필 사진에 대한 부분이 확정이 안난것 같기도 하고 우선순위가 높은 부분은 아닌것같아 뒤로 미뤄두려고 하는데 괜찮을까요?

<br/><br/>
