### PR TITLE
알림 확인 기능 및 친구 수락 기능 구현

### DIFF
--- a/MateRunner/MateRunner/Data/Network/DataMapping/NoticeDTO+Mapping.swift
+++ b/MateRunner/MateRunner/Data/Network/DataMapping/NoticeDTO+Mapping.swift
@@ -8,26 +8,51 @@
 import Foundation
 
 struct NoticeDTO: Codable {
-    private let sender: String
-    private let receiver: String
-    private let mode: String
+    private let id: String?
+    private let sender: StringValue
+    private let receiver: StringValue
+    private let mode: StringValue
+    private let isReceived: BooleanValue
+    
+    private enum RootKey: String, CodingKey {
+        case id = "name", fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case sender, receiver, mode, isReceived
+    }
     
     init(from domain: Notice) {
-        self.sender = domain.sender
-        self.receiver = domain.receiver
+        self.id = nil
+        self.sender = StringValue(value: domain.sender)
+        self.receiver = StringValue(value: domain.receiver)
+        self.isReceived = BooleanValue(value: domain.isReceived)
         
         if domain.mode == .invite {
-            self.mode = NoticeMode.invite.text()
+            self.mode = StringValue(value: NoticeMode.invite.text())
         } else {
-            self.mode = NoticeMode.requestMate.text()
+            self.mode = StringValue(value: NoticeMode.requestMate.text())
         }
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: RootKey.self)
+        let fieldContainer = try container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        
+        self.id = try container.decode(String.self, forKey: .id)
+        self.sender = try fieldContainer.decode(StringValue.self, forKey: .sender)
+        self.receiver = try fieldContainer.decode(StringValue.self, forKey: .receiver)
+        self.isReceived = try fieldContainer.decode(BooleanValue.self, forKey: .isReceived)
+        self.mode = try fieldContainer.decode(StringValue.self, forKey: .mode)
     }
     
     func toDomain() -> Notice {
         return Notice(
-            sender: self.sender,
-            receiver: self.receiver,
-            mode: NoticeMode(rawValue: self.mode) ?? .invite
+            id: self.id,
+            sender: self.sender.value,
+            receiver: self.receiver.value,
+            mode: NoticeMode(rawValue: self.mode.value) ?? .invite,
+            isReceived: self.isReceived.value
         )
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -270,11 +270,60 @@ final class DefaultFirestoreRepository {
             headers: FirestoreConfiguration.defaultHeaders
         ).map({ _ in })
     }
