### PR TITLE
메이트 요청시 FCM 전송과 함께 DB저장

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		5ED367DD27462BAD00901765 /* Int+Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED367DC27462BAD00901765 /* Int+Formatter.swift */; };
 		5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFABAED272FB5EB00686D08 /* UIColor+CustomColor.swift */; };
 		A8BD1D11AC8D953B7B75A308 /* Pods_RunningPreparationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0558F90EC7B3E79D9E2A05AD /* Pods_RunningPreparationTests.framework */; };
+		AE263BE0274D2403004A61E5 /* NoticeDTO+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BDF274D2403004A61E5 /* NoticeDTO+Mapping.swift */; };
 		AE3D14852737C5E600D4A186 /* Mets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D14842737C5E600D4A186 /* Mets.swift */; };
 		AE3D148B273A5D8D00D4A186 /* MateHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */; };
 		AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148C273A5DB400D4A186 /* MateViewModel.swift */; };
@@ -147,7 +148,7 @@
 		AEA8C559273D53360066E0E1 /* DefaultEmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */; };
 		AEA8C55C273D538A0066E0E1 /* EmojiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */; };
 		AEA8C55F273D6E690066E0E1 /* EmojiUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */; };
-		AEB3DFBC274956C30083BA9B /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB3DFBB274956C30083BA9B /* UserProfile.swift */; };
+		AEB3DFBC274956C30083BA9B /* UserProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB3DFBB274956C30083BA9B /* UserProfileDTO.swift */; };
 		AEB3DFBE274957D90083BA9B /* DefaultProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB3DFBD274957D90083BA9B /* DefaultProfileUseCase.swift */; };
 		AEB3DFC0274957E40083BA9B /* ProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB3DFBF274957E40083BA9B /* ProfileUseCase.swift */; };
 		AECB9A8227356AFF00533EF7 /* RunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB9A8127356AFF00533EF7 /* RunningUseCase.swift */; };
@@ -362,6 +363,7 @@
 		5EFABAED272FB5EB00686D08 /* UIColor+CustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CustomColor.swift"; sourceTree = "<group>"; };
 		75C2EB60A3DA2C9F93988C5E /* Pods-DistanceSettingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DistanceSettingTests.release.xcconfig"; path = "Target Support Files/Pods-DistanceSettingTests/Pods-DistanceSettingTests.release.xcconfig"; sourceTree = "<group>"; };
 		8364F1D7FD08181C4FEFF6CA /* Pods_DistanceSettingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DistanceSettingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE263BDF274D2403004A61E5 /* NoticeDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoticeDTO+Mapping.swift"; sourceTree = "<group>"; };
 		AE3D14842737C5E600D4A186 /* Mets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mets.swift; sourceTree = "<group>"; };
 		AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateHeaderView.swift; sourceTree = "<group>"; };
 		AE3D148C273A5DB400D4A186 /* MateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MateViewModel.swift; path = MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -410,7 +412,7 @@
 		AEA8C558273D53360066E0E1 /* DefaultEmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEmojiUseCase.swift; sourceTree = "<group>"; };
 		AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiViewModel.swift; sourceTree = "<group>"; };
 		AEA8C55E273D6E690066E0E1 /* EmojiUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUseCase.swift; sourceTree = "<group>"; };
-		AEB3DFBB274956C30083BA9B /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		AEB3DFBB274956C30083BA9B /* UserProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileDTO.swift; sourceTree = "<group>"; };
 		AEB3DFBD274957D90083BA9B /* DefaultProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProfileUseCase.swift; sourceTree = "<group>"; };
 		AEB3DFBF274957E40083BA9B /* ProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUseCase.swift; sourceTree = "<group>"; };
 		AECB9A8127356AFF00533EF7 /* RunningUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningUseCase.swift; sourceTree = "<group>"; };
@@ -646,8 +648,10 @@
 		3DFD08A62733A37800B46479 /* DataMapping */ = {
 			isa = PBXGroup;
 			children = (
+				AEB3DFBB274956C30083BA9B /* UserProfileDTO.swift */,
 				3DFD08A72733A39300B46479 /* RunningResultDTO+Mapping.swift */,
 				AE77C20C274632EF005EDEE0 /* MessagingRequestDTO.swift */,
+				AE263BDF274D2403004A61E5 /* NoticeDTO+Mapping.swift */,
 			);
 			path = DataMapping;
 			sourceTree = "<group>";
@@ -681,7 +685,6 @@
 				B0A0DA212744A126004DDC71 /* Region.swift */,
 				5E7B862727495A88003F9FA2 /* CalendarModel.swift */,
 				AE77C20E27463A76005EDEE0 /* MateRequest.swift */,
-				AEB3DFBB274956C30083BA9B /* UserProfile.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1900,6 +1903,7 @@
 				B0628B8D27397415004FAB0F /* DistanceSettingUseCase.swift in Sources */,
 				B03A563C2745E6FA00C5C2F2 /* FirebaseServiceError.swift in Sources */,
 				5E4675F2274139E20047D098 /* PickerTextField.swift in Sources */,
+				AE263BE0274D2403004A61E5 /* NoticeDTO+Mapping.swift in Sources */,
 				AE6A6F35272FC170005A3A5C /* DistanceSettingViewController.swift in Sources */,
 				3D2C2198273CF0D700D00C68 /* User.swift in Sources */,
 				3D6225492745E42B00E4A327 /* UserRepository.swift in Sources */,
@@ -2025,7 +2029,7 @@
 				5EAFFC5C2742309C00E985D7 /* DefaultSignUpUseCase.swift in Sources */,
 				AE77C21B27473BDF005EDEE0 /* MateRecordTableViewCell.swift in Sources */,
 				B0F5328B273A3397005A3F11 /* TabBarCoordinator.swift in Sources */,
-				AEB3DFBC274956C30083BA9B /* UserProfile.swift in Sources */,
+				AEB3DFBC274956C30083BA9B /* UserProfileDTO.swift in Sources */,
 				B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */,
 				AE3D148B273A5D8D00D4A186 /* MateHeaderView.swift in Sources */,
 				B0CF5C8327480CD1002217F6 /* RunningResultViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFABAED272FB5EB00686D08 /* UIColor+CustomColor.swift */; };
 		A8BD1D11AC8D953B7B75A308 /* Pods_RunningPreparationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0558F90EC7B3E79D9E2A05AD /* Pods_RunningPreparationTests.framework */; };
 		AE263BE0274D2403004A61E5 /* NoticeDTO+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BDF274D2403004A61E5 /* NoticeDTO+Mapping.swift */; };
