### PR TITLE
거리 설정 시 밑줄이 사라지는 버그 수정

### DIFF
--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SettingViewController/DistanceSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SettingViewController/DistanceSettingViewController.swift
@@ -80,7 +80,9 @@ private extension DistanceSettingViewController {
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         output?.$distanceFieldText
             .asDriver()
-            .drive(self.distanceTextField.rx.text)
+            .drive(onNext: { [weak self] text in
+                self?.updateDistanceText(with: text)
+            })
             .disposed(by: self.disposeBag)
         output?.keyboardShouldhide
             .asDriver(onErrorJustReturn: true)
@@ -89,6 +91,13 @@ private extension DistanceSettingViewController {
                 self?.doneButton.title = ""
             })
             .disposed(by: self.disposeBag)
+    }
+    
+    func updateDistanceText(with text: String?) {
+        guard let text = text else { return }
+        let attributes = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue]
+        let attributedString = NSAttributedString(string: text, attributes: attributes)
+        self.distanceTextField.attributedText = attributedString
     }
     
     func configureUI() {


### PR DESCRIPTION
### 📕 Issue Number

Close #55 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 버그수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

https://user-images.githubusercontent.com/46087477/142765289-8b16d304-813a-4e2d-8945-99bcc2a5c556.mp4


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 원인 
attributedString으로 값을 업데이트 하지 않고 label.text에 값을 계속 업데이트해서 추가속성이 적용되지 않는 문제였습니다. 
attributedString을 생성해서 텍스트필드의 값으로 넣어주는 메서드를 정의하고 subscribe에 이 메서드를 호출하도록 하여 버그를 수정했습니다.
<br/><br/>