+    
+    func fetchNotice(of userNickname: String) -> Observable<[Notice]?> {
+        let endPoint = FirestoreConfiguration.baseURL
+        + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.notificationPath
+        + "/\(userNickname)"
+        + FirestoreCollectionPath.recordsPath
+        
+        return self.urlSession.get(
+            url: endPoint,
+            headers: FirestoreConfiguration.defaultHeaders
+        )
+            .map({ data -> [Notice]? in
+                guard let result = try? JSONDecoder().decode(Documents<[NoticeDTO]>.self, from: data) else {
+                    return nil
+                }
+                return result.documents.map { $0.toDomain() }
+            })
+    }
+    
+    func save(notice: Notice, of userNickname: String) -> Observable<Void> {
+        let endPoint = FirestoreConfiguration.baseURL
+        + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.notificationPath
+        + "/\(userNickname)"
+        + FirestoreCollectionPath.recordsPath
+        
+        let dto = NoticeDTO(from: notice)
+        
+        return self.urlSession.post(
+            ["fields": dto],
+            url: endPoint,
+            headers: FirestoreConfiguration.defaultHeaders
+        )
+            .map({ _ in })
+    }
+    
+    func updateState(notice: Notice, of userNickname: String) -> Observable<Void> {
+        let endPoint = FirestoreConfiguration.firestoreBaseURL + (notice.id ?? "")
+        let dto = NoticeDTO(from: notice)
+        
+        return self.urlSession.patch(
+            ["fields": dto],
+            url: endPoint,
+            headers: FirestoreConfiguration.defaultHeaders
+        )
+            .map({ _ in })
+    }
 }
 
 // MARK: - firestore request constants
 extension DefaultFirestoreRepository {
     private enum FirestoreConfiguration {
+        static let firestoreBaseURL = "https://firestore.googleapis.com/v1/"
         static let baseURL = "https://firestore.googleapis.com/v1/projects/mate-runner-e232c"
         static let documentsPath = "/databases/(default)/documents"
         static let queryKey = ":runQuery"
@@ -291,6 +340,7 @@ extension DefaultFirestoreRepository {
         static let userPath = "/User"
         static let recordsPath = "/records"
         static let emojiPath = "/emojis"
+        static let notificationPath = "/Notification"
     }
     
     private enum FirestoreField {

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -72,17 +72,4 @@ final class DefaultMateRepository: MateRepository {
     func fetchFCMToken(of mate: String)-> Observable<String> {
         return self.realtimeNetworkService.fetchFCMToken(of: mate)
     }
-    
-    func saveRequestMate(_ notice: Notice?) -> Observable<Void> {
-        guard let notice = notice else {
-            return Observable.error(FirebaseServiceError.nilDataError)
-        }
-        
-        return self.fireStoreNetworkService.writeDTO(
-            NoticeDTO(from: notice),
-            collection: "Notification",
-            document: notice.receiver,
-            key: notice.sender
-        )
-    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
@@ -15,5 +15,4 @@ protocol MateRepository {
     func fetchFilteredNickname(text: String) -> Observable<[String]>
     func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> 
     func fetchFCMToken(of mate: String)-> Observable<String>
-    func saveRequestMate(_ notice: Notice?) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Domain/Model/FirestoreValues.swift
+++ b/MateRunner/MateRunner/Domain/Model/FirestoreValues.swift
@@ -119,6 +119,14 @@ struct DocumentsValue: Codable {
     }
 }
 
+struct Documents<T: Codable>: Codable {
+    let documents: T
+    
+    private enum CodingKeys: String, CodingKey {
+        case documents
+    }
+}
+
 struct QueryResultValue<T: Codable>: Codable {
     let readTime: String
     let document: T

--- a/MateRunner/MateRunner/Domain/Model/Notice.swift
+++ b/MateRunner/MateRunner/Domain/Model/Notice.swift
@@ -8,17 +8,33 @@
 import Foundation
 
 struct Notice {
+    private(set) var id: String?
     private(set) var sender: String
     private(set) var receiver: String
     private(set) var mode: NoticeMode
+    private(set) var isReceived: Bool
     
     init(
+        id: String?,
         sender: String,
         receiver: String,
-        mode: NoticeMode
+        mode: NoticeMode,
+        isReceived: Bool
     ) {
+        self.id = id
         self.sender = sender
         self.receiver = receiver
         self.mode = mode
+        self.isReceived = isReceived
+    }
+    
+    func copyUpdatedReceived() -> Notice {
+        return .init(
+            id: self.id,
+            sender: self.sender,
+            receiver: self.receiver,
+            mode: self.mode,
+            isReceived: true
+        )
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
@@ -12,7 +12,6 @@ import RxSwift
 final class DefaultMyPageUseCase: MyPageUseCase {
     private let userRepository: UserRepository
     private let disposeBag = DisposeBag()
-    var isNotificationOn = PublishSubject<Bool>()
     
     init(userRepository: UserRepository) {
         self.userRepository = userRepository

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/NotificationUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/NotificationUseCase.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+import RxSwift
+
 protocol NotificationUseCase {
-    
+    var notices: PublishSubject<[Notice]> { get set }
+    func fetchNotices()
+    func updateMateState(notice: Notice, isAccepted: Bool)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -124,6 +124,9 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
                     fireStoreNetworkService: DefaultFireStoreNetworkService(),
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
+                ),
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
@@ -31,6 +31,9 @@ final class DefaultAddMateCoordinator: AddMateCoordinator {
                     fireStoreNetworkService: DefaultFireStoreNetworkService(),
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
+                ),
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -27,6 +27,9 @@ final class DefaultMateCoordinator: MateCoordinator {
                     fireStoreNetworkService: DefaultFireStoreNetworkService(),
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
+                ),
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultNotificationCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultNotificationCoordinator.swift
@@ -25,7 +25,11 @@ final class DefaultNotificationCoordinator: NotificationCoordinator {
         let notificationViewController = NotificationViewController()
         notificationViewController.viewModel = NotificationViewModel(
             notificationCoordinator: self,
-            notificationUseCase: DefaultNotificationUseCase()
+            notificationUseCase: DefaultNotificationUseCase(
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
+                )
+            )
         )
         self.navigationController.pushViewController(notificationViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/View/NotificationTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/View/NotificationTableViewCell.swift
@@ -15,7 +15,6 @@ class NotificationTableViewCell: UITableViewCell {
     private lazy var iconLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.notoSans(size: 20, family: .regular)
-        label.text = "🤝"
         label.snp.makeConstraints { make in
             make.width.height.equalTo(40)
         }
@@ -29,14 +28,12 @@ class NotificationTableViewCell: UITableViewCell {
     private lazy var notificationTypeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.notoSans(size: 16, family: .bold)
-        label.text = "메이트 요청"
         return label
     }()
     
     private lazy var contentLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.notoSans(size: 13, family: .regular)
-        label.text = "minji님의 메이트 요청이 도착했습니다!"
         label.textColor = .systemGray
         return label
     }()
@@ -51,8 +48,17 @@ class NotificationTableViewCell: UITableViewCell {
         self.configureUI()
     }
     
-    func updateUI() {
-        // TODO: ViewModel에서 받아온 데이터로 업데이트 
+    func updateUI(mode: NoticeMode, sender: String, isReceived: Bool) {
+        switch mode {
+        case .invite:
+            self.notificationTypeLabel.text = "달리기 초대"
+            self.contentLabel.text = "\(sender)님이 달리기 초대장을 보냈습니다!"
+            self.iconLabel.text = "💌"
+        case .requestMate:
+            self.notificationTypeLabel.text = isReceived ? "[확인한 알림] 메이트 요청" : "메이트 요청"
+            self.contentLabel.text = isReceived ? "\(sender)님의 메이트 요청에 응답했습니다." : "\(sender)님의 메이트 요청이 도착했습니다!"
+            self.iconLabel.text = "🤝"
+        }
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/NotificationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/NotificationViewModel.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
+import RxRelay
 import RxSwift
 
 final class NotificationViewModel {
     private weak var notificationCoordinator: NotificationCoordinator?
     private let notificationUseCase: NotificationUseCase
+    var notices: [Notice] = []
     
     init(
         notificationCoordinator: NotificationCoordinator,
@@ -26,12 +28,29 @@ final class NotificationViewModel {
     }
     
     struct Output {
-        
+        var didLoadData = PublishRelay<Bool>()
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
+        input.viewDidLoadEvent
+            .subscribe(onNext: { [weak self] in
+                self?.notificationUseCase.fetchNotices()
+            })
+            .disposed(by: disposeBag)
+        
+        self.notificationUseCase.notices
+            .subscribe(onNext: { [weak self] notices in
+                self?.notices = notices
+                output.didLoadData.accept(true)
+            })
+            .disposed(by: disposeBag)
+        
         return output
+    }
+    
+    func updateMateState(notice: Notice, isAccepted: Bool) {
+        self.notificationUseCase.updateMateState(notice: notice, isAccepted: true)
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 알림 확인 기능 구현: 데이터 바인딩
- [x] 친구 수락 기능 구현
- [x] 초대장 전송 시 알림도 쌓이도록 구현

 https://user-images.githubusercontent.com/48787170/143395531-548f00bb-0d8e-4d93-a535-e96be58e7929.mov


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 데이터 바인딩 및 친구 수락, 친구 요청과 초대장 수신에 대한 알림 확인까지 가능합니다............!
- 특이 사항 2 FirestoreValues.swift에 DocumentsValue가 있긴 한데 저한테 필요한거랑 달라서 Documents로 따로 만들었어요,,,firestoreBaseURL도 마찬가지입니다ㅜㅜ 더 나은 네이밍 있으면 추천 부탁드려요..!
- 특이 사항 3 알림 뷰컨의 엠티뷰는 메이트엠티뷰를 그대로 썼습니다! 좀 더 범용적으로 쓸 수 있도록 파일 이름을 바꾸면 좋을 것 같아요 ㅎㅎ 유진님의 메이트 뷰컨을 많이 참고하면서 짰습니다.....감사합니다...


<br/><br/>
