### PR TITLE
메이트 화면 리팩토링 및 메이트 목록 인디케이터 추가

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -50,16 +50,8 @@ final class DefaultMateUseCase: MateUseCase {
             .disposed(by: self.disposeBag)
     }
     
-    func filteredMate(from text: String) {
-        var mate: MateList = []
-        
-        self.mate
-            .subscribe { list in
-                mate = list
-            }
-            .disposed(by: self.disposeBag)
-        
-        self.filterText(mate, from: text)
+    func filteredMate(base mate: MateList, from text: String) {
+       self.filterText(mate, from: text)
             .subscribe { [weak self] mate in
                 self?.mate.onNext(mate)
             }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -11,7 +11,8 @@ import RxSwift
 
 protocol MateUseCase {
     typealias MateList = [(key: String, value: String)]
-    var mate: BehaviorSubject<MateList> { get set }
+    var mate: PublishSubject<MateList> { get set }
+    var didLoadMate: PublishSubject<Bool> { get set }
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -10,9 +10,9 @@ import Foundation
 import RxSwift
 
 protocol MateUseCase {
-    typealias mateList = [(key: String, value: String)]
-    var mate: PublishSubject<mateList> { get set }
-    func fetchMateInfo()
+    typealias MateList = [(key: String, value: String)]
+    var mate: BehaviorSubject<MateList> { get set }
+    func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
     func filteredMate(from text: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -16,5 +16,5 @@ protocol MateUseCase {
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
-    func filteredMate(from text: String)
+    func filteredMate(base mate: MateList, from text: String)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -10,8 +10,10 @@ import Foundation
 import RxSwift
 
 protocol MateUseCase {
-    var mate: PublishSubject<[String: String]> { get set }
+    typealias mateList = [(key: String, value: String)]
+    var mate: PublishSubject<mateList> { get set }
     func fetchMateInfo()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
+    func filteredMate(from text: String)
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/AddMateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/AddMateViewController.swift
@@ -5,11 +5,11 @@
 //  Created by 이유진 on 2021/11/17.
 //
 
-import UIKit
+ import UIKit
 
-import RxSwift
+ import RxSwift
 
-final class AddMateViewController: UIViewController {
+ final class AddMateViewController: UIViewController {
     var viewModel: AddMateViewModel?
     private let disposeBag = DisposeBag()
     
@@ -35,11 +35,11 @@ final class AddMateViewController: UIViewController {
         self.configureUI()
         self.bindViewModel()
     }
-}
+ }
 
 // MARK: - Private Functions
 
-private extension AddMateViewController {
+ private extension AddMateViewController {
     func configureUI() {
         self.navigationItem.title = "친구 검색"
         self.view.backgroundColor = .systemBackground
@@ -94,23 +94,23 @@ private extension AddMateViewController {
     
     func checkMateCount() {
         self.removeEmptyView()
-        if self.viewModel?.mate.count == 0 {
+        if self.viewModel?.filteredMate.count == 0 {
             self.addEmptyView(title: "해당 닉네임의 메이트가 없습니다.")
         }
     }
-}
+ }
 
 // MARK: - UITableViewDelegate
 
-extension AddMateViewController: UITableViewDelegate {
+ extension AddMateViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return MateTableViewValue.tableViewCellHeight.value()
     }
-}
+ }
 
 // MARK: - UITableViewDataSource
 
-extension AddMateViewController: UITableViewDataSource {
+ extension AddMateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return MateTableViewValue.tableViewHeaderHeight.value()
     }
@@ -118,13 +118,13 @@ extension AddMateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: MateHeaderView.identifier) as? MateHeaderView else { return UITableViewHeaderFooterView() }
-        header.updateUI(description: "검색 결과", value: self.viewModel?.mate.count ?? 0)
+        header.updateUI(description: "검색 결과", value: self.viewModel?.filteredMate.count ?? 0)
         
         return header
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.viewModel?.mate.count ?? 0
+        return self.viewModel?.filteredMate.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -132,17 +132,17 @@ extension AddMateViewController: UITableViewDataSource {
             withIdentifier: AddMateTableViewCell.identifier,
             for: indexPath) as? AddMateTableViewCell else { return UITableViewCell() }
         cell.delegate = self
-        let mate = self.viewModel?.mate[indexPath.row]
+        let mate = self.viewModel?.filteredMate[indexPath.row]
         cell.updateUI(name: mate?.key ?? "", image: mate?.value ?? "")
         
         return cell
     }
-}
+ }
 
 // MARK: - AddMateDelegate
 
-extension AddMateViewController: AddMateDelegate {
+ extension AddMateViewController: AddMateDelegate {
     func addMate(nickname: String) {
         self.viewModel?.requestMate(to: nickname)
     }
-}
+ }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -24,7 +24,7 @@ class MateViewController: UIViewController {
     private lazy var mateSearchBar: UISearchBar = {
         let searchBar = UISearchBar()
         searchBar.placeholder = "닉네임을 입력해주세요."
-        searchBar.backgroundImage = UIImage() // searchBar Border 없애기 위해
+        searchBar.backgroundImage = UIImage()
         return searchBar
     }()
     
@@ -113,7 +113,20 @@ private extension MateViewController {
                 self?.view.endEditing(true)
             })
             .disposed(by: disposeBag)
+        
+        output?.filteredMateArray
+            .asDriver(onErrorJustReturn: [])
+            .drive(
+                self.mateTableView.rx.items(
+                    cellIdentifier: MateTableViewCell.identifier,
+                    cellType: MateTableViewCell.self
+                )
+            ) { _, model, cell in
+                cell.updateUI(name: model.key, image: model.value)
+            }
+            .disposed(by: self.disposeBag)
     }
+    
     
     func removeEmptyView() {
         self.mateTableView.subviews.forEach({ $0.removeFromSuperview() })
@@ -140,15 +153,12 @@ private extension MateViewController {
     }
 }
 
-// MARK: - UITableViewDelegate
-extension MateViewController: UITableViewDelegate {
+// MARK: - UITableViewDelegate, UITableViewDataSource
+extension MateViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return MateTableViewValue.tableViewCellHeight.value()
     }
-}
-
-// MARK: - UITableViewDataSource
-extension MateViewController: UITableViewDataSource {
+    
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return MateTableViewValue.tableViewHeaderHeight.value()
     }
@@ -170,17 +180,13 @@ extension MateViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(
             withIdentifier: MateTableViewCell.identifier,
             for: indexPath) as? MateTableViewCell else { return UITableViewCell() }
-        
-        let mate = self.mateViewModel?.filteredMate[indexPath.row]
-        cell.updateUI(name: mate?.key ?? "", image: mate?.value ?? "")
-        
         return cell
     }
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        let mate = self.mateViewModel?.filteredMate[indexPath.row]
-        guard let mateNickname = mate?.key else { return }
-        self.moveToNext(mate: mateNickname)
-    }
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        tableView.deselectRow(at: indexPath, animated: true)
+//        let mate = self.mateViewModel?.filteredMate[indexPath.row]
+//        guard let mateNickname = mate?.key else { return }
+//        self.moveToNext(mate: mateNickname)
+//    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -20,7 +20,6 @@ enum MateTableViewValue: CGFloat {
 class MateViewController: UIViewController {
     var mateViewModel: MateViewModel?
     private let disposeBag = DisposeBag()
-    private var initialLoad = true
     
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView()
@@ -129,7 +128,6 @@ private extension MateViewController {
             .drive(onNext: { [weak self] _ in
                 self?.mateTableView.reloadData()
                 self?.didLoadMate()
-                self?.initialLoad = false
             })
             .disposed(by: self.disposeBag)
         
@@ -155,7 +153,7 @@ private extension MateViewController {
     }
     
     func checkMateCount() {
-        if self.mateViewModel?.filteredMate?.count == 0 && !(self.initialLoad) {
+        if self.mateViewModel?.filteredMate?.count == 0 && !(self.mateViewModel?.initialLoad ?? true) {
             self.addEmptyView()
         } else {
             self.removeEmptyView()

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
@@ -13,7 +13,8 @@ import RxRelay
 final class AddMateViewModel {
     private let mateUseCase: MateUseCase
     weak var coordinator: AddMateCoordinator?
-    var mate: [(key: String, value: String)] = []
+    typealias MateList = [(key: String, value: String)]
+    var filteredMate: MateList = []
     
     struct Input {
         let searchButtonDidTap: Observable<Void>
@@ -47,7 +48,7 @@ final class AddMateViewModel {
         
         self.mateUseCase.mate
             .subscribe(onNext: { [weak self] mate in
-                self?.mate = self?.sortedMate(list: mate) ?? []
+                self?.filteredMate = mate
                 output.loadData.accept(true)
             })
             .disposed(by: disposeBag)
@@ -57,12 +58,5 @@ final class AddMateViewModel {
     
     func requestMate(to mate: String) {
         self.mateUseCase.sendRequestMate(to: mate)
-    }
-}
-
-// MARK: - Private Functions
-private extension AddMateViewModel {
-    func sortedMate(list: [String: String]) -> [(key: String, value: String)] {
-        return list.sorted { $0.0 < $1.0 }
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
@@ -13,7 +13,7 @@ final class MateViewModel {
     private let mateUseCase: MateUseCase
     weak var coordinator: MateCoordinator?
     typealias MateList = [(key: String, value: String)]
-    var filteredMate: MateList = []
+    var filteredMate: MateList?
     
     struct Input {
         let viewDidLoadEvent: Observable<Void>
@@ -66,6 +66,12 @@ final class MateViewModel {
         self.mateUseCase.mate
             .subscribe(onNext: { [weak self] mate in
                 self?.filteredMate = mate
+            })
+            .disposed(by: disposeBag)
+        
+        self.mateUseCase.didLoadMate
+            .filter { $0 }
+            .subscribe(onNext: { _ in
                 output.loadData.accept(true)
             })
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
@@ -12,8 +12,8 @@ import RxRelay
 final class MateViewModel {
     private let mateUseCase: MateUseCase
     weak var coordinator: MateCoordinator?
-    var mate: [String: String] = [:] // usecase에서 fetch 받고 순서맞춘 딕셔너리, 필터링 되는 것을 기준으로 잡을 원래의 딕셔너리
-    var filteredMate: [(key: String, value: String)] = []
+    
+    typealias mateList = [(key: String, value: String)]
     
     struct Input {
         let viewDidLoadEvent: Observable<Void>
@@ -25,7 +25,8 @@ final class MateViewModel {
     struct Output {
         @BehaviorRelayProperty var loadData: Bool = false
         @BehaviorRelayProperty var filterData: Bool = false
-        let doneButtonDidTap = PublishRelay<Bool>()
+        var doneButtonDidTap = PublishRelay<Bool>()
+        var filteredMateArray = PublishRelay<mateList>()
     }
     
     init(coordinator: MateCoordinator, mateUseCase: MateUseCase) {
@@ -43,10 +44,10 @@ final class MateViewModel {
             .disposed(by: disposeBag)
         
         input.searchBarTextEvent
-            .debounce(RxTimeInterval.microseconds(5), scheduler: MainScheduler.instance) // 0.5초동안 들어온 것중에 최신것을 방출
-            .distinctUntilChanged() // 같은 값 들어오면 무시
+            .debounce(RxTimeInterval.microseconds(5), scheduler: MainScheduler.instance)
+            .distinctUntilChanged()
             .subscribe(onNext: { [weak self] text in
-                self?.filterText(from: text)
+                self?.mateUseCase.filteredMate(from: text)
                 output.filterData = true
             })
             .disposed(by: disposeBag)
@@ -64,30 +65,17 @@ final class MateViewModel {
             .disposed(by: disposeBag)
         
         self.mateUseCase.mate
-            .subscribe(onNext: { [weak self] mate in
-                self?.mate = mate
-                self?.filteredMate = self?.sortedMate(list: mate) ?? []
-                output.loadData = true
-            })
+            .bind(to: output.filteredMateArray)
             .disposed(by: disposeBag)
         
         return output
     }
     
-    func pushMateProfile(of nickname: String) {
-        self.coordinator?.showMateProfileFlow(nickname)
-    }
-}
-
-// MARK: - Private Functions
-private extension MateViewModel {
-    func filterText(from text: String) {
-        self.filteredMate = self.sortedMate(list: self.mate.filter { key, _ in // 초기 mate를 기준으로 filter
-            return key.hasPrefix(text)
-        })
+    func bindMate(output: Output, disposeBag: DisposeBag) {
+        
     }
     
-    func sortedMate(list: [String: String]) -> [(key: String, value: String)] {
-        return list.sorted { $0.0 < $1.0 }
+    func pushMateProfile(of nickname: String) {
+        self.coordinator?.showMateProfileFlow(nickname)
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #190 #173 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 친구 목록 불러올 때 인디케이터 추가
- [x] 메이트 화면 비즈니스 로직 위치 변경


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
줌에서 말한것 처럼 rxdatasource없이 헤더나 섹션이 있는 테이블 뷰는 완벽하게 뷰컨과 분리를 시키기는 어려울것 같습니다..!
셀을 그리는 것 정도는 rx로 하려고 했으나 어차피 datasource를 채택하는 이상 셀을 그리는 메서드를 정의해야 하고 이렇게 되면 셀을 정의하는 부분이 2곳이 생기다보니 오히려 중복되는 코드가 생기는 느낌이 들었고 두번째로는 조금 더 복잡한 테이블뷰 같은 경우는 (친구 프로필) 셀을 업데이트 하는 부분을 섹션별로 업데이트 하는 부분이 rxcocoa만으로는 한계가 있는것 같아  다시 기존의 방식으로 돌아갔습니다.! 

- 특이 사항 2
의외로 인디케이터 부분에서 조금 고민이 생겼는데.. 현재 엠티뷰와 섞여있다보니 `처음 정보를 load해올때(엠티뷰는 뜨지않고 인디케이터만 떠야함)` , `두번째 부터는 인디케이터 사용 X, 검색해서 비어있을 경우 엠티뷰만 떠야함` 을 처리하려다보니 뷰모델에 initialLoad 라는 플래그값을 두게 되었습니다! 플래그값 없이 할 수 있는 방법이 있을지 고민입니다..!


<br/><br/>
