### PR TITLE
결과화면 뷰 리팩토링

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		B0CB4D212742C7E0005E4CD1 /* DefaultCoreMotionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D202742C7E0005E4CD1 /* DefaultCoreMotionService.swift */; };
 		B0CB4D232742C85B005E4CD1 /* DefaultRxTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D222742C85B005E4CD1 /* DefaultRxTimerService.swift */; };
 		B0CF5C8327480CD1002217F6 /* RunningResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF5C8227480CD1002217F6 /* RunningResultViewController.swift */; };
+		B0CF5C852748276F002217F6 /* RaceRunningResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF5C842748276F002217F6 /* RaceRunningResultViewModel.swift */; };
 		B0E72E0C272FCDEE009E5635 /* NotoSansKR-light.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F49272FCDA2005A3A5C /* NotoSansKR-light.otf */; };
 		B0E72E0D272FCDEE009E5635 /* NotoSansKR-regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F47272FCDA2005A3A5C /* NotoSansKR-regular.otf */; };
 		B0E72E0E272FCDEE009E5635 /* NotoSansKR-thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F4A272FCDA2005A3A5C /* NotoSansKR-thin.otf */; };
@@ -435,6 +436,7 @@
 		B0CB4D202742C7E0005E4CD1 /* DefaultCoreMotionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCoreMotionService.swift; sourceTree = "<group>"; };
 		B0CB4D222742C85B005E4CD1 /* DefaultRxTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRxTimerService.swift; sourceTree = "<group>"; };
 		B0CF5C8227480CD1002217F6 /* RunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultViewController.swift; sourceTree = "<group>"; };
+		B0CF5C842748276F002217F6 /* RaceRunningResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResultViewModel.swift; sourceTree = "<group>"; };
 		B0E72E14272FD2CC009E5635 /* DistanceSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceSettingViewModel.swift; sourceTree = "<group>"; };
 		B0F53284273A29EA005A3F11 /* TabBarPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPage.swift; sourceTree = "<group>"; };
 		B0F53288273A32E0005A3F11 /* CoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorType.swift; sourceTree = "<group>"; };
@@ -1303,6 +1305,7 @@
 			isa = PBXGroup;
 			children = (
 				3DF4C858273104B500A4B229 /* SingleRunningResultViewModel.swift */,
+				B0CF5C842748276F002217F6 /* RaceRunningResultViewModel.swift */,
 			);
 			path = ResultViewModel;
 			sourceTree = "<group>";
@@ -1788,6 +1791,7 @@
 				5E918A14272BD76D00B57888 /* MateRunner.xcdatamodeld in Sources */,
 				3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */,
 				5EBDA07C273BC67D00FC9707 /* CancelRunningResultViewController.swift in Sources */,
+				B0CF5C852748276F002217F6 /* RaceRunningResultViewModel.swift in Sources */,
 				B00133C6273D94B3004E0D1F /* DefaultMapUseCase.swift in Sources */,
 				3DF4C86927376B7B00A4B229 /* FireStoreNetworkService.swift in Sources */,
 				3DF4C859273104B500A4B229 /* SingleRunningResultViewModel.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -41,7 +41,7 @@
 		3DF4C86927376B7B00A4B229 /* FireStoreNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86827376B7B00A4B229 /* FireStoreNetworkService.swift */; };
 		3DF4C86C27376C9A00A4B229 /* RunningResultRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86B27376C9A00A4B229 /* RunningResultRepository.swift */; };
 		3DF4C86F27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C86E27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift */; };
-		3DF6D07E27301F1100991DC3 /* RunningResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */; };
+		3DF6D07E27301F1100991DC3 /* SingleRunningResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF6D07D27301F1100991DC3 /* SingleRunningResultViewController.swift */; };
 		3DFD08A82733A39300B46479 /* RunningResultDTO+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08A72733A39300B46479 /* RunningResultDTO+Mapping.swift */; };
 		3DFD08B627391AE300B46479 /* RunningRealTimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08B527391AE300B46479 /* RunningRealTimeData.swift */; };
 		3DFD08B827391BDA00B46479 /* RunningData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFD08B727391BDA00B46479 /* RunningData.swift */; };
@@ -192,6 +192,7 @@
 		B0CB4D1E2742B465005E4CD1 /* RxTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D1D2742B465005E4CD1 /* RxTimerService.swift */; };
 		B0CB4D212742C7E0005E4CD1 /* DefaultCoreMotionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D202742C7E0005E4CD1 /* DefaultCoreMotionService.swift */; };
 		B0CB4D232742C85B005E4CD1 /* DefaultRxTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D222742C85B005E4CD1 /* DefaultRxTimerService.swift */; };
+		B0CF5C8327480CD1002217F6 /* RunningResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CF5C8227480CD1002217F6 /* RunningResultViewController.swift */; };
 		B0E72E0C272FCDEE009E5635 /* NotoSansKR-light.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F49272FCDA2005A3A5C /* NotoSansKR-light.otf */; };
 		B0E72E0D272FCDEE009E5635 /* NotoSansKR-regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F47272FCDA2005A3A5C /* NotoSansKR-regular.otf */; };
 		B0E72E0E272FCDEE009E5635 /* NotoSansKR-thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F4A272FCDA2005A3A5C /* NotoSansKR-thin.otf */; };
