### PR TITLE
결과데이터 파이어베이스에 저장

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */; };
 		B02FCAE2273BDA8A001657FE /* RunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */; };
 		B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */; };
+		B03A563C2745E6FA00C5C2F2 /* FirebaseServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03A563B2745E6FA00C5C2F2 /* FirebaseServiceError.swift */; };
 		B03F2F38273CB85200BD25D7 /* RunningSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */; };
 		B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */; };
 		B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */; };
@@ -366,6 +367,7 @@
 		B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinatorDidFinishDelegate.swift; sourceTree = "<group>"; };
 		B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningCoordinator.swift; sourceTree = "<group>"; };
 		B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningCoordinator.swift; sourceTree = "<group>"; };
+		B03A563B2745E6FA00C5C2F2 /* FirebaseServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseServiceError.swift; sourceTree = "<group>"; };
 		B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewModel.swift; sourceTree = "<group>"; };
 		B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningPreparationUseCase.swift; sourceTree = "<group>"; };
 		B04A86BB2732D4D800F46069 /* RunningPreparationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunningPreparationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -892,6 +894,7 @@
 		5EFABAEB272FB51100686D08 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				B03A563A2745E4D900C5C2F2 /* Error */,
 				AEA8C560273E50AC0066E0E1 /* Service */,
 				B06E6DC527326C3C00D1EDAC /* Constant */,
 				5E32DC6327310035000E525B /* PropertyWrapper */,
@@ -1094,6 +1097,14 @@
 				B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */,
 			);
 			path = SingleRunningTests;
+			sourceTree = "<group>";
+		};
+		B03A563A2745E4D900C5C2F2 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				B03A563B2745E6FA00C5C2F2 /* FirebaseServiceError.swift */,
+			);
+			path = Error;
 			sourceTree = "<group>";
 		};
 		B04A86BC2732D4D800F46069 /* RunningPreparationTests */ = {
@@ -1633,6 +1644,7 @@
 				B0A0DA222744A126004DDC71 /* Region.swift in Sources */,
 				B05DEC2B273FBD8E00C0575B /* DefaultLocationService.swift in Sources */,
 				B0628B8D27397415004FAB0F /* DistanceSettingUseCase.swift in Sources */,
+				B03A563C2745E6FA00C5C2F2 /* FirebaseServiceError.swift in Sources */,
 				5E4675F2274139E20047D098 /* PickerTextField.swift in Sources */,
 				AE6A6F35272FC170005A3A5C /* DistanceSettingViewController.swift in Sources */,
 				3D2C2198273CF0D700D00C68 /* User.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		B02FCAE2273BDA8A001657FE /* RunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */; };
 		B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */; };
 		B03A563C2745E6FA00C5C2F2 /* FirebaseServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03A563B2745E6FA00C5C2F2 /* FirebaseServiceError.swift */; };
+		B03A563E2745E7EF00C5C2F2 /* FirebaseCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03A563D2745E7EF00C5C2F2 /* FirebaseCollection.swift */; };
 		B03F2F38273CB85200BD25D7 /* RunningSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B96273A17E8004FAB0F /* RunningSettingCoordinator.swift */; };
 		B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */; };
 		B04A86B62732C15900F46069 /* DefaultRunningPreparationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */; };
@@ -368,6 +369,7 @@
 		B02FCAE1273BDA8A001657FE /* RunningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningCoordinator.swift; sourceTree = "<group>"; };
 		B02FCAE3273BDB91001657FE /* DefaultRunningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningCoordinator.swift; sourceTree = "<group>"; };
 		B03A563B2745E6FA00C5C2F2 /* FirebaseServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseServiceError.swift; sourceTree = "<group>"; };
+		B03A563D2745E7EF00C5C2F2 /* FirebaseCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseCollection.swift; sourceTree = "<group>"; };
 		B04A86B32732C09D00F46069 /* RunningPreparationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewModel.swift; sourceTree = "<group>"; };
 		B04A86B52732C15900F46069 /* DefaultRunningPreparationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRunningPreparationUseCase.swift; sourceTree = "<group>"; };
 		B04A86BB2732D4D800F46069 /* RunningPreparationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunningPreparationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1168,6 +1170,7 @@
 				3D2C2197273CF0D700D00C68 /* User.swift */,
 				B0A0DA1F27441AD5004DDC71 /* LocationAuthorizationStatus.swift */,
 				5E5E555227450662002FE126 /* UserDefaultKey.swift */,
+				B03A563D2745E7EF00C5C2F2 /* FirebaseCollection.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -1702,6 +1705,7 @@
 				5E32DC6827314764000E525B /* RoundedButton.swift in Sources */,
 				AE3D14852737C5E600D4A186 /* Mets.swift in Sources */,
 				AE77C1FD274400AE005EDEE0 /* MateRepository.swift in Sources */,
