### PR TITLE
결과 화면 진입 시 결과 저장 구현

### DIFF
--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -10,8 +10,13 @@ import Foundation
 import RxSwift
 
 final class DefaultRunningResultRepository: RunningResultRepository {
-    let networkService = DefaultFireStoreNetworkService()
-    let userDefaultPersistence = DefaultUserDefaultPersistence()
+    let fireStoreService: FireStoreNetworkService
+    let userDefaultPersistence: UserDefaultPersistence
+    
+    init(fireStoreService: FireStoreNetworkService, userDefaultsPersistence: UserDefaultPersistence) {
+        self.fireStoreService = fireStoreService
+        self.userDefaultPersistence = userDefaultsPersistence
+    }
     
     private func fetchUserNickname() -> String? {
         return self.userDefaultPersistence.getStringValue(key: .nickname)
@@ -27,7 +32,7 @@ final class DefaultRunningResultRepository: RunningResultRepository {
             return Observable.error(FirebaseServiceError.userNicknameNotExistsError)
         }
         
-        return self.networkService.writeDTO(
+        return self.fireStoreService.writeDTO(
             RunningResultDTO(from: runningResult),
             collection: FirebaseCollection.runningResult,
             document: userNickName,

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -11,15 +11,13 @@ import RxSwift
 
 final class DefaultRunningResultRepository: RunningResultRepository {
     let fireStoreService: FireStoreNetworkService
-    let userDefaultPersistence: UserDefaultPersistence
     
-    init(fireStoreService: FireStoreNetworkService, userDefaultsPersistence: UserDefaultPersistence) {
+    init(fireStoreService: FireStoreNetworkService) {
         self.fireStoreService = fireStoreService
-        self.userDefaultPersistence = userDefaultsPersistence
     }
     
     private func fetchUserNickname() -> String? {
-        return self.userDefaultPersistence.getStringValue(key: .nickname)
+        return UserDefaults.standard.string(forKey: UserDefaultKey.nickname.rawValue)
     }
     
     func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void> {

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningResultRepository.swift
@@ -11,17 +11,27 @@ import RxSwift
 
 final class DefaultRunningResultRepository: RunningResultRepository {
     let networkService = DefaultFireStoreNetworkService()
+    let userDefaultPersistence = DefaultUserDefaultPersistence()
+    
+    private func fetchUserNickname() -> String? {
+        return self.userDefaultPersistence.getStringValue(key: .nickname)
+    }
     
     func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void> {
-        guard let runningResult = runningResult else {
+        guard let runningResult = runningResult,
+              let startDateTime = runningResult.dateTime else {
             return Observable.error(FirebaseServiceError.nilDataError)
+        }
+
+        guard let userNickName = self.fetchUserNickname() else {
+            return Observable.error(FirebaseServiceError.userNicknameNotExistsError)
         }
         
         return self.networkService.writeDTO(
             RunningResultDTO(from: runningResult),
             collection: FirebaseCollection.runningResult,
-            document: "hunihun956",
-            key: runningResult.dateTime?.fullDateTimeString() ?? Date().fullDateTimeString()
+            document: userNickName,
+            key: startDateTime.fullDateTimeString()
         )
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningResultRepository.swift
@@ -10,5 +10,6 @@ import Foundation
 import RxSwift
 
 protocol RunningResultRepository {
-    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void> 
+    func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void>
+    init(fireStoreService: FireStoreNetworkService, userDefaultsPersistence: UserDefaultPersistence)
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningResultRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningResultRepository.swift
@@ -11,5 +11,5 @@ import RxSwift
 
 protocol RunningResultRepository {
     func saveRunningResult(_ runningResult: RunningResult?) -> Observable<Void>
-    init(fireStoreService: FireStoreNetworkService, userDefaultsPersistence: UserDefaultPersistence)
+    init(fireStoreService: FireStoreNetworkService)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -35,7 +35,10 @@ final class DefaultRunningCoordinator: RunningCoordinator {
         singleRunningResultViewController.viewModel = RunningResultViewModel(
             coordinator: self,
             runningResultUseCase: DefaultRunningResultUseCase(
-                runningResultRepository: DefaultRunningResultRepository(),
+                runningResultRepository: DefaultRunningResultRepository(
+                    fireStoreService: DefaultFireStoreNetworkService(),
+                    userDefaultsPersistence: DefaultUserDefaultPersistence()
+                ),
                 runningResult: runningResult
             )
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -36,8 +36,7 @@ final class DefaultRunningCoordinator: RunningCoordinator {
             coordinator: self,
             runningResultUseCase: DefaultRunningResultUseCase(
                 runningResultRepository: DefaultRunningResultRepository(
-                    fireStoreService: DefaultFireStoreNetworkService(),
-                    userDefaultsPersistence: DefaultUserDefaultPersistence()
+                    fireStoreService: DefaultFireStoreNetworkService()
                 ),
                 runningResult: runningResult
             )

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -37,25 +37,7 @@ final class RunningResultViewModel {
     }
     
     func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
-        let runningResult = self.runningResultUseCase.runningResult
-        
-        let dateTime = runningResult.dateTime ?? Date()
-        let mode = runningResult.mode ?? .single
-        let coordinates = self.pointsToCoordinate2D(from: runningResult.points)
-        
-        let output = Output(
-            dateTime: BehaviorRelay(value: dateTime.fullDateTimeString()),
-            dayOfWeekAndTime: BehaviorRelay(value: dateTime.korDayOfTheWeekAndTimeString()),
-            mode: BehaviorRelay(value: mode.title),
-            distance: BehaviorRelay(value: self.convertToKilometerText(
-                from: runningResult.userElapsedDistance
-            )),
-            calorie: BehaviorRelay(value: String(Int(runningResult.calorie))),
-            time: BehaviorRelay(value: Date.secondsToTimeString(from: runningResult.userElapsedTime)),
-            points: BehaviorRelay(value: coordinates),
-            region: BehaviorRelay(value: self.calculateRegion(from: coordinates)),
-            saveFailAlertShouldShow: PublishRelay<Bool>()
-        )
+        let output = self.createViewModelOutput()
         
         input.viewDidLoadEvent.subscribe(
             onNext: { [weak self] _ in
@@ -74,6 +56,28 @@ final class RunningResultViewModel {
     
     func alertConfirmButtonDidTap() {
         self.coordinator?.finish()
+    }
+    
+    private func createViewModelOutput() -> Output {
+        let runningResult = self.runningResultUseCase.runningResult
+        
+        let dateTime = runningResult.dateTime ?? Date()
+        let mode = runningResult.mode ?? .single
+        let coordinates = self.pointsToCoordinate2D(from: runningResult.points)
+        
+        return Output(
+            dateTime: BehaviorRelay(value: dateTime.fullDateTimeString()),
+            dayOfWeekAndTime: BehaviorRelay(value: dateTime.korDayOfTheWeekAndTimeString()),
+            mode: BehaviorRelay(value: mode.title),
+            distance: BehaviorRelay(value: self.convertToKilometerText(
+                from: runningResult.userElapsedDistance
+            )),
+            calorie: BehaviorRelay(value: String(Int(runningResult.calorie))),
+            time: BehaviorRelay(value: Date.secondsToTimeString(from: runningResult.userElapsedTime)),
+            points: BehaviorRelay(value: coordinates),
+            region: BehaviorRelay(value: self.calculateRegion(from: coordinates)),
+            saveFailAlertShouldShow: PublishRelay<Bool>()
+        )
     }
     
     private func requestSavingResult(viewModelOutput: Output, disposeBag: DisposeBag) {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningResultViewModel.swift
@@ -25,41 +25,47 @@ final class RunningResultViewModel {
     }
     
     struct Output {
-        var dateTime = BehaviorRelay<String>(value: "")
-        var dayOfWeekAndTime = BehaviorRelay<String>(value: "")
-        var mode = BehaviorRelay<String>(value: "")
-        var distance = BehaviorRelay<String>(value: "")
-        var calorie = BehaviorRelay<String>(value: "")
-        var time = BehaviorRelay<String>(value: "")
-        var points = BehaviorRelay<[CLLocationCoordinate2D]>(value: [])
-        var region = BehaviorRelay<Region>(value: Region())
-        var saveFailAlertShouldShow = PublishRelay<Bool>()
+        var dateTime: BehaviorRelay<String>
+        var dayOfWeekAndTime: BehaviorRelay<String>
+        var mode: BehaviorRelay<String>
+        var distance: BehaviorRelay<String>
+        var calorie: BehaviorRelay<String>
+        var time: BehaviorRelay<String>
+        var points: BehaviorRelay<[CLLocationCoordinate2D]>
+        var region: BehaviorRelay<Region>
+        var saveFailAlertShouldShow: PublishRelay<Bool>
     }
     
     func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
         let runningResult = self.runningResultUseCase.runningResult
-        let output = Output()
         
-        guard let dateTime = runningResult.dateTime,
-              let mode = runningResult.mode else { return Output() }
+        let dateTime = runningResult.dateTime ?? Date()
+        let mode = runningResult.mode ?? .single
         let coordinates = self.pointsToCoordinate2D(from: runningResult.points)
         
-        input.viewDidLoadEvent.subscribe(onNext: { [weak self] _ in
-            guard let self = self else { return }
-            output.calorie.accept(String(Int(runningResult.calorie)))
-            output.dateTime.accept(dateTime.fullDateTimeString())
-            output.dayOfWeekAndTime.accept(dateTime.korDayOfTheWeekAndTimeString())
-            output.mode.accept(mode.title)
-            output.distance.accept(self.convertToKilometerText(from: runningResult.userElapsedDistance))
-            output.time.accept(Date.secondsToTimeString(from: runningResult.userElapsedTime))
-            output.points.accept(coordinates)
-            output.region.accept(self.calculateRegion(from: coordinates))
-        })
+        let output = Output(
+            dateTime: BehaviorRelay(value: dateTime.fullDateTimeString()),
+            dayOfWeekAndTime: BehaviorRelay(value: dateTime.korDayOfTheWeekAndTimeString()),
+            mode: BehaviorRelay(value: mode.title),
+            distance: BehaviorRelay(value: self.convertToKilometerText(
+                from: runningResult.userElapsedDistance
+            )),
+            calorie: BehaviorRelay(value: String(Int(runningResult.calorie))),
+            time: BehaviorRelay(value: Date.secondsToTimeString(from: runningResult.userElapsedTime)),
+            points: BehaviorRelay(value: coordinates),
+            region: BehaviorRelay(value: self.calculateRegion(from: coordinates)),
+            saveFailAlertShouldShow: PublishRelay<Bool>()
+        )
+        
+        input.viewDidLoadEvent.subscribe(
+            onNext: { [weak self] _ in
+                self?.requestSavingResult(viewModelOutput: output, disposeBag: disposeBag)
+            })
             .disposed(by: disposeBag)
         
         input.closeButtonDidTapEvent.subscribe(
             onNext: { [weak self] _ in
-                self?.closeButtonDidTap(viewModelOutput: output, disposeBag: disposeBag)
+                self?.coordinator?.finish()
             })
             .disposed(by: disposeBag)
         
@@ -70,16 +76,14 @@ final class RunningResultViewModel {
         self.coordinator?.finish()
     }
     
-    private func closeButtonDidTap(viewModelOutput: Output, disposeBag: DisposeBag) {
+    private func requestSavingResult(viewModelOutput: Output, disposeBag: DisposeBag) {
         self.runningResultUseCase.saveRunningResult()
-            .subscribe(onNext: { [weak self] _ in
-                self?.coordinator?.finish()
-            }, onError: { _ in
+            .subscribe(onError: { _ in
                 viewModelOutput.saveFailAlertShouldShow.accept(true)
             })
             .disposed(by: disposeBag)
     }
-    
+  
     private func convertToKilometerText(from value: Double) -> String {
         return String(format: "%.2f", round(value / 10) / 100)
     }

--- a/MateRunner/MateRunner/Util/Error/FirebaseServiceError.swift
+++ b/MateRunner/MateRunner/Util/Error/FirebaseServiceError.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum FirebaseServiceError: Error {
-    case nilDataError
+    case nilDataError, userNicknameNotExistsError
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #151 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 닫기 버튼을 누르지 않아도 결과화면 진입 시에 데이터를 저장하도록 수정
- [x] 뷰모델 리팩토링 


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- UserDefaultsKey 
키에 대한 enum이 읽어서 문자열로 사용하는 용도로만 쓰일 것 같은데 아래처럼 사용하는건 어떨까요? 
```swift
enum UserDefaultsKey: String {
    static let nickname = "nickname"
    static let isLoggedIn = "isLoggedIn"
}

// UserDefaultsKey.nickname
```

<br/><br/>