@@ -274,7 +275,7 @@
 		3DF4C86827376B7B00A4B229 /* FireStoreNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireStoreNetworkService.swift; sourceTree = "<group>"; };
 		3DF4C86B27376C9A00A4B229 /* RunningResultRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultRepository.swift; sourceTree = "<group>"; };
 		3DF4C86E27376CDA00A4B229 /* DefaultFireStoreNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFireStoreNetworkService.swift; sourceTree = "<group>"; };
-		3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultViewController.swift; sourceTree = "<group>"; };
+		3DF6D07D27301F1100991DC3 /* SingleRunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleRunningResultViewController.swift; sourceTree = "<group>"; };
 		3DFD08A72733A39300B46479 /* RunningResultDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RunningResultDTO+Mapping.swift"; sourceTree = "<group>"; };
 		3DFD08B527391AE300B46479 /* RunningRealTimeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRealTimeData.swift; sourceTree = "<group>"; };
 		3DFD08B727391BDA00B46479 /* RunningData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningData.swift; sourceTree = "<group>"; };
@@ -433,6 +434,7 @@
 		B0CB4D1D2742B465005E4CD1 /* RxTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxTimerService.swift; sourceTree = "<group>"; };
 		B0CB4D202742C7E0005E4CD1 /* DefaultCoreMotionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCoreMotionService.swift; sourceTree = "<group>"; };
 		B0CB4D222742C85B005E4CD1 /* DefaultRxTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRxTimerService.swift; sourceTree = "<group>"; };
+		B0CF5C8227480CD1002217F6 /* RunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultViewController.swift; sourceTree = "<group>"; };
 		B0E72E14272FD2CC009E5635 /* DistanceSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceSettingViewModel.swift; sourceTree = "<group>"; };
 		B0F53284273A29EA005A3F11 /* TabBarPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPage.swift; sourceTree = "<group>"; };
 		B0F53288273A32E0005A3F11 /* CoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorType.swift; sourceTree = "<group>"; };
@@ -1264,10 +1266,11 @@
 		B06612D12747499B00D6D970 /* ResultViewController */ = {
 			isa = PBXGroup;
 			children = (
-				3DF6D07D27301F1100991DC3 /* RunningResultViewController.swift */,
+				3DF6D07D27301F1100991DC3 /* SingleRunningResultViewController.swift */,
 				5EBDA073273B893D00FC9707 /* TeamRunningResultViewController.swift */,
 				5EBDA077273BA7ED00FC9707 /* RaceRunningResultViewController.swift */,
 				5EBDA07B273BC67D00FC9707 /* CancelRunningResultViewController.swift */,
+				B0CF5C8227480CD1002217F6 /* RunningResultViewController.swift */,
 			);
 			path = ResultViewController;
 			sourceTree = "<group>";
@@ -1912,7 +1915,7 @@
 				B0A0DA1E27441A0B004DDC71 /* HomeUseCase.swift in Sources */,
 				B0F53298273A5DCA005A3F11 /* DefaultHomeUseCase.swift in Sources */,
 				5E7F1F6F2733A37600F2B662 /* RunningInfoView.swift in Sources */,
-				3DF6D07E27301F1100991DC3 /* RunningResultViewController.swift in Sources */,
+				3DF6D07E27301F1100991DC3 /* SingleRunningResultViewController.swift in Sources */,
 				3DAF2D7B27439F7E00AC5FEA /* InvitationRepository.swift in Sources */,
 				AE6A6F562730E450005A3A5C /* UIView+ShadowEffect.swift in Sources */,
 				B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */,
@@ -1943,6 +1946,7 @@
 				B0F5328B273A3397005A3F11 /* TabBarCoordinator.swift in Sources */,
 				B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */,
 				AE3D148B273A5D8D00D4A186 /* MateHeaderView.swift in Sources */,
+				B0CF5C8327480CD1002217F6 /* RunningResultViewController.swift in Sources */,
 				AE77C20827454011005EDEE0 /* AddMateTableViewCell.swift in Sources */,
 				5E36992427358F7300D2A6F2 /* MapViewController.swift in Sources */,
 				3D62255127461F8F00E4A327 /* InviteMateRepository.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		3DAF2D832743A05700AC5FEA /* InvitationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAF2D822743A05700AC5FEA /* InvitationViewModel.swift */; };
 		3DAF2D8627447CA400AC5FEA /* RealtimeDatabaseNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAF2D8527447CA400AC5FEA /* RealtimeDatabaseNetworkService.swift */; };
 		3DAF2D8827447CD800AC5FEA /* DefaultRealtimeDatabaseNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAF2D8727447CD800AC5FEA /* DefaultRealtimeDatabaseNetworkService.swift */; };
-		3DF4C859273104B500A4B229 /* RunningResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C858273104B500A4B229 /* RunningResultViewModel.swift */; };
+		3DF4C859273104B500A4B229 /* SingleRunningResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C858273104B500A4B229 /* SingleRunningResultViewModel.swift */; };
 		3DF4C85B2731083B00A4B229 /* DefaultResultUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C85A2731083B00A4B229 /* DefaultResultUseCase.swift */; };
 		3DF4C86027355A3E00A4B229 /* Date+Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C85F27355A3E00A4B229 /* Date+Formatter.swift */; };
 		3DF4C8622735841B00A4B229 /* RunningResultUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4C8612735841A00A4B229 /* RunningResultUseCase.swift */; };
@@ -267,7 +267,7 @@
 		3DAF2D8527447CA400AC5FEA /* RealtimeDatabaseNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeDatabaseNetworkService.swift; sourceTree = "<group>"; };
 		3DAF2D8727447CD800AC5FEA /* DefaultRealtimeDatabaseNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRealtimeDatabaseNetworkService.swift; sourceTree = "<group>"; };
 		3DBEE5615C34824573628A82 /* Pods_SingleRunningTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SingleRunningTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3DF4C858273104B500A4B229 /* RunningResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultViewModel.swift; sourceTree = "<group>"; };
+		3DF4C858273104B500A4B229 /* SingleRunningResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleRunningResultViewModel.swift; sourceTree = "<group>"; };
 		3DF4C85A2731083B00A4B229 /* DefaultResultUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultResultUseCase.swift; sourceTree = "<group>"; };
 		3DF4C85F27355A3E00A4B229 /* Date+Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatter.swift"; sourceTree = "<group>"; };
 		3DF4C8612735841A00A4B229 /* RunningResultUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultUseCase.swift; sourceTree = "<group>"; };
@@ -1302,7 +1302,7 @@
 		B06612D427474A3F00D6D970 /* ResultViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				3DF4C858273104B500A4B229 /* RunningResultViewModel.swift */,
+				3DF4C858273104B500A4B229 /* SingleRunningResultViewModel.swift */,
 			);
 			path = ResultViewModel;
 			sourceTree = "<group>";
@@ -1790,7 +1790,7 @@
 				5EBDA07C273BC67D00FC9707 /* CancelRunningResultViewController.swift in Sources */,
 				B00133C6273D94B3004E0D1F /* DefaultMapUseCase.swift in Sources */,
 				3DF4C86927376B7B00A4B229 /* FireStoreNetworkService.swift in Sources */,