+				B03A563E2745E7EF00C5C2F2 /* FirebaseCollection.swift in Sources */,
 				5EBDA072273B629800FC9707 /* MyResultView.swift in Sources */,
 				B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */,
 				AE3D1492273A5F5900D4A186 /* MateTableViewCell.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -9,19 +9,23 @@ import Foundation
 
 import RxSwift
 
+enum FirebaseServiceError: Error {
+    case nilDataError
+}
+
 final class DefaultRunningResultRepository: RunningResultRepository {
     let networkService = DefaultFireStoreNetworkService()
     
-    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Bool> {
-        guard let runningResult = runningResult else { return Observable.of(false) }
+    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void> {
+        guard let runningResult = runningResult else {
+            return Observable.error(FirebaseServiceError.nilDataError)
+        }
         
-        let dto = RunningResultDTO(from: runningResult)
-        
-        return self.networkService.updateArray(
-            append: dto,
-            collection: "User",
+        return self.networkService.writeDTO(
+            RunningResultDTO(from: runningResult),
+            collection: "RunningResult",
             document: "hunihun956",
-            array: "records"
+            key: runningResult.dateTime?.fullDateTimeString() ?? Date().fullDateTimeString()
         )
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -19,7 +19,7 @@ final class DefaultRunningResultRepository: RunningResultRepository {
         
         return self.networkService.writeDTO(
             RunningResultDTO(from: runningResult),
-            collection: "RunningResult",
+            collection: FirebaseCollection.runningResult,
             document: "hunihun956",
             key: runningResult.dateTime?.fullDateTimeString() ?? Date().fullDateTimeString()
         )

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -9,10 +9,6 @@ import Foundation
 
 import RxSwift
 
-enum FirebaseServiceError: Error {
-    case nilDataError
-}
-
 final class DefaultRunningResultRepository: RunningResultRepository {
     let networkService = DefaultFireStoreNetworkService()
     

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningResultRepository.swift
@@ -10,5 +10,5 @@ import Foundation
 import RxSwift
 
 protocol RunningResultRepository {
-    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Bool>
+    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void> 
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/DefaultResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/DefaultResultUseCase.swift
@@ -18,7 +18,9 @@ final class DefaultRunningResultUseCase: RunningResultUseCase {
         self.runningResult = runningResult
     }
     
-    func saveRunningResult() -> Observable<Bool> {
+    func saveRunningResult() -> Observable<Void> {
         return self.runningResultRepository.saveRunningResult(runningResult)
+            .timeout(.seconds(2), scheduler: ConcurrentDispatchQueueScheduler.init(qos: .background))
+            .retry(3)
     }
  }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
@@ -11,5 +11,5 @@ import RxSwift
 
 protocol RunningResultUseCase {
     var runningResult: RunningResult { get set }
-    func saveRunningResult() -> Observable<Bool>
+    func saveRunningResult() -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Network/DefaultFireStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultFireStoreNetworkService.swift
@@ -26,7 +26,11 @@ final class DefaultFireStoreNetworkService: FireStoreNetworkService {
             do {
                 let newElement = try Firestore.Encoder().encode(dto)
                 documentReference.setData([key: newElement], merge: true) { error in
-                    if let error = error { emitter.onError(error) } else { emitter.onNext(()) }
+                    if let error = error {
+                        emitter.onError(error)
+                    } else {
+                        emitter.onNext(())
+                    }
                     emitter.onCompleted()
                 }
             } catch {

--- a/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
@@ -9,6 +9,10 @@ import Foundation
 
 import RxSwift
 
+enum FirebaseServiceError: Error {
+    case nilDataError
+}
+
 protocol FireStoreNetworkService {
     func fetchData<T>(
         type: T.Type,

--- a/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
@@ -9,10 +9,6 @@ import Foundation
 
 import RxSwift
 
-enum FirebaseServiceError: Error {
-    case nilDataError
-}
-
 protocol FireStoreNetworkService {
     func fetchData<T>(
         type: T.Type,

--- a/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/FireStoreNetworkService.swift
@@ -17,6 +17,13 @@ protocol FireStoreNetworkService {
         field: String
     ) -> Observable<T>
     
+    func writeDTO<T: Codable>(
+        _ dto: T,
+        collection: String,
+        document: String,
+        key: String
+    ) -> Observable<Void>
+    
     func documentDoesExist(collection: String, document: String) -> Observable<Bool>
     func writeData(collection: String, document: String, data: [String: Any]) -> Observable<Bool>
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningResultViewController.swift
@@ -255,7 +255,6 @@ private extension RunningResultViewController {
     func bindAlert(with viewModelOutput: RunningResultViewModel.Output) {
         viewModelOutput.saveFailAlertShouldShow
             .asDriver(onErrorJustReturn: false)
-            .debug()
             .drive(onNext: { [weak self] _ in
                 self?.showAlert()
             })
@@ -282,7 +281,6 @@ private extension RunningResultViewController {
     func bindLabels(with viewModelOutput: RunningResultViewModel.Output) {
         viewModelOutput.dateTime
             .asDriver(onErrorJustReturn: "Error")
-            .debug()
             .drive(self.dateTimeLabel.rx.text)
             .disposed(by: self.disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -72,12 +72,8 @@ final class RunningResultViewModel {
     
     private func closeButtonDidTap(viewModelOutput: Output, disposeBag: DisposeBag) {
         self.runningResultUseCase.saveRunningResult()
-            .subscribe(onNext: { [weak self] isSaveSuccess in
-                if isSaveSuccess {
-                    self?.coordinator?.finish()
-                } else {
-                    viewModelOutput.saveFailAlertShouldShow.accept(true)
-                }
+            .subscribe(onNext: { [weak self] _ in
+                self?.coordinator?.finish()
             }, onError: { _ in
                 viewModelOutput.saveFailAlertShouldShow.accept(true)
             })

--- a/MateRunner/MateRunner/Util/Constant/FirebaseCollection.swift
+++ b/MateRunner/MateRunner/Util/Constant/FirebaseCollection.swift
@@ -1,0 +1,12 @@
+//
+//  FirebaseCollection.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/18.
+//
+
+import Foundation
+
+enum FirebaseCollection {
+    static let runningResult = "RunningResult"
+}

--- a/MateRunner/MateRunner/Util/Error/FirebaseServiceError.swift
+++ b/MateRunner/MateRunner/Util/Error/FirebaseServiceError.swift
@@ -1,0 +1,12 @@
+//
+//  FirebaseNetworkError.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/18.
+//
+
+import Foundation
+
+enum FirebaseServiceError: Error {
+    case nilDataError
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #132 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 결과 레파지토리 수정
- [x] 기존 파이어베이스 서비스 수정

<img width="1229" alt="스크린샷 2021-11-17 오후 9 04 36" src="https://user-images.githubusercontent.com/46087477/142197414-ed763239-4065-4ba9-bcbb-1a129feba261.png">


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 파이어베이스 서비스 수정
기존에 민지님께서 만들어주신 저장 코드가 잘 동작해서 크게 수정할 부분은 없었습니다. 다만 기존에는 저장 성공시에 Observable에 true를 방출하고 있는데, false를 방출하는 경우가 nil데이터를 받을 때 말고는 없는 것 같아서 Observable<Void>로 바꾸고 에러 상황을 모두 Observable.error로 처리하도록 변경했습니다. 

- 정해야하는 것
현재 데이터가 RunningResult콜렉션 -> 닉네임 다큐먼트 에 저장되는데 어떻게 저장할지 아직 명확하게 정해지지 않은 것 같습니다. 지금은 운동을 시작한 날짜를 키로 잡아서 `[시작날짜문자열 : 결과딕셔너리]` 형태로 다큐먼트안에 저장하게 해두었습니다. 달리기 세션 아이디를 사용한다면 혼자달리기의 경우에는 유즈케이스에서 만들어주어야할 것 같은데 그럼 RunningResult 모델에 프로퍼티를 추가해야할 것 같습니다. 
-> 키는 지금처럼 시작날짜로, 세션ID는 함께 달리기 모드에서 만들기

- 닉네임 알아오기 
지금은 다큐먼트 아이디로 쓸 닉네임을 고정값으로 지정해두었습니다. userdefault 에 대한 레파지토리가 생기면 유즈케이스에서 사용자 닉네임을 읽어서 넘겨주어야할 것 같아요. 차후에 유저디폴트에 대한 기능이 완성되면 추가하겠습니다.

- 파이어베이스 서비스 에러 
서비스를 사용할 때 발생하는 에러를 enum에 정의해두었는데 그대로 사용해도 괜찮을까요? 지금은 파이어베이스에 저장하고자 하는 데이터가 nil일 때 스트림에 error를 반환하기위한 목적으로 사용하고 있습니다. 의논없이 만든거라 파일로 따로 빼두지는 않았습니다. 의견있으시면 알려주세요!
-> enum 만드는 걸로 결정

- 콜렉션 이름 상수로 관리
다큐먼트 이름은 닉네임을 사용하기 때문에 동적으로 변하는데 콜렉션 이름은 기능에 따라 정해져서 enum으로 따로 모아두어도 괜찮을 것 같다는 생각이 들었어요! 지금은 매직넘버로 되어있습니다.
-> 이것도 enum으로 

- 빈 값 관리
지금은 emoji같은 데이터가 파이어베이스에 빈 배열로 올라가게 되는데 이번주에 빈 값은 안올리자는 이야기가 있었어서요. 저도 NoSQL에서는 없으면 안올리는게 맞다고 생각하는데 DTO에서 Firebase용 데이터로 변환할 때의 처리를 추가해주어야할 것 같네요..그냥 빈 배열을 올리는 것도 방법인것 같아요..
-> 빈 값도 그대로 올리는 것으로 결정

<br/><br/>
