### PR TITLE
달리기 시작 및 종료 시 Running state 업데이트 구현 & 초대장 타임아웃 관련 버그 수정 & 혼자 달리기 시 서버에 실시간 데이터 업로드되지 않도록 수정

### DIFF
--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         application.registerForRemoteNotifications()
         
         if let nickName = UserDefaults.standard.string(forKey: "nickname") {
-            Database.database().reference().child("isRunning/\(nickName)").setValue(false)
+            Database.database().reference().child("state").child("\(nickName)/isRunning").setValue(false)
         }
         
         return true

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultRunningRepository.swift
@@ -43,7 +43,7 @@ final class DefaultRunningRepository: RunningRepository {
             }
     }
     
-    func save(_ domain: RunningRealTimeData, sessionId: String, user: String) -> Observable<Void> {
+    func saveRunningRealTimeData(_ domain: RunningRealTimeData, sessionId: String, user: String) -> Observable<Void> {
         guard let data = try? JSONEncoder.init().encode(domain),
         let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) else {
             return Observable.error(FirebaseServiceError.nilDataError)
@@ -66,5 +66,22 @@ final class DefaultRunningRepository: RunningRepository {
     
     func stopListen(sessionId: String, mate: String) {
         self.realtimeDatabaseNetworkService.stopListen(path: ["session", "\(sessionId)/\(mate)"])
+    }
+    
+    func saveRunningStatus(of user: String, isRunning: Bool) -> Observable<Void> {
+        return self.realtimeDatabaseNetworkService.updateChildValues(
+            with: ["isRunning": isRunning],
+            path: ["state", "\(user)"]
+        )
+    }
+    
+    func fetchRunningStatus(of mate: String) -> Observable<Bool> {
+        return self.realtimeDatabaseNetworkService.fetch(of: ["state/\(mate)"])
+            .map { data in
+                guard let isRunning = data["isRunning"] as? Bool else {
+                    return false
+                }
+                return isRunning
+            }
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/Protocol/RunningRepository.swift
@@ -12,7 +12,9 @@ import RxSwift
 protocol RunningRepository {
     func listen(sessionId: String, mate: String) -> Observable<RunningRealTimeData>
     func listenIsCancelled(of sessionId: String) -> Observable<Bool>
-    func save(_ domain: RunningRealTimeData, sessionId: String, user: String) -> Observable<Void>
+    func saveRunningRealTimeData(_ domain: RunningRealTimeData, sessionId: String, user: String) -> Observable<Void>
     func cancelSession(of runningSetting: RunningSetting) -> Observable<Void>
     func stopListen(sessionId: String, mate: String)
+    func saveRunningStatus(of user: String, isRunning: Bool) -> Observable<Void>
+    func fetchRunningStatus(of mate: String) -> Observable<Bool>
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
@@ -21,6 +21,8 @@ protocol RunningUseCase {
     var totalProgress: BehaviorSubject<Double> { get set }
     var cancelTimeLeft: PublishSubject<Int> { get set }
     var popUpTimeLeft: PublishSubject<Int> { get set }
+    func updateRunningStatus()
+    func cancelRunningStatus()
     func executePedometer()
     func executeActivity()
     func executeTimer()

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
@@ -76,10 +76,10 @@ private extension InvitationViewController {
     
     func showAlert(message: String) {
         let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        let confirm = UIAlertAction(title: "확인", style: .default, handler: nil)
-        alert.addAction(confirm)
-        present(alert, animated: false, completion: { [weak self] in
+        let confirm = UIAlertAction(title: "확인", style: .default, handler: { [weak self] _ in
             self?.viewModel?.finish()
         })
+        alert.addAction(confirm)
+        present(alert, animated: false, completion: nil)
     }
 }

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -62,6 +62,10 @@ final class InvitationViewModel {
             .disposed(by: disposeBag)
         
         input.rejectButtonDidTapEvent.subscribe(onNext: { [weak self] in
+            self?.invitationUseCase.rejectInvitation()
+                .publish()
+                .connect()
+                .disposed(by: disposeBag)
             self?.finish()
         })
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/RaceRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/RaceRunningViewModel.swift
@@ -49,6 +49,7 @@ final class RaceRunningViewModel {
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()
                 self?.runningUseCase.listenRunningSession()
+                self?.runningUseCase.updateRunningStatus()
             })
             .disposed(by: disposeBag)
         
@@ -123,6 +124,7 @@ final class RaceRunningViewModel {
             .filter({ $0 || $1 })
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] (_, isCanceled) in
+                self?.runningUseCase.cancelRunningStatus()
                 self?.coordinator?.pushRunningResultViewController(
                     with: self?.runningUseCase.createRunningResult(isCanceled: isCanceled)
                 )

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/SingleRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/SingleRunningViewModel.swift
@@ -45,6 +45,7 @@ final class SingleRunningViewModel {
                 self?.runningUseCase.executePedometer()
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()
+                self?.runningUseCase.updateRunningStatus()
             })
             .disposed(by: disposeBag)
         
@@ -106,6 +107,7 @@ final class SingleRunningViewModel {
             .filter({ $0 || $1 })
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] (_, isCanceled) in
+                self?.runningUseCase.cancelRunningStatus()
                 self?.coordinator?.pushRunningResultViewController(
                     with: self?.runningUseCase.createRunningResult(isCanceled: isCanceled)
                 )

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/TeamRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/TeamRunningViewModel.swift
@@ -49,6 +49,7 @@ final class TeamRunningViewModel {
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()
                 self?.runningUseCase.listenRunningSession()
+                self?.runningUseCase.updateRunningStatus()
             })
             .disposed(by: disposeBag)
         
@@ -122,6 +123,7 @@ final class TeamRunningViewModel {
             .filter({ $0 || $1 })
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] (_, isCanceled) in
+                self?.runningUseCase.cancelRunningStatus()
                 self?.coordinator?.pushRunningResultViewController(
                     with: self?.runningUseCase.createRunningResult(isCanceled: isCanceled)
                 )


### PR DESCRIPTION
### 📕 Issue Number

Close #192 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 달리기 시작 및 종료 시 Running state 업데이트 구현
- [x] 초대장 타임아웃 관련 버그 수정: 타임아웃 시 수락 터치하면 알러트 표시, 알러트의 버튼 터치 시 홈 화면으로 이동
- [x] 혼자 달리기 시 서버에 실시간 데이터 업로드되지 않도록 수정


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 현재 달리기 시작 및 종료 시 서버에 유저의 state가 업데이트 되기만 하는 상태입니다. 아까 말씀드렸던 것처럼 달리기 중인 친구 선택 불가능하게 막는 부분은 유진님 PR 머지된 후에 구현하겠습니다!

- 특이 사항 2

<br/><br/>
