### PR TITLE
달리기 중도 취소 관련 사항 구현 & isRunning 상태 서버 업로드

### DIFF
--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -14,7 +14,6 @@ import FirebaseMessaging
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
     func application(_ application: UIApplication,didFinishLaunchingWithOptions launchOptions:[UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
         
@@ -28,6 +27,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options: authOptions,completionHandler: { (_, _) in }
           )
         application.registerForRemoteNotifications()
+        
+        if let nickName = UserDefaults.standard.string(forKey: "nickname") {
+            Database.database().reference().child("isRunning/\(nickName)").setValue(false)
+        }
         
         return true
     }
@@ -71,10 +74,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate : MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
-        let ref: DatabaseReference = Database.database().reference()
-        
         if let nickName = UserDefaults.standard.string(forKey: "nickname") {
-            ref.child("fcmToken/\(nickName)").setValue(fcmToken)
+            Database.database().reference().child("fcmToken/\(nickName)").setValue(fcmToken)
         }
     }
 }

--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -74,7 +74,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate : MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
-        if let nickName = UserDefaults.standard.string(forKey: "nickname") {
+        if let nickName = UserDefaults.standard.string(forKey: UserDefaultKey.nickname.rawValue) {
             Database.database().reference().child("fcmToken/\(nickName)").setValue(fcmToken)
         }
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInvitationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInvitationRepository.swift
@@ -15,6 +15,18 @@ final class DefaultInvitationRepository: InvitationRepository {
         self.realtimeDatabaseNetworkService = realtimeDatabaseNetworkService
     }
     
+    func loadIsCancelled(of invitation: Invitation) -> Observable<Bool> {
+        let sessionId = invitation.sessionId
+        
+        return self.realtimeDatabaseNetworkService.fetch(of: ["session", "\(sessionId)"])
+            .map { data in
+                guard let isCancelled = data["isCancelled"] as? Bool else {
+                    return false
+                }
+                return isCancelled
+            }
+    }
+    
     func saveInvitationResponse(accept: Bool, invitation: Invitation) -> Observable<Void> {
         let sessionId = invitation.sessionId
         

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInvitationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInvitationRepository.swift
@@ -15,7 +15,7 @@ final class DefaultInvitationRepository: InvitationRepository {
         self.realtimeDatabaseNetworkService = realtimeDatabaseNetworkService
     }
     
-    func loadIsCancelled(of invitation: Invitation) -> Observable<Bool> {
+    func fetchCancellationStatus(of invitation: Invitation) -> Observable<Bool> {
         let sessionId = invitation.sessionId
         
         return self.realtimeDatabaseNetworkService.fetch(of: ["session", "\(sessionId)"])

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -59,9 +59,7 @@ final class DefaultInviteMateRepository: InviteMateRepository {
         let sessionId = invitation.sessionId
         
         return self.realtimeDatabaseNetworkService.updateChildValues(
-            with: [
-                "isCancelled": true
-            ],
+            with: ["isCancelled": true],
             path: ["session", "\(sessionId)"]
         )
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -47,10 +47,22 @@ final class DefaultInviteMateRepository: InviteMateRepository {
                 mate: runningRealTimeJsonData,
                 "isAccepted": false,
                 "isReceived": false,
+                "isCancelled": false,
                 "mode": mode.rawValue,
                 "targetDistance": targetDistance
             ],
             path: ["session", sessionId]
+        )
+    }
+    
+    func cancelSession(invitation: Invitation) -> Observable<Void> {
+        let sessionId = invitation.sessionId
+        
+        return self.realtimeDatabaseNetworkService.updateChildValues(
+            with: [
+                "isCancelled": true
+            ],
+            path: ["session", "\(sessionId)"]
         )
     }
     

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningRepository.swift
@@ -59,9 +59,7 @@ final class DefaultRunningRepository: RunningRepository {
         }
         
         return self.realtimeDatabaseNetworkService.updateChildValues(
-            with: [
-                "isCancelled": true
-            ],
+            with: ["isCancelled": true],
             path: ["session", "\(sessionId)"]
         )
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/InvitationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/InvitationRepository.swift
@@ -9,5 +9,6 @@ import Foundation
 import RxSwift
 
 protocol InvitationRepository {
+    func loadIsCancelled(of invitation: Invitation) -> Observable<Bool>
     func saveInvitationResponse(accept: Bool, invitation: Invitation) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/InvitationRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/InvitationRepository.swift
@@ -9,6 +9,6 @@ import Foundation
 import RxSwift
 
 protocol InvitationRepository {
-    func loadIsCancelled(of invitation: Invitation) -> Observable<Bool>
+    func fetchCancellationStatus(of invitation: Invitation) -> Observable<Bool>
     func saveInvitationResponse(accept: Bool, invitation: Invitation) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/InviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/InviteMateRepository.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 protocol InviteMateRepository {
     func createSession(invitation: Invitation, mate: String) -> Observable<Void>
+    func cancelSession(invitation: Invitation) -> Observable<Void>
     func listenInvitationResponse(of invitation: Invitation) -> Observable<(Bool, Bool)>
     func fetchFCMToken(of mate: String) -> Observable<String>
     func sendInvitation(_ invitation: Invitation, fcmToken: String) -> Observable<Void>

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningRepository.swift
@@ -11,6 +11,8 @@ import RxSwift
 
 protocol RunningRepository {
     func listen(sessionId: String, mate: String) -> Observable<RunningRealTimeData>
+    func listenIsCancelled(of sessionId: String) -> Observable<Bool>
     func save(_ domain: RunningRealTimeData, sessionId: String, user: String) -> Observable<Void>
+    func cancelSession(of runningSetting: RunningSetting) -> Observable<Void>
     func stopListen(sessionId: String, mate: String)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Common/DefaultInvitationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/DefaultInvitationUseCase.swift
@@ -11,6 +11,9 @@ import RxRelay
 import RxSwift
 
 final class DefaultInvitationUseCase: InvitationUseCase {
+    var isCancelled: PublishSubject<Bool> = PublishSubject<Bool>()
+    private let disposeBag = DisposeBag()
+    
     private let invitationRepository: InvitationRepository = DefaultInvitationRepository(
         realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
     )
@@ -19,6 +22,14 @@ final class DefaultInvitationUseCase: InvitationUseCase {
 
     init(invitation: Invitation) {
         self.invitation = invitation
+    }
+    
+    func checkIsCancelled() -> Observable<Bool> {
+        self.invitationRepository.loadIsCancelled(of: self.invitation)
+            .bind(to: self.isCancelled)
+            .disposed(by: self.disposeBag)
+        
+        return self.invitationRepository.loadIsCancelled(of: self.invitation)
     }
 
     func acceptInvitation() -> Observable<Void> {

--- a/MateRunner/MateRunner/Domain/UseCase/Common/DefaultInvitationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/DefaultInvitationUseCase.swift
@@ -25,11 +25,11 @@ final class DefaultInvitationUseCase: InvitationUseCase {
     }
     
     func checkIsCancelled() -> Observable<Bool> {
-        self.invitationRepository.loadIsCancelled(of: self.invitation)
+        self.invitationRepository.fetchCancellationStatus(of: self.invitation)
             .bind(to: self.isCancelled)
             .disposed(by: self.disposeBag)
         
-        return self.invitationRepository.loadIsCancelled(of: self.invitation)
+        return self.invitationRepository.fetchCancellationStatus(of: self.invitation)
     }
 
     func acceptInvitation() -> Observable<Void> {

--- a/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/InvitationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/InvitationUseCase.swift
@@ -6,10 +6,13 @@
 //
 import Foundation
 
+import RxRelay
 import RxSwift
 
 protocol InvitationUseCase {
     var invitation: Invitation { get set }
+    var isCancelled: PublishSubject<Bool> { get set }
+    func checkIsCancelled() -> Observable<Bool>
     func acceptInvitation() -> Observable<Void>
     func rejectInvitation() -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
@@ -13,6 +13,7 @@ protocol RunningUseCase {
     var runningSetting: RunningSetting { get set }
     var runningData: BehaviorSubject<RunningData> { get set }
     var isCanceled: BehaviorSubject<Bool> { get set }
+    var isCancelledByMate: BehaviorSubject<Bool> { get set }
     var isFinished: BehaviorSubject<Bool> { get set }
     var shouldShowPopUp: BehaviorSubject<Bool> { get set }
     var myProgress: BehaviorSubject<Double> { get set }
@@ -26,6 +27,6 @@ protocol RunningUseCase {
     func executeCancelTimer()
     func executePopUpTimer()
     func invalidateCancelTimer()
-    func listenMateRunningRealTimeData()
+    func listenRunningSession()
     func createRunningResult(isCanceled: Bool) -> RunningResult
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/SettingUseCase/DefaultInvitationWaitingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/SettingUseCase/DefaultInvitationWaitingUseCase.swift
@@ -65,6 +65,10 @@ final class DefaultInvitationWaitingUseCase: InvitationWaitingUseCase {
                     return PublishRelay<(Bool, Bool)>.just((false, false))
                 }
                 self.isCancelled.onNext(true)
+                self.inviteMateRepository.cancelSession(invitation: self.invitation)
+                    .publish()
+                    .connect()
+                    .disposed(by: self.disposeBag)
                 self.inviteMateRepository.stopListen(invitation: self.invitation)
                 return PublishRelay<(Bool, Bool)>.just((false, false))
             })

--- a/MateRunner/MateRunner/Network/Protocol/RealtimeDatabaseNetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/RealtimeDatabaseNetworkService.swift
@@ -14,5 +14,6 @@ protocol RealtimeDatabaseNetworkService {
     func update(with: Any, path: [String]) -> Observable<Void>
     func listen(path: [String]) -> Observable<FirebaseDictionary>
     func stopListen(path: [String])
+    func fetch(of path: [String])-> Observable<FirebaseDictionary>
     func fetchFCMToken(of mate: String)-> Observable<String>
 }

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
@@ -28,17 +28,18 @@ final class InvitationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
-        self.bindUI()
         self.bindViewModel()
     }
-    
 }
 
 // MARK: - Private Functions
 
 private extension InvitationViewController {
     func bindViewModel() {
-        let input = InvitationViewModel.Input(viewDidLoadEvent: Observable.just(()))
+        let input = InvitationViewModel.Input(
+            viewDidLoadEvent: Observable.just(()),
+            acceptButtonDidTapEvent: self.invitationView.acceptButton.rx.tap.asObservable(),
+            rejectButtonDidTapEvent: self.invitationView.rejectButton.rx.tap.asObservable())
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         
@@ -51,32 +52,34 @@ private extension InvitationViewController {
                 self.invitationView.updateLabelText(mate: host, mode: mode, distance: targetDistance)
             }
             .disposed(by: self.disposeBag)
+        
+        output?.cancelledAlertShouldShow.subscribe(
+            onNext: { [weak self] cancelledAlertShouldShow in
+                if cancelledAlertShouldShow {
+                    self?.showAlert(message: "취소된 달리기입니다.")
+                }
+        })
+            .disposed(by: self.disposeBag)
 
     }
     
-    func bindUI() {
-        self.invitationView.acceptButton.rx.tap
-            .subscribe(onNext: {
-                self.viewModel?.acceptButtonDidTap()
-            })
-            .disposed(by: self.disposeBag)
-        
-        self.invitationView.rejectButton.rx.tap
-            .subscribe(onNext: {
-                self.viewModel?.rejectButtonDidTap()
-            })
-            .disposed(by: self.disposeBag)
-    }
-    
     func configureUI() {
-//        self.view.backgroundColor = UIColor.clear //이렇게 한다면 이전 뷰컨에서 addsubView로 배경의 투명도와 색을 지정해야함
         self.tabBarController?.tabBar.isHidden = true
-        self.view.backgroundColor = UIColor.black.withAlphaComponent(0.5) // 투명도 있는 배경 -> animated: false
+        self.view.backgroundColor = UIColor.black.withAlphaComponent(0.5)
         self.view.isOpaque = false
         
         self.view.addSubview(invitationView)
         self.invitationView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()
         }
+    }
+    
+    func showAlert(message: String) {
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alert.addAction(confirm)
+        present(alert, animated: false, completion: { [weak self] in
+            self?.viewModel?.finish()
+        })
     }
 }

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -53,10 +53,11 @@ final class InvitationViewModel {
         input.acceptButtonDidTapEvent.subscribe(onNext: { [weak self] in
             guard let self = self else { return }
             self.invitationUseCase.checkIsCancelled()
-                .filter { $0 }
-                .subscribe { [weak self] _ in
+                .filter { !$0 }
+                .subscribe(onNext: { [weak self] _ in
                     self?.acceptInvitation()
-                }.disposed(by: disposeBag)
+                })
+                .disposed(by: disposeBag)
         })
             .disposed(by: disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -52,11 +52,11 @@ final class InvitationViewModel {
         
         input.acceptButtonDidTapEvent.subscribe(onNext: { [weak self] in
             guard let self = self else { return }
-            self.invitationUseCase.checkIsCancelled().subscribe(onNext: { isCancelled in
-                if !isCancelled {
-                    self.acceptInvitation()
-                }
-            }).disposed(by: disposeBag)
+            self.invitationUseCase.checkIsCancelled()
+                .filter { $0 }
+                .subscribe { [weak self] _ in
+                    self?.acceptInvitation()
+                }.disposed(by: disposeBag)
         })
             .disposed(by: disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RaceRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RaceRunningViewController.swift
@@ -146,5 +146,21 @@ private extension RaceRunningViewController {
                 self?.calorieView.updateValue(newValue: calorie)
             })
             .disposed(by: self.disposeBag)
+        
+        output?.cancelledAlertShouldShow
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] cancelledAlertShouldShow in
+                if cancelledAlertShouldShow {
+                    self?.showAlert(message: "메이트가 달리기를 중도 취소했습니다.")
+                }
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func showAlert(message: String) {
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alert.addAction(confirm)
+        present(alert, animated: false, completion: nil)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RaceRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RaceRunningViewController.swift
@@ -149,10 +149,9 @@ private extension RaceRunningViewController {
         
         output?.cancelledAlertShouldShow
             .asDriver(onErrorJustReturn: false)
-            .drive(onNext: { [weak self] cancelledAlertShouldShow in
-                if cancelledAlertShouldShow {
-                    self?.showAlert(message: "메이트가 달리기를 중도 취소했습니다.")
-                }
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                self?.showAlert(message: "메이트가 달리기를 중도 취소했습니다.")
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/TeamRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/TeamRunningViewController.swift
@@ -162,10 +162,9 @@ private extension TeamRunningViewController {
         
         output?.cancelledAlertShouldShow
             .asDriver(onErrorJustReturn: false)
-            .drive(onNext: { [weak self] cancelledAlertShouldShow in
-                if cancelledAlertShouldShow {
-                    self?.showAlert(message: "메이트가 달리기를 중도 취소했습니다.")
-                }
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                self?.showAlert(message: "메이트가 달리기를 중도 취소했습니다.")
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/TeamRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/TeamRunningViewController.swift
@@ -159,5 +159,21 @@ private extension TeamRunningViewController {
                 self?.calorieView.updateValue(newValue: calorie)
             })
             .disposed(by: self.disposeBag)
+        
+        output?.cancelledAlertShouldShow
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] cancelledAlertShouldShow in
+                if cancelledAlertShouldShow {
+                    self?.showAlert(message: "메이트가 달리기를 중도 취소했습니다.")
+                }
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func showAlert(message: String) {
+        let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alert.addAction(confirm)
+        present(alert, animated: false, completion: nil)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/RaceRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/RaceRunningViewModel.swift
@@ -29,6 +29,7 @@ final class RaceRunningViewModel {
         var timeSpent = PublishRelay<String>()
         var cancelTimeLeft = PublishRelay<String>()
         var popUpShouldShow = PublishRelay<Bool>()
+        var cancelledAlertShouldShow = PublishRelay<Bool>()
     }
     
     init(coordinator: RunningCoordinator, runningUseCase: RunningUseCase) {
@@ -47,7 +48,7 @@ final class RaceRunningViewModel {
                 self?.runningUseCase.executePedometer()
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()
-                self?.runningUseCase.listenMateRunningRealTimeData()
+                self?.runningUseCase.listenRunningSession()
             })
             .disposed(by: disposeBag)
         
@@ -109,6 +110,10 @@ final class RaceRunningViewModel {
         
         self.runningUseCase.mateProgress
             .bind(to: output.mateProgress)
+            .disposed(by: disposeBag)
+        
+        self.runningUseCase.isCancelledByMate
+            .bind(to: output.cancelledAlertShouldShow)
             .disposed(by: disposeBag)
         
         Observable.combineLatest(

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/TeamRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/TeamRunningViewModel.swift
@@ -29,6 +29,7 @@ final class TeamRunningViewModel {
         var timeSpent = PublishRelay<String>()
         var cancelTimeLeft = PublishRelay<String>()
         var popUpShouldShow = PublishRelay<Bool>()
+        var cancelledAlertShouldShow = PublishRelay<Bool>()
     }
     
     init(coordinator: RunningCoordinator, runningUseCase: RunningUseCase) {
@@ -47,7 +48,7 @@ final class TeamRunningViewModel {
                 self?.runningUseCase.executePedometer()
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()
-                self?.runningUseCase.listenMateRunningRealTimeData()
+                self?.runningUseCase.listenRunningSession()
             })
             .disposed(by: disposeBag)
         
@@ -110,6 +111,10 @@ final class TeamRunningViewModel {
         
         self.runningUseCase.totalProgress
             .bind(to: output.totalProgress)
+            .disposed(by: disposeBag)
+        
+        self.runningUseCase.isCancelledByMate
+            .bind(to: output.cancelledAlertShouldShow)
             .disposed(by: disposeBag)
         
         Observable.combineLatest(


### PR DESCRIPTION
### 📕 Issue Number

Close #110 
Close #157 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] isRunning 상태 서버 업로드
- [x] 메이트가 달리기 중도 종료 시 상대에게 알러트 표시

<img width="300px" src="https://user-images.githubusercontent.com/48787170/142835908-49496e17-9c91-41d4-b4df-bdd0170edda0.jpeg" />


- [x] 타임아웃 시 서버에 반영
- [x] 타임아웃된 달리기 초대장 수락 시 달리기가 시작되지 않도록 구현


<img width="300px" src="https://user-images.githubusercontent.com/48787170/142835661-bebe7450-5e10-45ba-abab-ea6372315e1e.jpeg" />

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 타임아웃된 초대장의 수락 버튼을 누르면 취소된 달리기라는 알러트가 뜨고, 그 알러트의 확인 버튼을 누르면 홈 화면으로 가도록 하고 싶은데 홈 화면으로 전환하는 부분이 안되네요ㅜㅜ이 부분은 오늘 밤이나 내일 중으로 원인 파악해서 수정하겠습니다..!


- 특이 사항 2

<br/><br/>