-				3DF4C859273104B500A4B229 /* RunningResultViewModel.swift in Sources */,
+				3DF4C859273104B500A4B229 /* SingleRunningResultViewModel.swift in Sources */,
 				B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */,
 				3DF4C8662737687900A4B229 /* DefaultRunningResultRepository.swift in Sources */,
 				5E5E5564274586CD002FE126 /* CalendarCell.swift in Sources */,

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -31,8 +31,8 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     
     func pushRunningResultViewController(with runningResult: RunningResult?) {
         guard let runningResult = runningResult else { return }
-        let singleRunningResultViewController = RunningResultViewController()
-        singleRunningResultViewController.viewModel = RunningResultViewModel(
+        let singleRunningResultViewController = SingleRunningResultViewController()
+        singleRunningResultViewController.viewModel = SingleRunningResultViewModel(
             coordinator: self,
             runningResultUseCase: DefaultRunningResultUseCase(
                 runningResultRepository: DefaultRunningResultRepository(

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/CancelRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/CancelRunningResultViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class CancelRunningResultViewController: RunningResultViewController {
     private lazy var lowerSeparator = self.createSeparator()
     
-    private lazy var titleLabel: UILabel = {
+    private lazy var cancelTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSans(size: 24, family: .medium)
         label.numberOfLines = 2
@@ -20,26 +20,25 @@ final class CancelRunningResultViewController: RunningResultViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureSubviews()
+        self.configureUI()
     }
     
-    override func configureDifferentSection() {
-        self.configureLowerSeparator()
-        self.configureTitleLabel()
-        self.configureMapView()
-    }
-    
-    override func configureMapView() {
+    override func configureSubviews() {
+        super.configureSubviews()
+        self.contentView.addSubview(self.lowerSeparator)
+        self.contentView.addSubview(self.cancelTitleLabel)
         self.contentView.addSubview(self.mapView)
-        self.mapView.snp.makeConstraints { make in
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(15)
-            make.left.right.equalToSuperview().inset(15)
-            make.height.equalTo(400)
-            make.bottom.equalToSuperview().inset(15)
-        }
     }
 }
 
 private extension CancelRunningResultViewController {
+    func configureUI() {
+        self.configureLowerSeparator()
+        self.configureTitleLabel()
+        self.configureMapView(with: self.cancelTitleLabel)
+    }
+    
     func configureLowerSeparator() {
         self.contentView.addSubview(self.lowerSeparator)
         self.lowerSeparator.snp.makeConstraints { make in
@@ -49,8 +48,8 @@ private extension CancelRunningResultViewController {
     }
     
     func configureTitleLabel() {
-        self.contentView.addSubview(self.titleLabel)
-        self.titleLabel.snp.makeConstraints { make in
+        self.contentView.addSubview(self.cancelTitleLabel)
+        self.cancelTitleLabel.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(15)
             make.top.equalTo(self.lowerSeparator.snp.bottom).offset(15)
         }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/CancelRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/CancelRunningResultViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class CancelRunningResultViewController: RunningResultViewController {
     private lazy var lowerSeparator = self.createSeparator()
     
-    private lazy var cancelTitleLabel: UILabel = {
+    private lazy var canceledTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSans(size: 24, family: .medium)
         label.numberOfLines = 2
@@ -27,7 +27,7 @@ final class CancelRunningResultViewController: RunningResultViewController {
     override func configureSubviews() {
         super.configureSubviews()
         self.contentView.addSubview(self.lowerSeparator)
-        self.contentView.addSubview(self.cancelTitleLabel)
+        self.contentView.addSubview(self.canceledTitleLabel)
         self.contentView.addSubview(self.mapView)
     }
 }
@@ -36,7 +36,7 @@ private extension CancelRunningResultViewController {
     func configureUI() {
         self.configureLowerSeparator()
         self.configureTitleLabel()
-        self.configureMapView(with: self.cancelTitleLabel)
+        self.configureMapView(with: self.canceledTitleLabel)
     }
     
     func configureLowerSeparator() {
@@ -48,8 +48,8 @@ private extension CancelRunningResultViewController {
     }
     
     func configureTitleLabel() {
-        self.contentView.addSubview(self.cancelTitleLabel)
-        self.cancelTitleLabel.snp.makeConstraints { make in
+        self.contentView.addSubview(self.canceledTitleLabel)
+        self.canceledTitleLabel.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(15)
             make.top.equalTo(self.lowerSeparator.snp.bottom).offset(15)
         }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RaceRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RaceRunningResultViewController.swift
@@ -15,23 +15,23 @@ final class RaceRunningResultViewController: RunningResultViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureSubviews()
+        self.configureUI()
     }
     
-    override func configureDifferentSection() {
+    override func configureSubviews() {
+        super.configureSubviews()
+        self.contentView.addSubview(self.lowerSeparator)
+        self.contentView.addSubview(self.raceResultView)
+        self.contentView.addSubview(self.reactionView)
+        self.contentView.addSubview(self.mapView)
+    }
+    
+    func configureUI() {
         self.configureLowerSeparator()
         self.configureRaceResultView()
         self.configureReactionView()
-        self.configureMapView()
-    }
-    
-    override func configureMapView() {
-        self.contentView.addSubview(self.mapView)
-        self.mapView.snp.makeConstraints { make in
-            make.top.equalTo(self.reactionView.snp.bottom).offset(15)
-            make.left.right.equalToSuperview().inset(15)
-            make.height.equalTo(400)
-            make.bottom.equalToSuperview().inset(15)
-        }
+        self.configureMapView(with: self.reactionView)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
+import MapKit
 import RxSwift
 
 class RunningResultViewController: UIViewController {
-    
     var contentView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemBackground
@@ -86,15 +86,13 @@ class RunningResultViewController: UIViewController {
         timeLabel: self.timeLabel
     )
     
+    lazy var mapView = MKMapView()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureCommonUI()
     }
-}
-
-// MARK: - Private Functions
-
-private extension RunningResultViewController {
+    
     func createSeparator() -> UIView {
         let view = UIView()
         view.backgroundColor = .systemGray4
@@ -104,6 +102,33 @@ private extension RunningResultViewController {
         return view
     }
     
+    func configureMapViewLocation(from region: Region) {
+        let coordinateLocation = region.center
+        let spanValue = MKCoordinateSpan(latitudeDelta: region.span.0, longitudeDelta: region.span.1)
+        let locationRegion = MKCoordinateRegion(center: coordinateLocation, span: spanValue)
+        self.mapView.setRegion(locationRegion, animated: true)
+    }
+    
+    func configureMap() {
+        self.mapView.delegate = self
+        self.mapView.mapType = .standard
+    }
+    
+    func configureSubviews() {
+        self.view.addSubview(self.scrollView)
+        self.scrollView.addSubview(self.contentView)
+        self.contentView.addSubview(self.closeButton)
+        self.contentView.addSubview(self.dateTimeLabel)
+        self.contentView.addSubview(self.korDateTimeLabel)
+        self.contentView.addSubview(self.runningModeLabel)
+        self.contentView.addSubview(self.upperSeparator)
+        self.contentView.addSubview(self.myResultView)
+    }
+}
+
+// MARK: - Private Functions
+
+private extension RunningResultViewController {
     func configureCommonUI() {
         self.view.backgroundColor = .systemBackground
         self.configureScrollView()
@@ -116,15 +141,12 @@ private extension RunningResultViewController {
     }
     
     func configureScrollView() {
-        self.view.addSubview(self.scrollView)
         self.scrollView.showsVerticalScrollIndicator = false
         
         self.scrollView.snp.makeConstraints { make in
             make.left.right.bottom.equalToSuperview()
             make.top.equalTo(self.view.safeAreaLayoutGuide)
         }
-        
-        self.scrollView.addSubview(self.contentView)
         
         self.contentView.snp.makeConstraints { make in
             make.width.equalToSuperview()
@@ -133,7 +155,6 @@ private extension RunningResultViewController {
     }
     
     func configureCloseButton() {
-        self.contentView.addSubview(self.closeButton)
         self.closeButton.snp.makeConstraints { make in
             make.top.right.equalToSuperview().inset(15)
             make.width.height.equalTo(25)
@@ -141,15 +162,12 @@ private extension RunningResultViewController {
     }
     
     func configureDateTimeLabel() {
-        self.contentView.addSubview(self.dateTimeLabel)
         self.dateTimeLabel.snp.makeConstraints { make in
             make.top.left.equalToSuperview().inset(15)
         }
     }
     
     func configureKorDateTimeLabel() {
-        self.contentView.addSubview(self.korDateTimeLabel)
-        
         self.korDateTimeLabel.snp.makeConstraints { [weak self] make in
             guard let self = self else { return }
             
@@ -159,8 +177,6 @@ private extension RunningResultViewController {
     }
     
     func configureRunningTypeLabel() {
-        self.contentView.addSubview(self.runningModeLabel)
-        
         self.runningModeLabel.snp.makeConstraints { [weak self] make in
             guard let self = self else { return }
             
@@ -171,7 +187,6 @@ private extension RunningResultViewController {
     }
     
     func configureUpperSeparator() {
-        self.contentView.addSubview(self.upperSeparator)
         self.upperSeparator.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(15)
             make.top.equalTo(self.runningModeLabel.snp.bottom).offset(15)
@@ -179,10 +194,22 @@ private extension RunningResultViewController {
     }
     
     func configureMyResultView() {
-        self.contentView.addSubview(self.myResultView)
         self.myResultView.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(15)
             make.top.equalTo(self.upperSeparator.snp.bottom)
         }
+    }
+}
+
+extension RunningResultViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let polyLine = overlay as? MKPolyline else { return MKOverlayRenderer() }
+        
+        let renderer = MKPolylineRenderer(polyline: polyLine)
+        renderer.strokeColor = .mrPurple
+        renderer.lineWidth = 5.0
+        renderer.alpha = 1.0
+        
+        return renderer
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
@@ -2,21 +2,16 @@
 //  RunningResultViewController.swift
 //  MateRunner
 //
-//  Created by 김민지 on 2021/11/01.
+//  Created by 전여훈 on 2021/11/20.
 //
 
-import CoreLocation
-import MapKit
 import UIKit
 
-import RxCocoa
 import RxSwift
 
 class RunningResultViewController: UIViewController {
-    var viewModel: RunningResultViewModel?
-    private let disposeBag = DisposeBag()
     
-    lazy var contentView: UIView = {
+    var contentView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemBackground
         return view
@@ -24,7 +19,7 @@ class RunningResultViewController: UIViewController {
     
     private lazy var scrollView = UIScrollView()
     
-    private lazy var closeButton: UIButton = {
+    lazy var closeButton: UIButton = {
         let button = UIButton()
         let xImage = UIImage(systemName: "xmark")
         button.setImage(xImage, for: .normal)
@@ -34,7 +29,7 @@ class RunningResultViewController: UIViewController {
         return button
     }()
     
-    private lazy var dateTimeLabel: UILabel = {
+    lazy var dateTimeLabel: UILabel = {
         let label = UILabel()
         label.text = "2020. 6. 10. - 오후 4:32"
         label.font = .notoSans(size: 18, family: .medium)
@@ -42,23 +37,25 @@ class RunningResultViewController: UIViewController {
         return label
     }()
     
-    private lazy var korDateTimeLabel: UILabel = {
+    lazy var korDateTimeLabel: UILabel = {
         let label = UILabel()
         label.text = "수요일 오후"
         label.font = .notoSans(size: 24, family: .medium)
         return label
     }()
     
-    private lazy var runningModeLabel: UILabel = {
+    lazy var runningModeLabel: UILabel = {
         let label = UILabel()
-        label.text = "혼자 달리기"
+        label.text = "hunihun956 메이트와 함께한 달리기 🏃🏻‍♂️"
         label.font = .notoSans(size: 24, family: .medium)
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
     private lazy var upperSeparator = self.createSeparator()
     
-    private lazy var distanceLabel: UILabel = {
+    lazy var distanceLabel: UILabel = {
         let label = UILabel()
         label.text = "5.00"
         label.font = .notoSansBoldItalic(size: 64)
@@ -69,14 +66,14 @@ class RunningResultViewController: UIViewController {
         return label
     }()
     
-    private lazy var calorieLabel: UILabel = {
+    lazy var calorieLabel: UILabel = {
         let label = UILabel()
         label.text = "128"
         label.font = .notoSans(size: 24, family: .black)
         return label
     }()
     
-    private lazy var timeLabel: UILabel = {
+    lazy var timeLabel: UILabel = {
         let label = UILabel()
         label.text = "24:50"
         label.font = .notoSans(size: 24, family: .black)
@@ -89,15 +86,15 @@ class RunningResultViewController: UIViewController {
         timeLabel: self.timeLabel
     )
     
-    lazy var mapView = MKMapView()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.configureUI()
-        self.configureMap()
-        self.bindViewModel()
+        self.configureCommonUI()
     }
-    
+}
+
+// MARK: - Private Functions
+
+private extension RunningResultViewController {
     func createSeparator() -> UIView {
         let view = UIView()
         view.backgroundColor = .systemGray4
@@ -107,41 +104,8 @@ class RunningResultViewController: UIViewController {
         return view
     }
     
-    func configureDifferentSection() {
-        self.configureMapView()
-    }
-    
-    func configureMapView() {
-        self.contentView.addSubview(self.mapView)
-        
-        self.mapView.snp.makeConstraints { [weak self] make in
-            guard let self = self else { return }
-            
-            make.top.equalTo(self.myResultView.snp.bottom).offset(15)
-            make.left.equalToSuperview().offset(15)
-            make.right.equalToSuperview().offset(-15)
-            make.height.equalTo(400)
-            make.bottom.equalToSuperview().offset(-15)
-        }
-    }
-}
-
-// MARK: - Private Functions
-
-private extension RunningResultViewController {
-    func configureMap() {
-        self.mapView.delegate = self
-        self.mapView.mapType = .standard
-    }
-    
-    func configureUI() {
+    func configureCommonUI() {
         self.view.backgroundColor = .systemBackground
-        
-        self.configureCommonSection()
-        self.configureDifferentSection()
-    }
-    
-    func configureCommonSection() {
         self.configureScrollView()
         self.configureCloseButton()
         self.configureDateTimeLabel()
@@ -202,6 +166,7 @@ private extension RunningResultViewController {
             
             make.top.equalTo(self.korDateTimeLabel.snp.bottom)
             make.left.equalToSuperview().offset(15)
+            make.right.equalToSuperview().offset(-15)
         }
     }
     
@@ -219,107 +184,5 @@ private extension RunningResultViewController {
             make.left.equalToSuperview().inset(15)
             make.top.equalTo(self.upperSeparator.snp.bottom)
         }
-    }
-    
-    func configureMapViewLocation(from region: Region) {
-        let coordinateLocation = region.center
-        let spanValue = MKCoordinateSpan(latitudeDelta: region.span.0, longitudeDelta: region.span.1)
-        let locationRegion = MKCoordinateRegion(center: coordinateLocation, span: spanValue)
-        self.mapView.setRegion(locationRegion, animated: true)
-    }
-    
-    func showAlert() {
-        let message = "달리기 결과 저장 중 오류가 발생했습니다."
-        
-        let alert = UIAlertController(title: "오류 발생", message: message, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "취소", style: .default, handler: { _ in
-            self.viewModel?.alertConfirmButtonDidTap()
-        })
-        alert.addAction(cancel)
-        present(alert, animated: false, completion: nil)
-    }
-    
-    func bindViewModel() {
-        guard let viewModel = self.viewModel else { return }
-        let input = RunningResultViewModel.Input(
-            viewDidLoadEvent: Observable<Void>.just(()).asObservable(),
-            closeButtonDidTapEvent: self.closeButton.rx.tap.asObservable()
-        )
-        let output = viewModel.transform(input, disposeBag: self.disposeBag)
-        
-        self.bindMap(with: output)
-        self.bindLabels(with: output)
-        self.bindAlert(with: output)
-    }
-    
-    func bindAlert(with viewModelOutput: RunningResultViewModel.Output) {
-        viewModelOutput.saveFailAlertShouldShow
-            .asDriver(onErrorJustReturn: false)
-            .drive(onNext: { [weak self] _ in
-                self?.showAlert()
-            })
-            .disposed(by: self.disposeBag)
-    }
-    
-    func bindMap(with viewModelOutput: RunningResultViewModel.Output) {
-        viewModelOutput.points
-            .asDriver(onErrorJustReturn: [])
-            .drive(onNext: { [weak self] points in
-                let lineDraw = MKPolyline(coordinates: points, count: points.count)
-                self?.mapView.addOverlay(lineDraw)
-            })
-            .disposed(by: self.disposeBag)
-        
-        viewModelOutput.region
-            .asDriver(onErrorJustReturn: Region())
-            .drive(onNext: { [weak self] region in
-                self?.configureMapViewLocation(from: region)
-            })
-            .disposed(by: self.disposeBag)
-    }
-    
-    func bindLabels(with viewModelOutput: RunningResultViewModel.Output) {
-        viewModelOutput.dateTime
-            .asDriver(onErrorJustReturn: "Error")
-            .drive(self.dateTimeLabel.rx.text)
-            .disposed(by: self.disposeBag)
-        
-        viewModelOutput.dayOfWeekAndTime
-            .asDriver(onErrorJustReturn: "Error")
-            .drive(self.korDateTimeLabel.rx.text)
-            .disposed(by: self.disposeBag)
-        
-        viewModelOutput.mode
-            .asDriver(onErrorJustReturn: "Error")
-            .drive(self.runningModeLabel.rx.text)
-            .disposed(by: self.disposeBag)
-        
-        viewModelOutput.distance
-            .asDriver(onErrorJustReturn: "Error")
-            .drive(self.distanceLabel.rx.text)
-            .disposed(by: self.disposeBag)
-        
-        viewModelOutput.calorie
-            .asDriver(onErrorJustReturn: "Error")
-            .drive(self.calorieLabel.rx.text)
-            .disposed(by: self.disposeBag)
-        
-        viewModelOutput.time
-            .asDriver(onErrorJustReturn: "Error")
-            .drive(self.timeLabel.rx.text)
-            .disposed(by: self.disposeBag)
-    }
-}
-
-extension RunningResultViewController: MKMapViewDelegate {
-    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-        guard let polyLine = overlay as? MKPolyline else { return MKOverlayRenderer() }
-        
-        let renderer = MKPolylineRenderer(polyline: polyLine)
-        renderer.strokeColor = .mrPurple
-        renderer.lineWidth = 5.0
-        renderer.alpha = 1.0
-        
-        return renderer
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
@@ -90,6 +90,7 @@ class RunningResultViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureSubviews()
         self.configureCommonUI()
     }
     
@@ -123,6 +124,29 @@ class RunningResultViewController: UIViewController {
         self.contentView.addSubview(self.runningModeLabel)
         self.contentView.addSubview(self.upperSeparator)
         self.contentView.addSubview(self.myResultView)
+    }
+    
+    func configureMapView() {
+        self.mapView.snp.makeConstraints { [weak self] make in
+            guard let self = self else { return }
+            
+            make.top.equalTo(self.myResultView.snp.bottom).offset(15)
+            make.left.equalToSuperview().offset(15)
+            make.right.equalToSuperview().offset(-15)
+            make.height.equalTo(400)
+            make.bottom.equalToSuperview().offset(-15)
+        }
+    }
+    
+    func showAlert() {
+        let message = "달리기 결과 저장 중 오류가 발생했습니다."
+        
+        let alert = UIAlertController(title: "오류 발생", message: message, preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .default, handler: { _ in
+            //
+        })
+        alert.addAction(cancel)
+        present(alert, animated: false, completion: nil)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
@@ -5,9 +5,9 @@
 //  Created by 전여훈 on 2021/11/20.
 //
 
+import MapKit
 import UIKit
 
-import MapKit
 import RxSwift
 
 class RunningResultViewController: UIViewController {
@@ -129,10 +129,9 @@ class RunningResultViewController: UIViewController {
     func configureMapView(with upperView: UIView) {
         self.mapView.snp.makeConstraints { make in
             make.top.equalTo(upperView.snp.bottom).offset(15)
-            make.left.equalToSuperview().offset(15)
-            make.right.equalToSuperview().offset(-15)
-            make.height.equalTo(400)
+            make.left.right.equalToSuperview().inset(15)
             make.bottom.equalToSuperview().offset(-15)
+            make.height.equalTo(400)
         }
     }
     
@@ -140,9 +139,7 @@ class RunningResultViewController: UIViewController {
         let message = "달리기 결과 저장 중 오류가 발생했습니다."
         
         let alert = UIAlertController(title: "오류 발생", message: message, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "취소", style: .default, handler: { _ in
-            //
-        })
+        let cancel = UIAlertAction(title: "취소", style: .default)
         alert.addAction(cancel)
         present(alert, animated: false, completion: nil)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
@@ -126,11 +126,9 @@ class RunningResultViewController: UIViewController {
         self.contentView.addSubview(self.myResultView)
     }
     
-    func configureMapView() {
-        self.mapView.snp.makeConstraints { [weak self] make in
-            guard let self = self else { return }
-            
-            make.top.equalTo(self.myResultView.snp.bottom).offset(15)
+    func configureMapView(with upperView: UIView) {
+        self.mapView.snp.makeConstraints { make in
+            make.top.equalTo(upperView.snp.bottom).offset(15)
             make.left.equalToSuperview().offset(15)
             make.right.equalToSuperview().offset(-15)
             make.height.equalTo(400)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -13,7 +13,7 @@ import RxCocoa
 import RxSwift
 
 class SingleRunningResultViewController: RunningResultViewController {
-    var viewModel: RunningResultViewModel?
+    var viewModel: SingleRunningResultViewModel?
     let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
@@ -34,7 +34,7 @@ class SingleRunningResultViewController: RunningResultViewController {
 private extension SingleRunningResultViewController {
     func bindViewModel() {
         guard let viewModel = self.viewModel else { return }
-        let input = RunningResultViewModel.Input(
+        let input = SingleRunningResultViewModel.Input(
             viewDidLoadEvent: Observable<Void>.just(()).asObservable(),
             closeButtonDidTapEvent: self.closeButton.rx.tap.asObservable()
         )
@@ -45,7 +45,7 @@ private extension SingleRunningResultViewController {
         self.bindAlert(with: output)
     }
     
-    func bindAlert(with viewModelOutput: RunningResultViewModel.Output) {
+    func bindAlert(with viewModelOutput: SingleRunningResultViewModel.Output) {
         viewModelOutput.saveFailAlertShouldShow
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: { [weak self] _ in
@@ -54,7 +54,7 @@ private extension SingleRunningResultViewController {
             .disposed(by: self.disposeBag)
     }
     
-    func bindMap(with viewModelOutput: RunningResultViewModel.Output) {
+    func bindMap(with viewModelOutput: SingleRunningResultViewModel.Output) {
         viewModelOutput.points
             .asDriver(onErrorJustReturn: [])
             .drive(onNext: { [weak self] points in
@@ -71,7 +71,7 @@ private extension SingleRunningResultViewController {
             .disposed(by: self.disposeBag)
     }
     
-    func bindLabels(with viewModelOutput: RunningResultViewModel.Output) {
+    func bindLabels(with viewModelOutput: SingleRunningResultViewModel.Output) {
         viewModelOutput.dateTime
             .asDriver(onErrorJustReturn: "Error")
             .drive(self.dateTimeLabel.rx.text)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -19,7 +19,7 @@ class SingleRunningResultViewController: RunningResultViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureMap()
-        self.configureMapView()
+        self.configureMapView(with: self.distanceLabel)
         self.bindViewModel()
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -15,74 +15,23 @@ import RxSwift
 class SingleRunningResultViewController: RunningResultViewController {
     var viewModel: RunningResultViewModel?
     let disposeBag = DisposeBag()
-    lazy var mapView = MKMapView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.configureUI()
         self.configureMap()
+        self.configureMapView()
         self.bindViewModel()
     }
     
-    func createSeparator() -> UIView {
-        let view = UIView()
-        view.backgroundColor = .systemGray4
-        view.snp.makeConstraints { make in
-            make.height.equalTo(1)
-        }
-        return view
-    }
-    
-    func configureDifferentSection() {
-        self.configureMapView()
-    }
-    
-    func configureMapView() {
-        super.contentView.addSubview(self.mapView)
-        
-        self.mapView.snp.makeConstraints { [weak self] make in
-            guard let self = self else { return }
-            
-            make.top.equalTo(self.myResultView.snp.bottom).offset(15)
-            make.left.equalToSuperview().offset(15)
-            make.right.equalToSuperview().offset(-15)
-            make.height.equalTo(400)
-            make.bottom.equalToSuperview().offset(-15)
-        }
+    override func configureSubviews() {
+        super.configureSubviews()
+        self.contentView.addSubview(self.mapView)
     }
 }
 
 // MARK: - Private Functions
 
 private extension SingleRunningResultViewController {
-    func configureMap() {
-        self.mapView.delegate = self
-        self.mapView.mapType = .standard
-    }
-    
-    func configureUI() {
-        self.view.backgroundColor = .systemBackground
-        self.configureDifferentSection()
-    }
-    
-    func configureMapViewLocation(from region: Region) {
-        let coordinateLocation = region.center
-        let spanValue = MKCoordinateSpan(latitudeDelta: region.span.0, longitudeDelta: region.span.1)
-        let locationRegion = MKCoordinateRegion(center: coordinateLocation, span: spanValue)
-        self.mapView.setRegion(locationRegion, animated: true)
-    }
-    
-    func showAlert() {
-        let message = "달리기 결과 저장 중 오류가 발생했습니다."
-        
-        let alert = UIAlertController(title: "오류 발생", message: message, preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "취소", style: .default, handler: { _ in
-            self.viewModel?.alertConfirmButtonDidTap()
-        })
-        alert.addAction(cancel)
-        present(alert, animated: false, completion: nil)
-    }
-    
     func bindViewModel() {
         guard let viewModel = self.viewModel else { return }
         let input = RunningResultViewModel.Input(
@@ -152,18 +101,5 @@ private extension SingleRunningResultViewController {
             .asDriver(onErrorJustReturn: "Error")
             .drive(self.timeLabel.rx.text)
             .disposed(by: self.disposeBag)
-    }
-}
-
-extension SingleRunningResultViewController: MKMapViewDelegate {
-    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-        guard let polyLine = overlay as? MKPolyline else { return MKOverlayRenderer() }
-        
-        let renderer = MKPolylineRenderer(polyline: polyLine)
-        renderer.strokeColor = .mrPurple
-        renderer.lineWidth = 5.0
-        renderer.alpha = 1.0
-        
-        return renderer
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -13,7 +13,7 @@ import RxSwift
 
 final class SingleRunningResultViewController: RunningResultViewController {
     var viewModel: SingleRunningResultViewModel?
-    let disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -18,7 +18,7 @@ final class SingleRunningResultViewController: RunningResultViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureMap()
-        self.configureMapView(with: self.distanceLabel)
+        self.configureMapView(with: self.myResultView)
         self.bindViewModel()
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -5,14 +5,13 @@
 //  Created by 김민지 on 2021/11/01.
 //
 
-import CoreLocation
 import MapKit
 import UIKit
 
 import RxCocoa
 import RxSwift
 
-class SingleRunningResultViewController: RunningResultViewController {
+final class SingleRunningResultViewController: RunningResultViewController {
     var viewModel: SingleRunningResultViewModel?
     let disposeBag = DisposeBag()
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/SingleRunningResultViewController.swift
@@ -1,0 +1,169 @@
+//
+//  SingleRunningResultViewController.swift
+//  MateRunner
+//
+//  Created by 김민지 on 2021/11/01.
+//
+
+import CoreLocation
+import MapKit
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+class SingleRunningResultViewController: RunningResultViewController {
+    var viewModel: RunningResultViewModel?
+    let disposeBag = DisposeBag()
+    lazy var mapView = MKMapView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureUI()
+        self.configureMap()
+        self.bindViewModel()
+    }
+    
+    func createSeparator() -> UIView {
+        let view = UIView()
+        view.backgroundColor = .systemGray4
+        view.snp.makeConstraints { make in
+            make.height.equalTo(1)
+        }
+        return view
+    }
+    
+    func configureDifferentSection() {
+        self.configureMapView()
+    }
+    
+    func configureMapView() {
+        super.contentView.addSubview(self.mapView)
+        
+        self.mapView.snp.makeConstraints { [weak self] make in
+            guard let self = self else { return }
+            
+            make.top.equalTo(self.myResultView.snp.bottom).offset(15)
+            make.left.equalToSuperview().offset(15)
+            make.right.equalToSuperview().offset(-15)
+            make.height.equalTo(400)
+            make.bottom.equalToSuperview().offset(-15)
+        }
+    }
+}
+
+// MARK: - Private Functions
+
+private extension SingleRunningResultViewController {
+    func configureMap() {
+        self.mapView.delegate = self
+        self.mapView.mapType = .standard
+    }
+    
+    func configureUI() {
+        self.view.backgroundColor = .systemBackground
+        self.configureDifferentSection()
+    }
+    
+    func configureMapViewLocation(from region: Region) {
+        let coordinateLocation = region.center
+        let spanValue = MKCoordinateSpan(latitudeDelta: region.span.0, longitudeDelta: region.span.1)
+        let locationRegion = MKCoordinateRegion(center: coordinateLocation, span: spanValue)
+        self.mapView.setRegion(locationRegion, animated: true)
+    }
+    
+    func showAlert() {
+        let message = "달리기 결과 저장 중 오류가 발생했습니다."
+        
+        let alert = UIAlertController(title: "오류 발생", message: message, preferredStyle: .alert)
+        let cancel = UIAlertAction(title: "취소", style: .default, handler: { _ in
+            self.viewModel?.alertConfirmButtonDidTap()
+        })
+        alert.addAction(cancel)
+        present(alert, animated: false, completion: nil)
+    }
+    
+    func bindViewModel() {
+        guard let viewModel = self.viewModel else { return }
+        let input = RunningResultViewModel.Input(
+            viewDidLoadEvent: Observable<Void>.just(()).asObservable(),
+            closeButtonDidTapEvent: self.closeButton.rx.tap.asObservable()
+        )
+        let output = viewModel.transform(input, disposeBag: self.disposeBag)
+        
+        self.bindMap(with: output)
+        self.bindLabels(with: output)
+        self.bindAlert(with: output)
+    }
+    
+    func bindAlert(with viewModelOutput: RunningResultViewModel.Output) {
+        viewModelOutput.saveFailAlertShouldShow
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] _ in
+                self?.showAlert()
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func bindMap(with viewModelOutput: RunningResultViewModel.Output) {
+        viewModelOutput.points
+            .asDriver(onErrorJustReturn: [])
+            .drive(onNext: { [weak self] points in
+                let lineDraw = MKPolyline(coordinates: points, count: points.count)
+                self?.mapView.addOverlay(lineDraw)
+            })
+            .disposed(by: self.disposeBag)
+        
+        viewModelOutput.region
+            .asDriver(onErrorJustReturn: Region())
+            .drive(onNext: { [weak self] region in
+                self?.configureMapViewLocation(from: region)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func bindLabels(with viewModelOutput: RunningResultViewModel.Output) {
+        viewModelOutput.dateTime
+            .asDriver(onErrorJustReturn: "Error")
+            .drive(self.dateTimeLabel.rx.text)
+            .disposed(by: self.disposeBag)
+        
+        viewModelOutput.dayOfWeekAndTime
+            .asDriver(onErrorJustReturn: "Error")
+            .drive(self.korDateTimeLabel.rx.text)
+            .disposed(by: self.disposeBag)
+        
+        viewModelOutput.mode
+            .asDriver(onErrorJustReturn: "Error")
+            .drive(self.runningModeLabel.rx.text)
+            .disposed(by: self.disposeBag)
+        
+        viewModelOutput.distance
+            .asDriver(onErrorJustReturn: "Error")
+            .drive(self.distanceLabel.rx.text)
+            .disposed(by: self.disposeBag)
+        
+        viewModelOutput.calorie
+            .asDriver(onErrorJustReturn: "Error")
+            .drive(self.calorieLabel.rx.text)
+            .disposed(by: self.disposeBag)
+        
+        viewModelOutput.time
+            .asDriver(onErrorJustReturn: "Error")
+            .drive(self.timeLabel.rx.text)
+            .disposed(by: self.disposeBag)
+    }
+}
+
+extension SingleRunningResultViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let polyLine = overlay as? MKPolyline else { return MKOverlayRenderer() }
+        
+        let renderer = MKPolylineRenderer(polyline: polyLine)
+        renderer.strokeColor = .mrPurple
+        renderer.lineWidth = 5.0
+        renderer.alpha = 1.0
+        
+        return renderer
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/TeamRunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/TeamRunningResultViewController.swift
@@ -21,23 +21,23 @@ final class TeamRunningResultViewController: RunningResultViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureSubviews()
+        self.configureUI()
     }
     
-    override func configureDifferentSection() {
+    override func configureSubviews() {
+        super.configureSubviews()
+        self.contentView.addSubview(self.lowerSeparator)
+        self.contentView.addSubview(self.teamResultView)
+        self.contentView.addSubview(self.reactionView)
+        self.contentView.addSubview(self.mapView)
+    }
+    
+    func configureUI() {
         self.configureLowerSeparator()
         self.configureTeamResultView()
         self.configureReactionView()
-        self.configureMapView()
-    }
-    
-    override func configureMapView() {
-        self.contentView.addSubview(self.mapView)
-        self.mapView.snp.makeConstraints { make in
-            make.top.equalTo(self.reactionView.snp.bottom).offset(15)
-            make.left.right.equalToSuperview().inset(15)
-            make.height.equalTo(400)
-            make.bottom.equalToSuperview().inset(15)
-        }
+        self.configureMapView(with: self.reactionView)
     }
 }
 
@@ -45,7 +45,6 @@ final class TeamRunningResultViewController: RunningResultViewController {
 
 private extension TeamRunningResultViewController {
     func configureLowerSeparator() {
-        self.contentView.addSubview(self.lowerSeparator)
         self.lowerSeparator.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(15)
             make.top.equalTo(self.myResultView.snp.bottom).offset(15)
@@ -53,7 +52,6 @@ private extension TeamRunningResultViewController {
     }
     
     func configureTeamResultView() {
-        self.contentView.addSubview(self.teamResultView)
         self.teamResultView.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(15)
             make.top.equalTo(self.lowerSeparator.snp.bottom).offset(15)
@@ -61,7 +59,6 @@ private extension TeamRunningResultViewController {
     }
     
     func configureReactionView() {
-        self.contentView.addSubview(self.reactionView)
         self.reactionView.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(15)
             make.top.equalTo(self.teamResultView.snp.bottom).offset(20)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/RaceRunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/RaceRunningResultViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  RaceRunningResultViewModel.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/20.
+//
+
+import CoreLocation
+
+import RxRelay
+import RxSwift
+
+class RaceRunningResultViewModel {
+    private let runningResultUseCase: RunningResultUseCase
+    weak var coordinator: RunningCoordinator?
+    
+    init(coordinator: RunningCoordinator, runningResultUseCase: RunningResultUseCase) {
+        self.coordinator = coordinator
+        self.runningResultUseCase = runningResultUseCase
+    }
+    
+    struct Input {
+        let viewDidLoadEvent: Observable<Void>
+        let closeButtonDidTapEvent: Observable<Void>
+    }
+    
+    struct Output {
+        var dateTime: BehaviorRelay<String>
+        var dayOfWeekAndTime: BehaviorRelay<String>
+        var mode: BehaviorRelay<String>
+        var distance: BehaviorRelay<String>
+        var calorie: BehaviorRelay<String>
+        var time: BehaviorRelay<String>
+        var points: BehaviorRelay<[CLLocationCoordinate2D]>
+        var region: BehaviorRelay<Region>
+        var userNickname: BehaviorRelay<String>
+        var selectedEmoji: BehaviorRelay<String>
+        var mateDistance: BehaviorRelay<String>
+        var headerMessage: BehaviorRelay<String>
+        var resultMessage: BehaviorRelay<String>
+        var saveFailAlertShouldShow: PublishRelay<Bool>
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/SingleRunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/SingleRunningResultViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  RunningResultViewModel.swift
+//  SingleRunningResultViewModel.swift
 //  MateRunner
 //
 //  Created by 김민지 on 2021/11/02.
@@ -10,7 +10,7 @@ import CoreLocation
 import RxRelay
 import RxSwift
 
-final class RunningResultViewModel {
+final class SingleRunningResultViewModel {
     private let runningResultUseCase: RunningResultUseCase
     weak var coordinator: RunningCoordinator?
     


### PR DESCRIPTION
### 📕 Issue Number

Close #175 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 작성


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 다 뷰모델 때문에..
원래 뷰컨트롤러도 전혀 문제가 없어요! 그런데 이제 뷰모델을 각 모드에 대해 설정해주어야 하다보니 혼자달리기 결과화면을 상속 받고 있는 문제가 있어 공통 클래스를 하나 두고 각 모드가 공통클래스를 상속받도록 했습니다.

- 오버뷰
<img width="766" alt="스크린샷 2021-11-20 오후 1 50 00" src="https://user-images.githubusercontent.com/46087477/142714869-134831b7-b7eb-4cf0-a320-ab303538a3f9.png">


공통 UI는 부모 클래스로 빼고 자식들은 자기 자신이 가지는 컴포넌트들을 정의한 후에 subview의 순서만 변경해줍니다.

- configureSubviews 
    각 결과화면에서 사실 지도까지는 모두 공통되는 UI컴포넌트이고 추가적으로 몇개의 UI가 더 있는데, 지도까지 모두 base 클래스에서 관리하기 위해서 subview에 add하는 순서만 각 모드별 결과화면에서 정하도록 했습니다. 
    
    ```swift
    func configureSubviews() {
            self.view.addSubview(self.scrollView)
            self.scrollView.addSubview(self.contentView)
            self.contentView.addSubview(self.closeButton)
            self.contentView.addSubview(self.dateTimeLabel)
            self.contentView.addSubview(self.korDateTimeLabel)
            self.contentView.addSubview(self.runningModeLabel)
            self.contentView.addSubview(self.upperSeparator)
            self.contentView.addSubview(self.myResultView)
        }
    ```
    
    그래서 부모 클래스에서는 이렇게 지도화면 직전까지 모두에게 필요한 UI들을 넣어주고 
    
    
    ```swift
        override func configureSubviews() {
            super.configureSubviews()
            self.contentView.addSubview(self.lowerSeparator)
            self.contentView.addSubview(self.teamResultView)
            self.contentView.addSubview(self.reactionView)
            self.contentView.addSubview(self.mapView)
        }
    ```
    
    상속받는 쪽에서는 공통 컴포넌트에 추가적으로 필요한 컴포넌트들을 넣어주도록 했습니다.
    
- mapView 설정 
    지도의 경우에는 위치가 혼자달리기 모드와 같이 달리기 모드에서 달라지는데요, 오버라이딩으로 하기에는 레이아웃을 잡을 기준 뷰만 달라지고 나머지는 모두 동일해서 인자로 기준 뷰를 받는 공통함수로 분리했습니다.
    
    ```swift
        func configureMapView(with upperView: UIView) {
            self.mapView.snp.makeConstraints { make in
                make.top.equalTo(upperView.snp.bottom).offset(15)
                make.left.equalToSuperview().offset(15)
                make.right.equalToSuperview().offset(-15)
                make.height.equalTo(400)
                make.bottom.equalToSuperview().offset(-15)
            }
        }
    ```

- 뷰모델 파일이 추가되었어요ㅠ
피알을 나눌 생각으로 이 브랜치를 만들었는데 뷰모델을 생성한 커밋까지 포함되어 버렸네요.. 아직 미완성된 파일이니 따로 리뷰하지 않으셔도 됩니다..

<br/><br/>