+		AE263BE2274DDD62004A61E5 /* NoticeMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BE1274DDD62004A61E5 /* NoticeMode.swift */; };
+		AE263BE4274DDD7F004A61E5 /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BE3274DDD7F004A61E5 /* Notice.swift */; };
 		AE3D14852737C5E600D4A186 /* Mets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D14842737C5E600D4A186 /* Mets.swift */; };
 		AE3D148B273A5D8D00D4A186 /* MateHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */; };
 		AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148C273A5DB400D4A186 /* MateViewModel.swift */; };
@@ -364,6 +366,8 @@
 		75C2EB60A3DA2C9F93988C5E /* Pods-DistanceSettingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DistanceSettingTests.release.xcconfig"; path = "Target Support Files/Pods-DistanceSettingTests/Pods-DistanceSettingTests.release.xcconfig"; sourceTree = "<group>"; };
 		8364F1D7FD08181C4FEFF6CA /* Pods_DistanceSettingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DistanceSettingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE263BDF274D2403004A61E5 /* NoticeDTO+Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoticeDTO+Mapping.swift"; sourceTree = "<group>"; };
+		AE263BE1274DDD62004A61E5 /* NoticeMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeMode.swift; sourceTree = "<group>"; };
+		AE263BE3274DDD7F004A61E5 /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 		AE3D14842737C5E600D4A186 /* Mets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mets.swift; sourceTree = "<group>"; };
 		AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateHeaderView.swift; sourceTree = "<group>"; };
 		AE3D148C273A5DB400D4A186 /* MateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MateViewModel.swift; path = MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -685,6 +689,7 @@
 				B0A0DA212744A126004DDC71 /* Region.swift */,
 				5E7B862727495A88003F9FA2 /* CalendarModel.swift */,
 				AE77C20E27463A76005EDEE0 /* MateRequest.swift */,
+				AE263BE3274DDD7F004A61E5 /* Notice.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1406,6 +1411,7 @@
 				5E5E555227450662002FE126 /* UserDefaultKey.swift */,
 				B03A563D2745E7EF00C5C2F2 /* FirebaseCollection.swift */,
 				3D62255827495ED400E4A327 /* Configuration.swift */,
+				AE263BE1274DDD62004A61E5 /* NoticeMode.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -1928,6 +1934,7 @@
 				B04A86B42732C09D00F46069 /* RunningPreparationViewModel.swift in Sources */,
 				B0F5328D273A33D0005A3F11 /* DefaultTabBarCoordinator.swift in Sources */,
 				AEA8C559273D53360066E0E1 /* DefaultEmojiUseCase.swift in Sources */,
+				AE263BE2274DDD62004A61E5 /* NoticeMode.swift in Sources */,
 				5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */,
 				3D2C2192273CB55F00D00C68 /* Invitation.swift in Sources */,
 				5E6F3826273A0F52009686DC /* TeamRunningViewController.swift in Sources */,
@@ -1946,6 +1953,7 @@
 				3DAF2D832743A05700AC5FEA /* InvitationViewModel.swift in Sources */,
 				B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */,
 				5E7DEE7B273FA78F002E1374 /* DefaultLoginCoordinator.swift in Sources */,
