### PR TITLE
[Fix] 사용자 위치정보가 업데이트 되지 않는 버그 수정

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultHomeUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultHomeUseCase.swift
@@ -37,7 +37,6 @@ final class DefaultHomeUseCase: HomeUseCase {
                 }
             })
             .disposed(by: self.disposeBag)
-        self.locationService.requestAuthorization()
     }
     
     func observeUserLocation() {

--- a/MateRunner/MateRunner/Util/Service/DefaultLocationService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultLocationService.swift
@@ -14,7 +14,7 @@ import RxSwift
 final class DefaultLocationService: NSObject, LocationService {
     var locationManager: CLLocationManager?
     var disposeBag: DisposeBag = DisposeBag()
-    var authorizationStatus = PublishRelay<CLAuthorizationStatus>()
+    var authorizationStatus = BehaviorRelay<CLAuthorizationStatus>(value: .notDetermined)
     
     override init() {
         super.init()

--- a/MateRunner/MateRunner/Util/Service/Protocol/LocationService.swift
+++ b/MateRunner/MateRunner/Util/Service/Protocol/LocationService.swift
@@ -12,7 +12,7 @@ import RxRelay
 import RxSwift
 
 protocol LocationService {
-    var authorizationStatus: PublishRelay<CLAuthorizationStatus> { get set }
+    var authorizationStatus: BehaviorRelay<CLAuthorizationStatus> { get set }
     func start()
     func stop()
     func requestAuthorization()


### PR DESCRIPTION
### 📕 Issue Number

Close #133 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 현재 위치 버그 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 버그 원인 
버그의 원인은 LocationService 가 PublishRelay로 권한 값을 방출하는데에 있었습니다. viewDidLoad에서 뷰모델의 transform 이 불리면 사용자 위치정보에 대한 권한을 확인합니다.

    LocationService에 구현되어 있는 ManagerDelegate는 권한이 변경될 때 호출됩니다.

    ```swift
            input.viewDidLoadEvent
                .subscribe({ [weak self] _ in
                    self?.homeUseCase.checkAuthorization()
                    self?.homeUseCase.observeUserLocation()
                })
                .disposed(by: disposeBag)
    ```

    함수가 호출 되면 LocationService에 현재 권한 값을 subscribe해두고 요청을 보내는데요,
    
    ```swift
        func checkAuthorization() {
            self.locationService.observeUpdatedAuthorization()
                .subscribe(onNext: { [weak self] status in
                    switch status {
                    case .authorizedAlways, .authorizedWhenInUse:
                        self?.authorizationStatus.onNext(.allowed)
                        self?.locationService.start()
                    case .notDetermined:
                        self?.authorizationStatus.onNext(.notDetermined)
                        self?.locationService.requestAuthorization()
                    case .denied, .restricted:
                        self?.authorizationStatus.onNext(.disallowed)
                    @unknown default:
                        self?.authorizationStatus.onNext(nil)
                    }
                })
                .disposed(by: self.disposeBag)
            self.locationService.requestAuthorization()
        }
    ```
     여기서 막연하게 requestAuthorization()을 부르면 권한 정보가 업데이트 될 것이라고 생각한 것이 문제였습니다 😔

    일단 권한 정보는 아래 delegate 메서드를 통해 업데이트 되는 값을 subscribe합니다.    

    ```swift
        func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
            self.authorizationStatus.accept(status)
        }
    ```    
     이 메서드가 실행되는 조건을 공식문서에서 찾아봤는데요, 두 가지 경우가 있었습니다.

              1. LocationManager 인스턴스를 생성했을 때
              2. 권한 허용 창을 통해 사용자가 권한을 설정했을 때 -> 권한 허용은 CLAuthorizationStatus가 notDetermined 일 때만 불립니다.

     notDetiermined 가 되는 조건은 앱을 처음 실행했을 때와, 한 번만 허용(Allow Once)을 한 뒤에 앱을 종료했을 때입니다. 

   그래서 1번 조건에 따라서 LocationService가 만들어지는 시점에 PublishRelay를 통해 현재 권한에 대한 정보가 방출되는데, LocationService는 유즈케이스의 생성자에서 만들어지고, 권한정보를 subscribe하는 시점은 이미 인스턴스가 만들어지고 난 이후의 시점이기 때문에 PublishRelay는 새로운 구독자에게 최근 값을 방출하지 않아 현재 사용자의 권한정보를 알 수 없었습니다.

   따라서 BehaviorRelay로 변경하니 다음과 같은 시간순서대로 emit/subscribe가 발생해서 문제가 해결되었습니다.

              1. LocationService 생성시 Delegate가 불리며 현재 권한 정보를 BehaviorRelay에 방출.
              2. transform 메서드에서 requestAuthorization을 부르며 LocationService를 subscribe.
              3. BehaviorRelay는 스트림에 들어왔던 마지막 값(1번에서 방출된)을 새로운 구독자에게 방출
              4. 현재 권한 확인 후 알러트, 현재위치 추적 등 선택 

    BehaviorRelay의 초기값은 큰 의미 없이 notDetermined로 넣어두었습니다. 어차피 인스턴스 생성시점에 변경되니까요.

   여담으로 현재 권한을 확인하는 프로퍼티인 locationManager.CLAuthorizationStatus가 있는데 iOS14 이후부터 지원합니다. 이게 진작 있었으면 덜 헷갈렸을텐데..

reference
[https://developer.apple.com/documentation/corelocation/cllocationmanager/1620562-requestwheninuseauthorization](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620562-requestwheninuseauthorization)
[https://stackoverflow.com/questions/30106341/swift-locationmanager-didchangeauthorizationstatus-always-called](https://stackoverflow.com/questions/30106341/swift-locationmanager-didchangeauthorizationstatus-always-called)

<br/><br/>
