### PR TITLE
회원가입 기능 구현

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08A72733A39300B46479 /* RunningResultDTO+Mapping.swift */; };
 		3DFD08B627391AE300B46479 /* RunningRealTimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08B527391AE300B46479 /* RunningRealTimeData.swift */; };
 		3DFD08B827391BDA00B46479 /* RunningData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08B727391BDA00B46479 /* RunningData.swift */; };
+		5E0A58072743B3CA00D85D5B /* SignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A58062743B3CA00D85D5B /* SignUpRepository.swift */; };
+		5E0A58092743B40600D85D5B /* DefaultSignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A58082743B40600D85D5B /* DefaultSignUpRepository.swift */; };
 		5E171E61273251B4001C003B /* RunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E171E60273251B4001C003B /* RunningResult.swift */; };
 		5E171E632732536C001C003B /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E171E622732536C001C003B /* Point.swift */; };
 		5E171E6527325691001C003B /* RunningSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E171E6427325691001C003B /* RunningSetting.swift */; };
@@ -235,6 +237,8 @@
 		3DFD08B727391BDA00B46479 /* RunningData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningData.swift; sourceTree = "<group>"; };
 		51910B235E01B925173A4A06 /* Pods_RunningPreparationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunningPreparationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5548203E72F57E9BDD31D1FD /* Pods_MateRunner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MateRunner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E0A58062743B3CA00D85D5B /* SignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRepository.swift; sourceTree = "<group>"; };
+		5E0A58082743B40600D85D5B /* DefaultSignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignUpRepository.swift; sourceTree = "<group>"; };
 		5E171E60273251B4001C003B /* RunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResult.swift; sourceTree = "<group>"; };
 		5E171E622732536C001C003B /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		5E171E6427325691001C003B /* RunningSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningSetting.swift; sourceTree = "<group>"; };
@@ -417,6 +421,7 @@
 		3DF4C8632737684000A4B229 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				5E0A58042743B38A00D85D5B /* SignUp */,
 				3DF4C8642737686200A4B229 /* Home */,
 			);
 			path = Repository;
@@ -530,6 +535,23 @@
 				B01205CACB0E40A1BDDD081F /* Pods-RunningPreparationTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		5E0A58042743B38A00D85D5B /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				5E0A58052743B39400D85D5B /* Protocol */,