+				AE263BE4274DDD7F004A61E5 /* Notice.swift in Sources */,
 				B04A86CD2732F48300F46069 /* RunningPreparationUseCase.swift in Sources */,
 				AE77C2022744DFAB005EDEE0 /* DefaultAddMateCoordinator.swift in Sources */,
 				3D2C218C273B9F9B00D00C68 /* DefaultInvitationWaitingUseCase.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Network/DataMapping/NoticeDTO+Mapping.swift
+++ b/MateRunner/MateRunner/Data/Network/DataMapping/NoticeDTO+Mapping.swift
@@ -7,15 +7,6 @@
 
 import Foundation
 
-enum NoticeMode: String {
-    case invite = "invite"
-    case requestMate = "requestMate"
-    
-    func text() -> String {
-        return self.rawValue
-    }
-}
-
 struct NoticeDTO: Codable {
     private let sender: String
     private let receiver: String
@@ -33,34 +24,10 @@ struct NoticeDTO: Codable {
     }
     
     func toDomain() -> Notice {
-        var noticeMode = NoticeMode.invite
-        
-        if self.mode == NoticeMode.invite.text() {
-            noticeMode = NoticeMode.invite
-        } else {
-            noticeMode = NoticeMode.requestMate
-        }
-        
         return Notice(
             sender: self.sender,
             receiver: self.receiver,
-            mode: noticeMode
+            mode: NoticeMode(rawValue: self.mode) ?? .invite
         )
-    }
-}
-
-struct Notice {
-    private(set) var sender: String
-    private(set) var receiver: String
-    private(set) var mode: NoticeMode
-    
-    init(
-        sender: String,
-        receiver: String,
-        mode: NoticeMode
-    ) {
-        self.sender = sender
-        self.receiver = receiver
-        self.mode = mode
     }
 }

--- a/MateRunner/MateRunner/Data/Network/DataMapping/NoticeDTO+Mapping.swift
+++ b/MateRunner/MateRunner/Data/Network/DataMapping/NoticeDTO+Mapping.swift
@@ -1,0 +1,66 @@
+//
+//  NoticeDTO+Mapping.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/23.
+//
+
+import Foundation
+
+enum NoticeMode: String {
+    case invite = "invite"
+    case requestMate = "requestMate"
+    
+    func text() -> String {
+        return self.rawValue
+    }
+}
+
+struct NoticeDTO: Codable {
+    private let sender: String
+    private let receiver: String
+    private let mode: String
+    
+    init(from domain: Notice) {
+        self.sender = domain.sender
+        self.receiver = domain.receiver
+        
+        if domain.mode == .invite {
+            self.mode = NoticeMode.invite.text()
+        } else {
+            self.mode = NoticeMode.requestMate.text()
+        }
+    }
+    
+    func toDomain() -> Notice {
+        var noticeMode = NoticeMode.invite
+        
+        if self.mode == NoticeMode.invite.text() {
+            noticeMode = NoticeMode.invite
+        } else {
+            noticeMode = NoticeMode.requestMate
+        }
+        
+        return Notice(
+            sender: self.sender,
+            receiver: self.receiver,
+            mode: noticeMode
+        )
+    }
+}
+
+struct Notice {
+    private(set) var sender: String
+    private(set) var receiver: String
+    private(set) var mode: NoticeMode
+    
+    init(
+        sender: String,
+        receiver: String,
+        mode: NoticeMode
+    ) {
+        self.sender = sender
+        self.receiver = receiver
+        self.mode = mode
+    }
+}

--- a/MateRunner/MateRunner/Data/Network/DataMapping/UserProfileDTO.swift
+++ b/MateRunner/MateRunner/Data/Network/DataMapping/UserProfileDTO.swift
@@ -1,5 +1,5 @@
 //
-//  UserProfile.swift
+//  UserProfileDTO.swift
 //  MateRunner
 //
 //  Created by 이유진 on 2021/11/21.

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -72,4 +72,17 @@ final class DefaultMateRepository: MateRepository {
     func fetchFCMToken(of mate: String)-> Observable<String> {
         return self.realtimeNetworkService.fetchFCMToken(of: mate)
     }
+    
+    func saveRequestMate(_ notice: Notice?) -> Observable<Void> {
+        guard let notice = notice else {
+            return Observable.error(FirebaseServiceError.nilDataError)
+        }
+        
+        return self.fireStoreNetworkService.writeDTO(
+            NoticeDTO(from: notice),
+            collection: "Notification",
+            document: notice.receiver,
+            key: notice.sender
+        )
+    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
@@ -15,4 +15,5 @@ protocol MateRepository {
     func fetchFilteredNickname(text: String) -> Observable<[String]>
     func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> 
     func fetchFCMToken(of mate: String)-> Observable<String>
+    func saveRequestMate(_ notice: Notice?) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
@@ -13,6 +13,6 @@ protocol MateRepository {
     func fetchMateNickname() -> Observable<[String]>
     func fetchMateProfileImage(from nickname: String) -> Observable<String>
     func fetchFilteredNickname(text: String) -> Observable<[String]>
-    func sendRequestMate(from sender: String, fcmToken: String)
+    func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> 
     func fetchFCMToken(of mate: String)-> Observable<String>
 }

--- a/MateRunner/MateRunner/Domain/Model/Notice.swift
+++ b/MateRunner/MateRunner/Domain/Model/Notice.swift
@@ -6,3 +6,19 @@
 //
 
 import Foundation
+
+struct Notice {
+    private(set) var sender: String
+    private(set) var receiver: String
+    private(set) var mode: NoticeMode
+    
+    init(
+        sender: String,
+        receiver: String,
+        mode: NoticeMode
+    ) {
+        self.sender = sender
+        self.receiver = receiver
+        self.mode = mode
+    }
+}

--- a/MateRunner/MateRunner/Domain/Model/Notice.swift
+++ b/MateRunner/MateRunner/Domain/Model/Notice.swift
@@ -1,0 +1,8 @@
+//
+//  Notice.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/24.
+//
+
+import Foundation

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-import RxSwift
 import RxRelay
+import RxSwift
 
 final class DefaultMateUseCase: MateUseCase {
     private let repository: MateRepository

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -15,6 +15,7 @@ final class DefaultMateUseCase: MateUseCase {
     private let disposeBag = DisposeBag()
     var mate: PublishSubject<MateList> = PublishSubject()
     var didLoadMate: PublishSubject<Bool> = PublishSubject()
+    var didRequestMate: PublishSubject<Bool> = PublishSubject()
     
     init(repository: MateRepository) {
         self.repository = repository
@@ -79,10 +80,7 @@ final class DefaultMateUseCase: MateUseCase {
         )
         self.repository.saveRequestMate(notice)
             .subscribe(onNext: { [weak self] in
-                self?.mateToIndexPath(of: mate)
-                    .subscribe(onNext: { [weak self] index in
-                    })
-                    .disposed(by: self?.disposeBag ?? DisposeBag())
+                self?.didRequestMate.onNext(true)
             })
             .disposed(by: self.disposeBag)
     }
@@ -100,19 +98,5 @@ final class DefaultMateUseCase: MateUseCase {
     private func sortedMate(list: [String: String]) -> MateList {
         return list.sorted { $0.0 < $1.0 }
     }
-    
-    private func mateToIndexPath(of nickname: String) -> Observable<Int> {
-        return PublishSubject<Int>.create{ [weak self] observe in
-            self?.mate
-                .subscribe(onNext:{ mate in
-                    for i in 0..<mate.count {
-                        if mate[i].key == nickname {
-                            observe.onNext(i)
-                        }
-                    }
-                })
-                .disposed(by: self?.disposeBag ?? DisposeBag())
-            return Disposables.create()
-        }
-    }
+
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -61,7 +61,11 @@ final class DefaultMateUseCase: MateUseCase {
     func sendRequestMate(to mate: String) {
         self.repository.fetchFCMToken(of: mate)
             .subscribe(onNext: { [weak self] token in
-                self?.repository.sendRequestMate(from: "yujin", fcmToken: token)
+                self?.repository.sendRequestMate(from: "yjsimul", fcmToken: token)
+                    .subscribe(onNext: {
+                        
+                    })
+                    .disposed(by: self?.disposeBag ?? DisposeBag())
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -50,16 +50,8 @@ final class DefaultMateUseCase: MateUseCase {
             .disposed(by: self.disposeBag)
     }
     
-    func filteredMate(from text: String) {
-        var mate: MateList = []
-        
-        self.mate
-            .subscribe { list in
-                mate = list
-            }
-            .disposed(by: self.disposeBag)
-        
-        self.filterText(mate, from: text)
+    func filteredMate(base mate: MateList, from text: String) {
+       self.filterText(mate, from: text)
             .subscribe { [weak self] mate in
                 self?.mate.onNext(mate)
             }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -62,10 +62,23 @@ final class DefaultMateUseCase: MateUseCase {
         self.repository.fetchFCMToken(of: mate)
             .subscribe(onNext: { [weak self] token in
                 self?.repository.sendRequestMate(from: "yjsimul", fcmToken: token)
-                    .subscribe(onNext: {
-                        
+                    .subscribe(onNext: { [weak self] in
+                        self?.saveRequestMate(to: mate)
                     })
                     .disposed(by: self?.disposeBag ?? DisposeBag())
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func saveRequestMate(to mate: String) {
+        let notice = Notice(
+            sender: "yujin",
+            receiver: mate,
+            mode: NoticeMode.requestMate
+        )
+        self.repository.saveRequestMate(notice)
+            .subscribe(onNext: {
+                
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -52,7 +52,7 @@ final class DefaultMateUseCase: MateUseCase {
             .disposed(by: self.disposeBag)
     }
     
-    func filteredMate(base mate: MateList, from text: String) {
+    func filterMate(base mate: MateList, from text: String) {
        self.filterText(mate, from: text)
             .subscribe { [weak self] mate in
                 self?.mate.onNext(mate)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -13,7 +13,7 @@ import RxRelay
 final class DefaultMateUseCase: MateUseCase {
     private let repository: MateRepository
     private let disposeBag = DisposeBag()
-    var mate: PublishSubject<MateList> = PublishSubject()
+    var mateList: PublishSubject<MateList> = PublishSubject()
     var didLoadMate: PublishSubject<Bool> = PublishSubject()
     var didRequestMate: PublishSubject<Bool> = PublishSubject()
     
@@ -46,7 +46,7 @@ final class DefaultMateUseCase: MateUseCase {
                 })
         })
             .subscribe { [weak self] _ in
-                self?.mate.onNext(self?.sortedMate(list: mateList) ?? [])
+                self?.mateList.onNext(self?.sortedMate(list: mateList) ?? [])
                 self?.didLoadMate.onNext(true)
             }
             .disposed(by: self.disposeBag)
@@ -55,7 +55,7 @@ final class DefaultMateUseCase: MateUseCase {
     func filterMate(base mate: MateList, from text: String) {
        self.filterText(mate, from: text)
             .subscribe { [weak self] mate in
-                self?.mate.onNext(mate)
+                self?.mateList.onNext(mate)
             }
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -11,7 +11,8 @@ import RxSwift
 
 protocol MateUseCase {
     typealias MateList = [(key: String, value: String)]
-    var mate: BehaviorSubject<MateList> { get set }
+    var mate: PublishSubject<MateList> { get set }
+    var didLoadMate: PublishSubject<Bool> { get set }
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -17,5 +17,5 @@ protocol MateUseCase {
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
-    func filteredMate(base mate: MateList, from text: String)
+    func filterMate(base mate: MateList, from text: String)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 protocol MateUseCase {
     typealias MateList = [(key: String, value: String)]
-    var mate: PublishSubject<MateList> { get set }
+    var mateList: PublishSubject<MateList> { get set }
     var didLoadMate: PublishSubject<Bool> { get set }
     var didRequestMate: PublishSubject<Bool> { get set }
     func fetchMateList()

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -10,9 +10,9 @@ import Foundation
 import RxSwift
 
 protocol MateUseCase {
-    typealias mateList = [(key: String, value: String)]
-    var mate: PublishSubject<mateList> { get set }
-    func fetchMateInfo()
+    typealias MateList = [(key: String, value: String)]
+    var mate: BehaviorSubject<MateList> { get set }
+    func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
     func filteredMate(from text: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -13,6 +13,7 @@ protocol MateUseCase {
     typealias MateList = [(key: String, value: String)]
     var mate: PublishSubject<MateList> { get set }
     var didLoadMate: PublishSubject<Bool> { get set }
+    var didRequestMate: PublishSubject<Int> { get set }
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -13,7 +13,7 @@ protocol MateUseCase {
     typealias MateList = [(key: String, value: String)]
     var mate: PublishSubject<MateList> { get set }
     var didLoadMate: PublishSubject<Bool> { get set }
-    var didRequestMate: PublishSubject<Int> { get set }
+    var didRequestMate: PublishSubject<Bool> { get set }
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -16,5 +16,5 @@ protocol MateUseCase {
     func fetchMateList()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
-    func filteredMate(from text: String)
+    func filteredMate(base mate: MateList, from text: String)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/MateUseCase.swift
@@ -10,8 +10,10 @@ import Foundation
 import RxSwift
 
 protocol MateUseCase {
-    var mate: PublishSubject<[String: String]> { get set }
+    typealias mateList = [(key: String, value: String)]
+    var mate: PublishSubject<mateList> { get set }
     func fetchMateInfo()
     func fetchMateInfo(name: String)
     func sendRequestMate(to mate: String)
+    func filteredMate(from text: String)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -121,8 +121,9 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             coordinator: DefaultMateCoordinator(UINavigationController()),
             mateUseCase: DefaultMateUseCase(
                 repository: DefaultMateRepository(
-                    networkService: DefaultFireStoreNetworkService(),
-                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService()
+                    fireStoreNetworkService: DefaultFireStoreNetworkService(),
+                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
+                    urlSessionNetworkService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
@@ -28,8 +28,9 @@ final class DefaultAddMateCoordinator: AddMateCoordinator {
             coordinator: self,
             mateUseCase: DefaultMateUseCase(
                 repository: DefaultMateRepository(
-                    networkService: DefaultFireStoreNetworkService(),
-                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService()
+                    fireStoreNetworkService: DefaultFireStoreNetworkService(),
+                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
+                    urlSessionNetworkService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -24,8 +24,9 @@ final class DefaultMateCoordinator: MateCoordinator {
             coordinator: self,
             mateUseCase: DefaultMateUseCase(
                 repository: DefaultMateRepository(
-                    networkService: DefaultFireStoreNetworkService(),
-                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService()
+                    fireStoreNetworkService: DefaultFireStoreNetworkService(),
+                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
+                    urlSessionNetworkService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
@@ -62,6 +62,7 @@ private extension AddMateTableViewCell {
             .bind { [weak self] in
                 guard let mate = self?.mateNameLabel.text else { return }
                 self?.addButton.isEnabled = false
+                self?.addButton.backgroundColor = .mrGray
                 self?.delegate?.addMate(nickname: mate)
             }
             .disposed(by: self.disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
@@ -61,6 +61,7 @@ private extension AddMateTableViewCell {
         self.addButton.rx.tap
             .bind { [weak self] in
                 guard let mate = self?.mateNameLabel.text else { return }
+                self?.addButton.isEnabled = false
                 self?.delegate?.addMate(nickname: mate)
             }
             .disposed(by: self.disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/AddMateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/AddMateViewController.swift
@@ -5,11 +5,11 @@
 //  Created by 이유진 on 2021/11/17.
 //
 
- import UIKit
+import UIKit
 
- import RxSwift
+import RxSwift
 
- final class AddMateViewController: UIViewController {
+final class AddMateViewController: UIViewController {
     var viewModel: AddMateViewModel?
     private let disposeBag = DisposeBag()
     
@@ -35,11 +35,11 @@
         self.configureUI()
         self.bindViewModel()
     }
- }
+}
 
 // MARK: - Private Functions
 
- private extension AddMateViewController {
+private extension AddMateViewController {
     func configureUI() {
         self.navigationItem.title = "친구 검색"
         self.view.backgroundColor = .systemBackground
@@ -98,19 +98,19 @@
             self.addEmptyView(title: "해당 닉네임의 메이트가 없습니다.")
         }
     }
- }
+}
 
 // MARK: - UITableViewDelegate
 
- extension AddMateViewController: UITableViewDelegate {
+extension AddMateViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return MateTableViewValue.tableViewCellHeight.value()
     }
- }
+}
 
 // MARK: - UITableViewDataSource
 
- extension AddMateViewController: UITableViewDataSource {
+extension AddMateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return MateTableViewValue.tableViewHeaderHeight.value()
     }
@@ -137,12 +137,12 @@
         
         return cell
     }
- }
+}
 
 // MARK: - AddMateDelegate
 
- extension AddMateViewController: AddMateDelegate {
+extension AddMateViewController: AddMateDelegate {
     func addMate(nickname: String) {
         self.viewModel?.requestMate(to: nickname)
     }
- }
+}

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/AddMateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/AddMateViewController.swift
@@ -5,11 +5,11 @@
 //  Created by 이유진 on 2021/11/17.
 //
 
-import UIKit
+ import UIKit
 
-import RxSwift
+ import RxSwift
 
-final class AddMateViewController: UIViewController {
+ final class AddMateViewController: UIViewController {
     var viewModel: AddMateViewModel?
     private let disposeBag = DisposeBag()
     
@@ -35,11 +35,11 @@ final class AddMateViewController: UIViewController {
         self.configureUI()
         self.bindViewModel()
     }
-}
+ }
 
 // MARK: - Private Functions
 
-private extension AddMateViewController {
+ private extension AddMateViewController {
     func configureUI() {
         self.navigationItem.title = "친구 검색"
         self.view.backgroundColor = .systemBackground
@@ -94,23 +94,23 @@ private extension AddMateViewController {
     
     func checkMateCount() {
         self.removeEmptyView()
-        if self.viewModel?.mate.count == 0 {
+        if self.viewModel?.filteredMate.count == 0 {
             self.addEmptyView(title: "해당 닉네임의 메이트가 없습니다.")
         }
     }
-}
+ }
 
 // MARK: - UITableViewDelegate
 
-extension AddMateViewController: UITableViewDelegate {
+ extension AddMateViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return MateTableViewValue.tableViewCellHeight.value()
     }
-}
+ }
 
 // MARK: - UITableViewDataSource
 
-extension AddMateViewController: UITableViewDataSource {
+ extension AddMateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return MateTableViewValue.tableViewHeaderHeight.value()
     }
@@ -118,13 +118,13 @@ extension AddMateViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: MateHeaderView.identifier) as? MateHeaderView else { return UITableViewHeaderFooterView() }
-        header.updateUI(description: "검색 결과", value: self.viewModel?.mate.count ?? 0)
+        header.updateUI(description: "검색 결과", value: self.viewModel?.filteredMate.count ?? 0)
         
         return header
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.viewModel?.mate.count ?? 0
+        return self.viewModel?.filteredMate.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -132,17 +132,17 @@ extension AddMateViewController: UITableViewDataSource {
             withIdentifier: AddMateTableViewCell.identifier,
             for: indexPath) as? AddMateTableViewCell else { return UITableViewCell() }
         cell.delegate = self
-        let mate = self.viewModel?.mate[indexPath.row]
+        let mate = self.viewModel?.filteredMate[indexPath.row]
         cell.updateUI(name: mate?.key ?? "", image: mate?.value ?? "")
         
         return cell
     }
-}
+ }
 
 // MARK: - AddMateDelegate
 
-extension AddMateViewController: AddMateDelegate {
+ extension AddMateViewController: AddMateDelegate {
     func addMate(nickname: String) {
         self.viewModel?.requestMate(to: nickname)
     }
-}
+ }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -24,7 +24,7 @@ class MateViewController: UIViewController {
     private lazy var mateSearchBar: UISearchBar = {
         let searchBar = UISearchBar()
         searchBar.placeholder = "닉네임을 입력해주세요."
-        searchBar.backgroundImage = UIImage() // searchBar Border 없애기 위해
+        searchBar.backgroundImage = UIImage()
         return searchBar
     }()
     
@@ -113,7 +113,20 @@ private extension MateViewController {
                 self?.view.endEditing(true)
             })
             .disposed(by: disposeBag)
+        
+        output?.filteredMateArray
+            .asDriver(onErrorJustReturn: [])
+            .drive(
+                self.mateTableView.rx.items(
+                    cellIdentifier: MateTableViewCell.identifier,
+                    cellType: MateTableViewCell.self
+                )
+            ) { _, model, cell in
+                cell.updateUI(name: model.key, image: model.value)
+            }
+            .disposed(by: self.disposeBag)
     }
+    
     
     func removeEmptyView() {
         self.mateTableView.subviews.forEach({ $0.removeFromSuperview() })
@@ -140,15 +153,12 @@ private extension MateViewController {
     }
 }
 
-// MARK: - UITableViewDelegate
-extension MateViewController: UITableViewDelegate {
+// MARK: - UITableViewDelegate, UITableViewDataSource
+extension MateViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return MateTableViewValue.tableViewCellHeight.value()
     }
-}
-
-// MARK: - UITableViewDataSource
-extension MateViewController: UITableViewDataSource {
+    
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return MateTableViewValue.tableViewHeaderHeight.value()
     }
@@ -170,17 +180,13 @@ extension MateViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(
             withIdentifier: MateTableViewCell.identifier,
             for: indexPath) as? MateTableViewCell else { return UITableViewCell() }
-        
-        let mate = self.mateViewModel?.filteredMate[indexPath.row]
-        cell.updateUI(name: mate?.key ?? "", image: mate?.value ?? "")
-        
         return cell
     }
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        let mate = self.mateViewModel?.filteredMate[indexPath.row]
-        guard let mateNickname = mate?.key else { return }
-        self.moveToNext(mate: mateNickname)
-    }
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        tableView.deselectRow(at: indexPath, animated: true)
+//        let mate = self.mateViewModel?.filteredMate[indexPath.row]
+//        guard let mateNickname = mate?.key else { return }
+//        self.moveToNext(mate: mateNickname)
+//    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -31,6 +31,7 @@ class MateViewController: UIViewController {
         activityIndicator.startAnimating()
         return activityIndicator
     }()
+    
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
@@ -122,7 +123,7 @@ private extension MateViewController {
         
         let output = self.mateViewModel?.transform(from: input, disposeBag: self.disposeBag)
         
-        output?.loadData
+        output?.didLoadData
             .asDriver(onErrorJustReturn: false)
             .filter { $0 }
             .drive(onNext: { [weak self] _ in
@@ -131,7 +132,7 @@ private extension MateViewController {
             })
             .disposed(by: self.disposeBag)
         
-        output?.filterData
+        output?.didFilterData
             .asDriver(onErrorJustReturn: false)
             .filter { $0 }
             .drive(onNext: { [weak self] _ in
@@ -153,7 +154,9 @@ private extension MateViewController {
     }
     
     func checkMateCount() {
-        if self.mateViewModel?.filteredMate?.count == 0 && !(self.mateViewModel?.initialLoad ?? true) {
+        guard let initialLoad = self.mateViewModel?.initialLoad else { return }
+        
+        if self.mateViewModel?.filteredMate?.count == 0 && !(initialLoad) {
             self.addEmptyView()
         } else {
             self.removeEmptyView()

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateViewController.swift
@@ -20,7 +20,6 @@ enum MateTableViewValue: CGFloat {
 class MateViewController: UIViewController {
     var mateViewModel: MateViewModel?
     private let disposeBag = DisposeBag()
-    private var initialLoad = true
     
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView()
@@ -129,7 +128,6 @@ private extension MateViewController {
             .drive(onNext: { [weak self] _ in
                 self?.mateTableView.reloadData()
                 self?.didLoadMate()
-                self?.initialLoad = false
             })
             .disposed(by: self.disposeBag)
         
@@ -155,7 +153,7 @@ private extension MateViewController {
     }
     
     func checkMateCount() {
-        if self.mateViewModel?.filteredMate?.count == 0 && !(self.initialLoad) {
+        if self.mateViewModel?.filteredMate?.count == 0 && !(self.mateViewModel?.initialLoad ?? true) {
             self.addEmptyView()
         } else {
             self.removeEmptyView()

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
@@ -46,7 +46,7 @@ final class AddMateViewModel {
             })
             .disposed(by: disposeBag)
         
-        self.mateUseCase.mate
+        self.mateUseCase.mateList
             .subscribe(onNext: { [weak self] mate in
                 self?.filteredMate = mate
                 output.loadData.accept(true)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
@@ -13,7 +13,8 @@ import RxRelay
 final class AddMateViewModel {
     private let mateUseCase: MateUseCase
     weak var coordinator: AddMateCoordinator?
-    var mate: [(key: String, value: String)] = []
+    typealias MateList = [(key: String, value: String)]
+    var filteredMate: MateList = []
     
     struct Input {
         let searchButtonDidTap: Observable<Void>
@@ -47,7 +48,7 @@ final class AddMateViewModel {
         
         self.mateUseCase.mate
             .subscribe(onNext: { [weak self] mate in
-                self?.mate = self?.sortedMate(list: mate) ?? []
+                self?.filteredMate = mate
                 output.loadData.accept(true)
             })
             .disposed(by: disposeBag)
@@ -57,12 +58,5 @@ final class AddMateViewModel {
     
     func requestMate(to mate: String) {
         self.mateUseCase.sendRequestMate(to: mate)
-    }
-}
-
-// MARK: - Private Functions
-private extension AddMateViewModel {
-    func sortedMate(list: [String: String]) -> [(key: String, value: String)] {
-        return list.sorted { $0.0 < $1.0 }
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
@@ -23,6 +23,7 @@ final class AddMateViewModel {
     
     struct Output {
         let loadData = PublishRelay<Bool>()
+//        let didRequestMate = PublishRelay<Int>()
     }
     
     init(coordinator: AddMateCoordinator, mateUseCase: MateUseCase) {
@@ -52,6 +53,12 @@ final class AddMateViewModel {
                 output.loadData.accept(true)
             })
             .disposed(by: disposeBag)
+//
+//        self.mateUseCase.didRequestMate
+//            .subscribe(onNext: {
+//                output.didRequestMate.accept($0)
+//            })
+//            .disposed(by: disposeBag)
         
         return output
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/AddMateViewModel.swift
@@ -23,7 +23,6 @@ final class AddMateViewModel {
     
     struct Output {
         let loadData = PublishRelay<Bool>()
-//        let didRequestMate = PublishRelay<Int>()
     }
     
     init(coordinator: AddMateCoordinator, mateUseCase: MateUseCase) {
@@ -53,12 +52,6 @@ final class AddMateViewModel {
                 output.loadData.accept(true)
             })
             .disposed(by: disposeBag)
-//
-//        self.mateUseCase.didRequestMate
-//            .subscribe(onNext: {
-//                output.didRequestMate.accept($0)
-//            })
-//            .disposed(by: disposeBag)
         
         return output
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
@@ -25,8 +25,8 @@ final class MateViewModel {
     }
     
     struct Output {
-        var loadData = PublishRelay<Bool>()
-        var filterData = PublishRelay<Bool>()
+        var didLoadData = PublishRelay<Bool>()
+        var didFilterData = PublishRelay<Bool>()
         var doneButtonDidTap = PublishRelay<Bool>()
     }
     
@@ -48,8 +48,8 @@ final class MateViewModel {
             .debounce(RxTimeInterval.microseconds(5), scheduler: MainScheduler.instance)
             .distinctUntilChanged()
             .subscribe(onNext: { [weak self] text in
-                self?.mateUseCase.filteredMate(base: self?.mate ?? [], from: text)
-                output.filterData.accept(true)
+                self?.mateUseCase.filterMate(base: self?.mate ?? [], from: text)
+                output.didFilterData.accept(true)
             })
             .disposed(by: disposeBag)
         
@@ -77,7 +77,7 @@ final class MateViewModel {
         self.mateUseCase.didLoadMate
             .filter { $0 }
             .subscribe(onNext: { _ in
-                output.loadData.accept(true)
+                output.didLoadData.accept(true)
                 self.initialLoad = false
             })
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
@@ -13,7 +13,7 @@ final class MateViewModel {
     private let mateUseCase: MateUseCase
     weak var coordinator: MateCoordinator?
     typealias MateList = [(key: String, value: String)]
-    var filteredMate: MateList = []
+    var filteredMate: MateList?
     
     struct Input {
         let viewDidLoadEvent: Observable<Void>
@@ -66,6 +66,12 @@ final class MateViewModel {
         self.mateUseCase.mate
             .subscribe(onNext: { [weak self] mate in
                 self?.filteredMate = mate
+            })
+            .disposed(by: disposeBag)
+        
+        self.mateUseCase.didLoadMate
+            .filter { $0 }
+            .subscribe(onNext: { _ in
                 output.loadData.accept(true)
             })
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
@@ -12,8 +12,8 @@ import RxRelay
 final class MateViewModel {
     private let mateUseCase: MateUseCase
     weak var coordinator: MateCoordinator?
-    var mate: [String: String] = [:] // usecase에서 fetch 받고 순서맞춘 딕셔너리, 필터링 되는 것을 기준으로 잡을 원래의 딕셔너리
-    var filteredMate: [(key: String, value: String)] = []
+    
+    typealias mateList = [(key: String, value: String)]
     
     struct Input {
         let viewDidLoadEvent: Observable<Void>
@@ -25,7 +25,8 @@ final class MateViewModel {
     struct Output {
         @BehaviorRelayProperty var loadData: Bool = false
         @BehaviorRelayProperty var filterData: Bool = false
-        let doneButtonDidTap = PublishRelay<Bool>()
+        var doneButtonDidTap = PublishRelay<Bool>()
+        var filteredMateArray = PublishRelay<mateList>()
     }
     
     init(coordinator: MateCoordinator, mateUseCase: MateUseCase) {
@@ -43,10 +44,10 @@ final class MateViewModel {
             .disposed(by: disposeBag)
         
         input.searchBarTextEvent
-            .debounce(RxTimeInterval.microseconds(5), scheduler: MainScheduler.instance) // 0.5초동안 들어온 것중에 최신것을 방출
-            .distinctUntilChanged() // 같은 값 들어오면 무시
+            .debounce(RxTimeInterval.microseconds(5), scheduler: MainScheduler.instance)
+            .distinctUntilChanged()
             .subscribe(onNext: { [weak self] text in
-                self?.filterText(from: text)
+                self?.mateUseCase.filteredMate(from: text)
                 output.filterData = true
             })
             .disposed(by: disposeBag)
@@ -64,30 +65,17 @@ final class MateViewModel {
             .disposed(by: disposeBag)
         
         self.mateUseCase.mate
-            .subscribe(onNext: { [weak self] mate in
-                self?.mate = mate
-                self?.filteredMate = self?.sortedMate(list: mate) ?? []
-                output.loadData = true
-            })
+            .bind(to: output.filteredMateArray)
             .disposed(by: disposeBag)
         
         return output
     }
     
-    func pushMateProfile(of nickname: String) {
-        self.coordinator?.showMateProfileFlow(nickname)
-    }
-}
-
-// MARK: - Private Functions
-private extension MateViewModel {
-    func filterText(from text: String) {
-        self.filteredMate = self.sortedMate(list: self.mate.filter { key, _ in // 초기 mate를 기준으로 filter
-            return key.hasPrefix(text)
-        })
+    func bindMate(output: Output, disposeBag: DisposeBag) {
+        
     }
     
-    func sortedMate(list: [String: String]) -> [(key: String, value: String)] {
-        return list.sorted { $0.0 < $1.0 }
+    func pushMateProfile(of nickname: String) {
+        self.coordinator?.showMateProfileFlow(nickname)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift
@@ -65,7 +65,7 @@ final class MateViewModel {
             })
             .disposed(by: disposeBag)
         
-        self.mateUseCase.mate
+        self.mateUseCase.mateList
             .subscribe(onNext: { [weak self] mate in
                 if self?.initialLoad ?? true {
                     self?.mate = mate

--- a/MateRunner/MateRunner/Util/Constant/NoticeMode.swift
+++ b/MateRunner/MateRunner/Util/Constant/NoticeMode.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeMode.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/24.
+//
+
+import Foundation

--- a/MateRunner/MateRunner/Util/Constant/NoticeMode.swift
+++ b/MateRunner/MateRunner/Util/Constant/NoticeMode.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+
+enum NoticeMode: String {
+    case invite = "invite"
+    case requestMate = "requestMate"
+    
+    func text() -> String {
+        return self.rawValue
+    }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #194 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 알림관련 DB
- [x] FCM 전송 시 DB에 저장


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
![스크린샷 2021-11-24 오전 12 32 19](https://user-images.githubusercontent.com/41044154/143053987-fb20a8ba-178b-47f5-8c7e-f059e9764a0f.png)
현재 이러한 구조로 DB를 만들었고 저장하고 있습니다! 일단 대강 만들어두다보니 나중에 수정할 일이 있을것 같아요! 컬렉션이나 필드 이름도 임의적으로 정했는데 다른 좋은 네이밍이 있다면 바꿔도 좋습니다! ㅎㅎ
일단은 현재 저런 모양으로 DTO를 만들었고 나중에 알림목록 구현해주실때 이걸로 바로 디코딩해서 사용하시면 될 것 같습니다!
자신이 받은 알림을 한번에 확인할 수 있도록 수신자 이름으로 도큐먼트를 만들었고 도큐먼트 안에 딕셔너리의 키 값을 발신자로 해두었습니다! 
캡처에서는 `yujin --(친구요청보냄)--> yjsimul` 인 상황에서 DB에 올라가는 상황입니다!

<br/><br/>
