### PR TITLE
초대 대기 타임아웃 버그 수정

### DIFF
--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -15,8 +15,6 @@ import FirebaseMessaging
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    var appCoordinator: AppCoordinator?
-    
     func application(_ application: UIApplication,didFinishLaunchingWithOptions launchOptions:[UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
         
@@ -94,23 +92,10 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
         
         guard let invitation = Invitation(from: userInfo),
               let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
-              let window = sceneDelegate.window
+              let appCoordinator = sceneDelegate.appCoordinator
         else { return }
         
-        if sceneDelegate.appCoordinator != nil {
-            sceneDelegate.appCoordinator?.showInvitationFlow(with: invitation)
-        } else {
-            let navigationController: UINavigationController = .init()
-            
-            window.tintColor = .mrPurple
-            window.rootViewController = navigationController
-            window.makeKeyAndVisible()
-            
-            self.appCoordinator = DefaultAppCoordinator(navigationController)
-            sceneDelegate.appCoordinator = self.appCoordinator
-            self.appCoordinator?.start()
-            self.appCoordinator?.showInvitationFlow(with: invitation)
-        }
+        appCoordinator.showInvitationFlow(with: invitation)
         
         completionHandler()
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -59,6 +59,7 @@ final class DefaultInviteMateRepository {
                 guard let isRecieved = snapshot.childSnapshot(forPath: "isReceived").value as? Bool,
                       let isAccepted = snapshot.childSnapshot(forPath: "isAccepted").value as? Bool else {
                           observer.onError(MockError.unknown)
+                          observer.onCompleted()
                           return
                       }
                 

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -125,7 +125,6 @@ final class DefaultInviteMateRepository {
     }
     
     func stopListen(invitation: Invitation) {
-        print("stop listen")
         let sessionId = invitation.sessionId
         self.ref.child("session").child("\(sessionId)").removeAllObservers()
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -54,15 +54,18 @@ final class DefaultInviteMateRepository {
     func listenSession(invitation: Invitation) -> Observable<(Bool, Bool)> {
         let sessionId = invitation.sessionId
         
-        return BehaviorRelay<(Bool, Bool)>.create { [weak self] observe in
+        return Observable<(Bool, Bool)>.create { [weak self] observer in
             self?.ref.child("session").child("\(sessionId)").observe(DataEventType.value, with: { snapshot in
                 guard let isRecieved = snapshot.childSnapshot(forPath: "isReceived").value as? Bool,
                       let isAccepted = snapshot.childSnapshot(forPath: "isAccepted").value as? Bool else {
-                          observe.onError(MockError.unknown)
+                          observer.onError(MockError.unknown)
                           return
                       }
                 
-                observe.onNext((isRecieved, isAccepted))
+                if isRecieved || isAccepted {
+                    observer.onNext((isRecieved, isAccepted))
+                    observer.onCompleted()
+                }
             })
             return Disposables.create()
         }
@@ -122,6 +125,7 @@ final class DefaultInviteMateRepository {
     }
     
     func stopListen(invitation: Invitation) {
+        print("stop listen")
         let sessionId = invitation.sessionId
         self.ref.child("session").child("\(sessionId)").removeAllObservers()
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultInvitationWaitingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultInvitationWaitingUseCase.swift
@@ -14,7 +14,7 @@ final class DefaultInvitationWaitingUseCase: InvitationWaitingUseCase {
     var repository = DefaultInviteMateRepository()
     var runningSetting: RunningSetting
     var requestSuccess: PublishRelay<Bool> = PublishRelay<Bool>()
-    var requestStatus: PublishRelay<(Bool, Bool)> = PublishRelay<(Bool, Bool)>()
+    var requestStatus: PublishSubject<(Bool, Bool)> = PublishSubject<(Bool, Bool)>()
     var isAccepted: PublishSubject<Bool> = PublishSubject<Bool>()
     var isRejected: PublishSubject<Bool> = PublishSubject<Bool>()
     var isCancelled: PublishSubject<Bool> = PublishSubject<Bool>()
@@ -61,6 +61,7 @@ final class DefaultInvitationWaitingUseCase: InvitationWaitingUseCase {
                 guard let self = self else {
                     return PublishRelay<(Bool, Bool)>.just((false, false))
                 }
+                
                 self.isCancelled.onNext(true)
                 self.repository.stopListen(invitation: self.invitation)
                 return PublishRelay<(Bool, Bool)>.just((false, false))

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultInvitationWaitingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultInvitationWaitingUseCase.swift
@@ -66,7 +66,8 @@ final class DefaultInvitationWaitingUseCase: InvitationWaitingUseCase {
                 self.repository.stopListen(invitation: self.invitation)
                 return PublishRelay<(Bool, Bool)>.just((false, false))
             })
-            .subscribe { (isRecieved, isAccepted) in
+            .subscribe { [weak self] (isRecieved, isAccepted) in
+                guard let self = self else { return }
                 if isRecieved && isAccepted {
                     self.isAccepted.onNext(true)
                     self.repository.stopListen(invitation: self.invitation)

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/InvitationWaitingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/InvitationWaitingUseCase.swift
@@ -13,7 +13,7 @@ import RxSwift
 protocol InvitationWaitingUseCase {
     var runningSetting: RunningSetting { get set }
     var requestSuccess: PublishRelay<Bool> { get set }
-    var requestStatus: PublishRelay<(Bool, Bool)> { get set }
+    var requestStatus: PublishSubject<(Bool, Bool)> { get set }
     var isAccepted: PublishSubject<Bool> { get set }
     var isRejected: PublishSubject<Bool> { get set }
     var isCancelled: PublishSubject<Bool> { get set }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -43,8 +43,7 @@ final class DefaultAppCoordinator: AppCoordinator {
         guard let homeCoordinator = self.findCoordinator(type: .home) as? DefaultHomeCoordinator else { return }
         
         let settingCoordinator = self.findCoordinator(type: .setting) as? DefaultRunningSettingCoordinator ??
-        DefaultRunningSettingCoordinator(self.navigationController)
-        
+        DefaultRunningSettingCoordinator(homeCoordinator.navigationController)
         homeCoordinator.childCoordinators.append(settingCoordinator)
         settingCoordinator.finishDelegate = homeCoordinator
         settingCoordinator.settingFinishDelegate = homeCoordinator

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -40,7 +40,14 @@ final class DefaultAppCoordinator: AppCoordinator {
     }
     
     func showInvitationFlow(with invitation: Invitation) {
-        let settingCoordinator = DefaultRunningSettingCoordinator(self.navigationController)
+        guard let homeCoordinator = self.findCoordinator(type: .home) as? DefaultHomeCoordinator else { return }
+        
+        let settingCoordinator = self.findCoordinator(type: .setting) as? DefaultRunningSettingCoordinator ??
+        DefaultRunningSettingCoordinator(self.navigationController)
+        
+        homeCoordinator.childCoordinators.append(settingCoordinator)
+        settingCoordinator.finishDelegate = homeCoordinator
+        settingCoordinator.settingFinishDelegate = homeCoordinator
         
         let useCase = DefaultInvitationUseCase(invitation: invitation)
         let viewModel = InvitationViewModel(settingCoordinator: settingCoordinator, invitationUseCase: useCase)
@@ -51,9 +58,8 @@ final class DefaultAppCoordinator: AppCoordinator {
         )
         viewController.viewModel = viewModel
         viewController.modalPresentationStyle = .fullScreen
-        self.navigationController.pushViewController(viewController, animated: false)
         
-        childCoordinators.append(settingCoordinator)
+        settingCoordinator.navigationController.pushViewController(viewController, animated: false)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -70,7 +70,7 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     private func startTabCoordinator(of page: TabBarPage, to tabNavigationController: UINavigationController) {
         switch page {
         case .home:
-            let homeCoordinator = DefaultHomeCoorditnator(tabNavigationController)
+            let homeCoordinator = DefaultHomeCoordinator(tabNavigationController)
             homeCoordinator.finishDelegate = self
             self.childCoordinators.append(homeCoordinator)
             homeCoordinator.start()

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/Coordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/Coordinator.swift
@@ -14,6 +14,7 @@ protocol Coordinator: AnyObject {
     var type: CoordinatorType { get }
     func start()
     func finish()
+    func findCoordinator(type: CoordinatorType) -> Coordinator?
     
     init(_ navigationController: UINavigationController)
 }
@@ -22,5 +23,15 @@ extension Coordinator {
     func finish() {
         childCoordinators.removeAll()
         finishDelegate?.coordinatorDidFinish(childCoordinator: self)
+    }
+    
+    func findCoordinator(type: CoordinatorType) -> Coordinator? {
+        for child in self.childCoordinators {
+            if child.type == type {
+                return child
+            }
+            return child.findCoordinator(type: type)
+        }
+        return nil
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -48,10 +48,9 @@ extension DefaultHomeCoordinator: CoordinatorFinishDelegate {
         print("finish")
         self.childCoordinators = self.childCoordinators
             .filter({ $0.type != childCoordinator.type })
-        print("Coord", self.navigationController)
-        print(self.navigationController.viewControllers.count)
-        self.navigationController.viewControllers = []
-        print(self.navigationController.viewControllers.count)
+
+        childCoordinator.navigationController.popToRootViewController(animated: true)
+
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -45,13 +45,9 @@ final class DefaultHomeCoordinator: HomeCoordinator {
 
 extension DefaultHomeCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
-        print("finish")
         self.childCoordinators = self.childCoordinators
             .filter({ $0.type != childCoordinator.type })
-        print("Coord", self.navigationController)
-        print(self.navigationController.viewControllers.count)
-        self.navigationController.viewControllers = []
-        print(self.navigationController.viewControllers.count)
+        childCoordinator.navigationController.popToRootViewController(animated: true)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DefaultHomeCoorditnator: HomeCoordinator {
+final class DefaultHomeCoordinator: HomeCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
     var homeViewController: HomeViewController
@@ -43,15 +43,19 @@ final class DefaultHomeCoorditnator: HomeCoordinator {
     }
 }
 
-extension DefaultHomeCoorditnator: CoordinatorFinishDelegate {
+extension DefaultHomeCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
+        print("finish")
         self.childCoordinators = self.childCoordinators
             .filter({ $0.type != childCoordinator.type })
-        self.navigationController.popToRootViewController(animated: true)
+        print("Coord", self.navigationController)
+        print(self.navigationController.viewControllers.count)
+        self.navigationController.viewControllers = []
+        print(self.navigationController.viewControllers.count)
     }
 }
 
-extension DefaultHomeCoorditnator: SettingCoordinatorDidFinishDelegate {
+extension DefaultHomeCoordinator: SettingCoordinatorDidFinishDelegate {
     func settingCoordinatorDidFinish(with runningSettingData: RunningSetting) {
         self.showRunningFlow(with: runningSettingData)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -63,7 +63,9 @@ private extension InvitationViewController {
         
         self.invitationView.rejectButton.rx.tap
             .subscribe(onNext: {
+                print("VC", self.navigationController)
                 self.viewModel?.rejectButtonDidTap()
+                // self.navigationController?.popToRootViewController(animated: true)
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/InvitationViewController.swift
@@ -63,9 +63,7 @@ private extension InvitationViewController {
         
         self.invitationView.rejectButton.rx.tap
             .subscribe(onNext: {
-                print("VC", self.navigationController)
                 self.viewModel?.rejectButtonDidTap()
-                // self.navigationController?.popToRootViewController(animated: true)
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/InvitationViewModel.swift
@@ -68,7 +68,6 @@ final class InvitationViewModel {
             .debug()
             .subscribe { success in
                 if success.element ?? false {
-                    // TODO: settingCoordinator의 finishDelegate 설정
                     self.settingCoordinator?.finish()
                 }
             }


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 초대 대기 타임아웃 버그 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 기존에는 달리기가 수락되어도 일정 시간이 지나면 대기 시간이 지나 취소되었다고 알러트가 표시되는 버그가 있었습니다. 수락 상태값을 담는 프로퍼티의 타입을 PublishRelay에서 PublishSubject으로 바꾸고, 레포지토리에서도 Observable을 반환하도록 수정하여 해결하였습니다.

이전 PR에서 브랜치를 이어서 작업했더니 작업 내역이 한 눈에 들어오지 않네요ㅜㅜ 다음 파일에만 수정사항이 있으니 참고 부탁드려요!

/Data/Repository/Home/DefaultInviteMateRepository.swift
/Domain/UseCase/Home/DefaultInvitationWaitingUseCase.swift
/Domain/UseCase/Home/Protocol/InvitationWaitingUseCase.swift

- 특이 사항 2

<br/><br/>