+				5E0A58082743B40600D85D5B /* DefaultSignUpRepository.swift */,
+			);
+			path = SignUp;
+			sourceTree = "<group>";
+		};
+		5E0A58052743B39400D85D5B /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				5E0A58062743B3CA00D85D5B /* SignUpRepository.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		5E171E5F2732518E001C003B /* Model */ = {
@@ -1565,6 +1587,7 @@
 				AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */,
 				AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */,
 				5E32DC652731004D000E525B /* BehaviorRelayProperty.swift in Sources */,
+				5E0A58092743B40600D85D5B /* DefaultSignUpRepository.swift in Sources */,
 				AE77C1F32742A39F005EDEE0 /* MateCoordinator.swift in Sources */,
 				AECB9A8227356AFF00533EF7 /* RunningUseCase.swift in Sources */,
 				B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */,
@@ -1598,6 +1621,7 @@
 				3D2C217E273A99AC00D00C68 /* TeamRunningRepository.swift in Sources */,
 				5E171E6527325691001C003B /* RunningSetting.swift in Sources */,
 				AE3D149F273BDB5800D4A186 /* Double+Formatter.swift in Sources */,
+				5E0A58072743B3CA00D85D5B /* SignUpRepository.swift in Sources */,
 				B0F53298273A5DCA005A3F11 /* HomeUseCase.swift in Sources */,
 				5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */,
 				3DF6D07E27301F1100991DC3 /* RunningResultViewController.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/SignUp/DefaultSignUpRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/SignUp/DefaultSignUpRepository.swift
@@ -1,0 +1,22 @@
+//
+//  DefaultSignUpRepository.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/16.
+//
+
+import Foundation
+
+import RxSwift
+
+final class DefaultSignUpRepository: SignUpRepository {
+    private let networkService: FireStoreNetworkService
+    
+    init(networkService: FireStoreNetworkService) {
+        self.networkService = networkService
+    }
+    
+    func checkDuplicate(of nickname: String) -> Observable<Bool> {
+        return self.networkService.documentDoesExist(collection: "User", document: nickname)
+    }
+}

--- a/MateRunner/MateRunner/Data/Repository/SignUp/DefaultSignUpRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/SignUp/DefaultSignUpRepository.swift
@@ -19,4 +19,12 @@ final class DefaultSignUpRepository: SignUpRepository {
     func checkDuplicate(of nickname: String) -> Observable<Bool> {
         return self.networkService.documentDoesExist(collection: "User", document: nickname)
     }
+    
+    func saveUserInfo(nickname: String, height: Int, weight: Int) -> Observable<Bool> {
+        let data: [String: Any] = [
+            "height": height,
+            "weight": weight
+        ]
+        return self.networkService.writeData(collection: "User", document: nickname, data: data)
+    }
 }

--- a/MateRunner/MateRunner/Data/Repository/SignUp/Protocol/SignUpRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/SignUp/Protocol/SignUpRepository.swift
@@ -1,0 +1,14 @@
+//
+//  SignUpRepository.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/16.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol SignUpRepository {
+    func checkDuplicate(of nickname: String) -> Observable<Bool>
+}

--- a/MateRunner/MateRunner/Data/Repository/SignUp/Protocol/SignUpRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/SignUp/Protocol/SignUpRepository.swift
@@ -11,4 +11,5 @@ import RxSwift
 
 protocol SignUpRepository {
     func checkDuplicate(of nickname: String) -> Observable<Bool>
+    func saveUserInfo(nickname: String, height: Int, weight: Int) -> Observable<Bool>
 }

--- a/MateRunner/MateRunner/Domain/UseCase/SignUp/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/SignUp/DefaultSignUpUseCase.swift
@@ -15,6 +15,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     var height: BehaviorSubject<Int> = BehaviorSubject(value: 170)
     var weight: BehaviorSubject<Int> = BehaviorSubject(value: 60)
     var canSignUp = PublishSubject<Bool>()
+    var signUpResult = PublishSubject<Bool>()
     var disposeBag = DisposeBag()
     
     init(repository: SignUpRepository) {
@@ -48,11 +49,13 @@ final class DefaultSignUpUseCase: SignUpUseCase {
             .disposed(by: self.disposeBag)
     }
     
-    func saveUserInfo(nickname: String?) {
+    func signUp(nickname: String?) {
         guard let nickname = nickname,
               let height = try? self.height.value(),
               let weight = try? self.weight.value() else { return }
         
-        print(nickname, height, weight)
+        self.repository.saveUserInfo(nickname: nickname, height: height, weight: weight)
+            .bind(to: self.signUpResult)
+            .disposed(by: self.disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/SignUp/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/SignUp/DefaultSignUpUseCase.swift
@@ -58,4 +58,10 @@ final class DefaultSignUpUseCase: SignUpUseCase {
             .bind(to: self.signUpResult)
             .disposed(by: self.disposeBag)
     }
+    
+    func saveLoginInfo(nickname: String?) {
+        guard let nickname = nickname else { return }
+        UserDefaults.standard.set(nickname, forKey: "nickname")
+        UserDefaults.standard.set(true, forKey: "isLoggedIn")
+    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/SignUp/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/SignUp/DefaultSignUpUseCase.swift
@@ -10,9 +10,16 @@ import Foundation
 import RxSwift
 
 final class DefaultSignUpUseCase: SignUpUseCase {
+    private let repository: SignUpRepository
     var validText = PublishSubject<String?>()
     var height: BehaviorSubject<Int> = BehaviorSubject(value: 170)
     var weight: BehaviorSubject<Int> = BehaviorSubject(value: 60)
+    var canSignUp = PublishSubject<Bool>()
+    var disposeBag = DisposeBag()
+    
+    init(repository: SignUpRepository) {
+        self.repository = repository
+    }
     
     func validate(text: String) {
         self.validText.onNext(self.checkValidty(of: text))
@@ -32,5 +39,20 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     func getCurrentWeight() {
         guard let currentWeight = try? self.weight.value() else { return }
         self.weight.onNext(currentWeight)
+    }
+    
+    func checkDuplicate(of nickname: String?) {
+        guard let nickname = nickname else { return }
+        self.repository.checkDuplicate(of: nickname)
+            .bind(to: self.canSignUp)
+            .disposed(by: self.disposeBag)
+    }
+    
+    func saveUserInfo(nickname: String?) {
+        guard let nickname = nickname,
+              let height = try? self.height.value(),
+              let weight = try? self.weight.value() else { return }
+        
+        print(nickname, height, weight)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/SignUp/Protocol/SignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/SignUp/Protocol/SignUpUseCase.swift
@@ -14,9 +14,10 @@ protocol SignUpUseCase {
     var height: BehaviorSubject<Int> { get set }
     var weight: BehaviorSubject<Int> { get set }
     var canSignUp: PublishSubject<Bool> { get set }
+    var signUpResult: PublishSubject<Bool> { get set }
     func validate(text: String)
     func getCurrentHeight()
     func getCurrentWeight()
     func checkDuplicate(of nickname: String?)
-    func saveUserInfo(nickname: String?)
+    func signUp(nickname: String?)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/SignUp/Protocol/SignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/SignUp/Protocol/SignUpUseCase.swift
@@ -20,4 +20,5 @@ protocol SignUpUseCase {
     func getCurrentWeight()
     func checkDuplicate(of nickname: String?)
     func signUp(nickname: String?)
+    func saveLoginInfo(nickname: String?)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/SignUp/Protocol/SignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/SignUp/Protocol/SignUpUseCase.swift
@@ -13,7 +13,10 @@ protocol SignUpUseCase {
     var validText: PublishSubject<String?> { get set }
     var height: BehaviorSubject<Int> { get set }
     var weight: BehaviorSubject<Int> { get set }
+    var canSignUp: PublishSubject<Bool> { get set }
     func validate(text: String)
     func getCurrentHeight()
     func getCurrentWeight()
+    func checkDuplicate(of nickname: String?)
+    func saveUserInfo(nickname: String?)
 }

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -48,8 +48,10 @@ final class FireStoreNetworkService: NetworkService {
         let documentReference = self.database.collection(collection).document(document)
         
         return Observable.create { emitter in
-            documentReference.getDocument { (document, _) in
-                if let document = document, document.exists {
+            documentReference.getDocument { (document, error) in
+                if let error = error {
+                    emitter.onError(error)
+                } else if let document = document, document.exists {
                     emitter.onNext(false)
                 } else {
                     emitter.onNext(true)
@@ -65,8 +67,7 @@ final class FireStoreNetworkService: NetworkService {
         return Observable.create { emitter in
             documentReference.setData(data, merge: true) { error in
                 if let error = error {
-                    print(error)
-                    emitter.onNext(false)
+                    emitter.onError(error)
                 } else {
                     emitter.onNext(true)
                 }

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -58,4 +58,20 @@ final class FireStoreNetworkService: NetworkService {
             return Disposables.create()
         }
     }
+    
+    func writeData(collection: String, document: String, data: [String: Any]) -> Observable<Bool> {
+        let documentReference = self.database.collection(collection).document(document)
+        
+        return Observable.create { emitter in
+            documentReference.setData(data, merge: true) { error in
+                if let error = error {
+                    print(error)
+                    emitter.onNext(false)
+                } else {
+                    emitter.onNext(true)
+                }
+            }
+            return Disposables.create()
+        }
+    }
 }

--- a/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/FIreStoreNetworkService.swift
@@ -43,4 +43,19 @@ final class FireStoreNetworkService: NetworkService {
             return Disposables.create()
         }
     }
+    
+    func documentDoesExist(collection: String, document: String) -> Observable<Bool> {
+        let documentReference = self.database.collection(collection).document(document)
+        
+        return Observable.create { emitter in
+            documentReference.getDocument { (document, _) in
+                if let document = document, document.exists {
+                    emitter.onNext(false)
+                } else {
+                    emitter.onNext(true)
+                }
+            }
+            return Disposables.create()
+        }
+    }
 }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -42,11 +42,7 @@ final class DefaultAppCoordinator: AppCoordinator {
 
 extension DefaultAppCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
-        guard let index = self.childCoordinators.firstIndex(
-            where: { $0.type == childCoordinator.type }
-        ) else { return }
-        
-        self.childCoordinators.remove(at: index)
+        self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
         
         if childCoordinator.type == .login {
             self.navigationController.view.backgroundColor = .systemBackground

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -19,12 +19,13 @@ final class DefaultAppCoordinator: AppCoordinator {
     }
     
     func start() {
-        self.showTabBarFlow()
-        // self.showLoginFlow()
+        // self.showTabBarFlow()
+        self.showLoginFlow()
     }
     
     func showLoginFlow() {
         let loginCoordinator = DefaultLoginCoordinator(self.navigationController)
+        loginCoordinator.finishDelegate = self
         loginCoordinator.start()
         childCoordinators.append(loginCoordinator)
     }
@@ -33,5 +34,21 @@ final class DefaultAppCoordinator: AppCoordinator {
         let tabBarCoordinator = DefaultTabBarCoordinator(navigationController)
         tabBarCoordinator.start()
         childCoordinators.append(tabBarCoordinator)
+    }
+}
+
+extension DefaultAppCoordinator: CoordinatorFinishDelegate {
+    func coordinatorDidFinish(childCoordinator: Coordinator) {
+        guard let index = self.childCoordinators.firstIndex(
+            where: { $0.type == childCoordinator.type }
+        ) else { return }
+        
+        self.childCoordinators.remove(at: index)
+        
+        if childCoordinator.type == .login {
+            self.navigationController.view.backgroundColor = .systemBackground
+            self.navigationController.viewControllers.removeAll()
+            self.showTabBarFlow()
+        }
     }
 }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -19,8 +19,11 @@ final class DefaultAppCoordinator: AppCoordinator {
     }
     
     func start() {
-        // self.showTabBarFlow()
-        self.showLoginFlow()
+        if UserDefaults.standard.bool(forKey: "isLoggedIn") {
+            self.showTabBarFlow()
+        } else {
+            self.showLoginFlow()
+        }
     }
     
     func showLoginFlow() {

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -47,7 +47,6 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
         self.tabBarController.tabBar.backgroundColor = .systemBackground
         self.tabBarController.tabBar.tintColor = UIColor.mrPurple
         
-        // self.navigationController.viewControllers = [self.tabBarController]
         self.navigationController.pushViewController(self.tabBarController, animated: true)
     }
     

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -47,7 +47,8 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
         self.tabBarController.tabBar.backgroundColor = .systemBackground
         self.tabBarController.tabBar.tintColor = UIColor.mrPurple
         
-        self.navigationController.viewControllers = [self.tabBarController]
+        // self.navigationController.viewControllers = [self.tabBarController]
+        self.navigationController.pushViewController(self.tabBarController, animated: true)
     }
     
     private func configureTabBarItem(of page: TabBarPage) -> UITabBarItem {

--- a/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultLoginCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultLoginCoordinator.swift
@@ -26,7 +26,15 @@ final class DefaultLoginCoordinator: LoginCoordinator {
     
     func showSignUpFlow() {
         let signUpCoordinator = DefaultSignUpCoordinator(self.navigationController)
+        signUpCoordinator.finishDelegate = self
         self.childCoordinators.append(signUpCoordinator)
         signUpCoordinator.start()
+    }
+}
+
+extension DefaultLoginCoordinator: CoordinatorFinishDelegate {
+    func coordinatorDidFinish(childCoordinator: Coordinator) {
+        self.childCoordinators.removeAll()
+        self.finishDelegate?.coordinatorDidFinish(childCoordinator: self)
     }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultSignUpCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultSignUpCoordinator.swift
@@ -30,4 +30,8 @@ final class DefaultSignUpCoordinator: SignUpCoordinator {
         )
         self.navigationController.pushViewController(self.signUpViewController, animated: true)
     }
+    
+    func finish() {
+        self.finishDelegate?.coordinatorDidFinish(childCoordinator: self)
+    }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultSignUpCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultSignUpCoordinator.swift
@@ -22,7 +22,11 @@ final class DefaultSignUpCoordinator: SignUpCoordinator {
     func start() {
         self.signUpViewController.viewModel = SignUpViewModel(
             coordinator: self,
-            signUpUseCase: DefaultSignUpUseCase()
+            signUpUseCase: DefaultSignUpUseCase(
+                repository: DefaultSignUpRepository(
+                    networkService: FireStoreNetworkService()
+                )
+            )
         )
         self.navigationController.pushViewController(self.signUpViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -26,11 +26,13 @@ final class SignUpViewController: UIViewController {
         textField.borderStyle = .roundedRect
         textField.backgroundColor = .systemGray6
         textField.font = .notoSans(size: 16, family: .regular)
+        textField.placeholder = "5~20자의 영문, 숫자 조합"
         return textField
     }()
     
     private lazy var heightTextField = PickerTextField()
     private lazy var weightTextField = PickerTextField()
+    private lazy var descriptionLabel = UILabel()
     
     private lazy var nicknameSection = self.createInputSection(
         text: "닉네임",
@@ -101,6 +103,7 @@ private extension SignUpViewController {
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         self.bindNicknameTextField(output: output)
+        self.bindDescriptionLabel(output: output)
         self.bindHeightTextField(output: output)
         self.bindWeightTextField(output: output)
         self.bindDoneButton(output: output)
@@ -110,6 +113,16 @@ private extension SignUpViewController {
         output?.$nicknameFieldText
             .asDriver()
             .drive(self.nicknameTextField.rx.text)
+            .disposed(by: self.disposeBag)
+    }
+    
+    func bindDescriptionLabel(output: SignUpViewModel.Output?) {
+        output?.$isNicknameValid
+            .asDriver()
+            .drive(onNext: { [weak self] isValid in
+                guard let text = self?.nicknameTextField.text else { return }
+                self?.descriptionLabel.text = (isValid || text.isEmpty) ? "" : "닉네임은 5자 이상이어야 합니다."
+            })
             .disposed(by: self.disposeBag)
     }
     
@@ -185,9 +198,8 @@ private extension SignUpViewController {
     }
     
     func createNicknameLabelStack(titleLabel: UILabel) -> UIStackView {
-        let descriptionLabel = UILabel()
-        descriptionLabel.font = .notoSans(size: 14, family: .regular)
-        descriptionLabel.text = "5~20자의 영문, 숫자 조합"
+        self.descriptionLabel.font = .notoSans(size: 14, family: .regular)
+        self.descriptionLabel.textColor = .mrPurple
 
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -195,7 +207,7 @@ private extension SignUpViewController {
         stackView.alignment = .lastBaseline
         
         stackView.addArrangedSubview(titleLabel)
-        stackView.addArrangedSubview(descriptionLabel)
+        stackView.addArrangedSubview(self.descriptionLabel)
         return stackView
     }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -214,7 +214,7 @@ private extension SignUpViewController {
         stackView.distribution = .fill
         stackView.alignment = .lastBaseline
         
-        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(self.titleLabel)
         stackView.addArrangedSubview(self.descriptionLabel)
         return stackView
     }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -98,7 +98,8 @@ private extension SignUpViewController {
             heightTextFieldDidTapEvent: self.heightTextField.rx.controlEvent(.editingDidBegin).asObservable(),
             heightPickerSelectedRow: self.heightTextField.pickerView.rx.itemSelected.map { $0.row },
             weightTextFieldDidTapEvent: self.weightTextField.rx.controlEvent(.editingDidBegin).asObservable(),
-            weightPickerSelectedRow: self.weightTextField.pickerView.rx.itemSelected.map { $0.row }
+            weightPickerSelectedRow: self.weightTextField.pickerView.rx.itemSelected.map { $0.row },
+            doneButtonDidTapEvent: self.doneButton.rx.tap.asObservable()
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
@@ -122,6 +123,13 @@ private extension SignUpViewController {
             .drive(onNext: { [weak self] isValid in
                 guard let text = self?.nicknameTextField.text else { return }
                 self?.descriptionLabel.text = (isValid || text.isEmpty) ? "" : "닉네임은 5자 이상이어야 합니다."
+            })
+            .disposed(by: self.disposeBag)
+        
+        output?.$canSignUp
+            .asDriver()
+            .drive(onNext: { [weak self] canSignUp in
+                self?.descriptionLabel.text = canSignUp ? "" : "해당 닉네임이 이미 존재합니다."
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -111,14 +111,14 @@ private extension SignUpViewController {
     }
     
     func bindNicknameTextField(output: SignUpViewModel.Output?) {
-        output?.$nicknameFieldText
+        output?.nicknameFieldText
             .asDriver()
             .drive(self.nicknameTextField.rx.text)
             .disposed(by: self.disposeBag)
     }
     
     func bindDescriptionLabel(output: SignUpViewModel.Output?) {
-        output?.$isNicknameValid
+        output?.isNicknameValid
             .asDriver()
             .drive(onNext: { [weak self] isValid in
                 guard let text = self?.nicknameTextField.text else { return }
@@ -126,7 +126,7 @@ private extension SignUpViewController {
             })
             .disposed(by: self.disposeBag)
         
-        output?.$canSignUp
+        output?.canSignUp
             .asDriver()
             .drive(onNext: { [weak self] canSignUp in
                 self?.descriptionLabel.text = canSignUp ? "" : "해당 닉네임이 이미 존재합니다."
@@ -135,19 +135,19 @@ private extension SignUpViewController {
     }
     
     func bindHeightTextField(output: SignUpViewModel.Output?) {
-        output?.$heightRange
+        output?.heightRange
             .asDriver()
             .drive(self.heightTextField.pickerView.rx.itemTitles) { (_, element) in
                 return element
             }
             .disposed(by: self.disposeBag)
         
-        output?.$heightFieldText
+        output?.heightFieldText
             .asDriver()
             .drive(self.heightTextField.rx.text)
             .disposed(by: self.disposeBag)
         
-        output?.$heightPickerRow
+        output?.heightPickerRow
             .asDriver()
             .drive(onNext: { [weak self] row in
                 self?.heightTextField.pickerView.selectRow(row, inComponent: 0, animated: false)
@@ -156,19 +156,19 @@ private extension SignUpViewController {
     }
     
     func bindWeightTextField(output: SignUpViewModel.Output?) {
-        output?.$weightRange
+        output?.weightRange
             .asDriver()
             .drive(self.weightTextField.pickerView.rx.itemTitles) { (_, element) in
                 return element
             }
             .disposed(by: self.disposeBag)
         
-        output?.$weightFieldText
+        output?.weightFieldText
             .asDriver()
             .drive(self.weightTextField.rx.text)
             .disposed(by: self.disposeBag)
         
-        output?.$weightPickerRow
+        output?.weightPickerRow
             .asDriver()
             .drive(onNext: { [weak self] row in
                 self?.weightTextField.pickerView.selectRow(row, inComponent: 0, animated: false)
@@ -177,7 +177,7 @@ private extension SignUpViewController {
     }
     
     func bindDoneButton(output: SignUpViewModel.Output?) {
-        output?.$isNicknameValid
+        output?.isNicknameValid
             .asDriver()
             .drive(onNext: { [weak self] isValid in
                 self?.doneButton.isEnabled = isValid

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -109,6 +109,11 @@ final class SignUpViewModel {
             .bind(to: output.$weightPickerRow)
             .disposed(by: disposeBag)
         
+        self.bindSignUp(input: input, output: output, disposeBag: disposeBag)
+        return output
+    }
+    
+    private func bindSignUp(input: Input, output: Output, disposeBag: DisposeBag) {
         input.doneButtonDidTapEvent
             .subscribe(onNext: { [weak self] in
                 self?.signUpUseCase.checkDuplicate(of: output.nicknameFieldText)
@@ -122,11 +127,15 @@ final class SignUpViewModel {
         self.signUpUseCase.canSignUp
             .filter { $0 }
             .subscribe(onNext: { [weak self] _ in
-                self?.signUpUseCase.saveUserInfo(nickname: output.nicknameFieldText)
+                self?.signUpUseCase.signUp(nickname: output.nicknameFieldText)
             })
             .disposed(by: disposeBag)
         
-        return output
+        self.signUpUseCase.signUpResult
+            .filter { $0 }
+            .subscribe(onNext: { [weak self] _ in
+                print("저장 성공")
+            })
     }
     
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -134,8 +134,9 @@ final class SignUpViewModel {
         self.signUpUseCase.signUpResult
             .filter { $0 }
             .subscribe(onNext: { [weak self] _ in
-                print("저장 성공")
+                self?.coordinator?.finish()
             })
+            .disposed(by: disposeBag)
     }
     
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -134,6 +134,7 @@ final class SignUpViewModel {
         self.signUpUseCase.signUpResult
             .filter { $0 }
             .subscribe(onNext: { [weak self] _ in
+                self?.signUpUseCase.saveLoginInfo(nickname: output.nicknameFieldText)
                 self?.coordinator?.finish()
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
### 📕 Issue Number

Close #129 

https://user-images.githubusercontent.com/77449223/142033122-df472f15-19f9-4fdc-a4b1-a11473fb2583.mov

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 닉네임 중복 검사
- [x] 서버 DB에 닉네임, 키, 몸무게 정보 저장
- [x] 회원가입 완료 후 앱 내에 로그인 정보 저장
- [x] 회원가입 완료 후 홈 화면 이동

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현재 `NavigationController`에 `LoginViewController`, `SignUpViewController` 순으로 스택이 쌓여있고, 회원가입에 성공하면 `viewControllers` 배열을 모두 비운 뒤 `showTabBarFlow`를 호출하도록 하였습니다. 처음에는 매끄러운 화면 전환을 위해 `TabBarController`를 `push`하고 앞의 두 뷰컨을 제거하고 싶었는데 그게 안되네요.. ㅠㅠ

- 닉네임 중복 체크를 위해 `FireStoreNetworkService`에서 특정 collection의 특정 document가 존재하는지 여부를 알려주는 메소드를 구현하였고, 특정 document에 data를 저장하는 `writeData` 메소드를 구현하였습니다. 참고로 `merge` 값이 `true`여야지 수정, 생성하려는 필드 외에 다른 필드가 사라지지 않습니다.

- 회원가입을 완료하면 `UserDefault`에 자신의 닉네임 정보와 로그인 정보를 저장하도록 하였습니다. 따라서 한번 회원가입을 하면 다음에 앱을 다시 실행할 때 바로 홈 화면으로 이동할 수 있습니다. `UserDefault`에 저장하는 로직을 UseCase에 구현한 이유는 Repository나 Service단에 구현하게 되면 UseCase에서는 단순히 호출만 하게될 것 같아서입니다. 이 부분 여러분들과 얘기해보고 리팩토링 해보고 싶습니다!

<br/><br/>
