### PR TITLE
프로필 정보(키, 몸무게) 편집 기능 구현

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */; };
 		5E53FF06274F471C002EE49C /* license.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5E53FF05274F471C002EE49C /* license.txt */; };
 		5E53FF08274F5B75002EE49C /* ImageEditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E53FF07274F5B75002EE49C /* ImageEditButton.swift */; };
+		5E53FF0A274FE831002EE49C /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E53FF09274FE831002EE49C /* FilePath.swift */; };
 		5E5E555327450662002FE126 /* UserDefaultKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E555227450662002FE126 /* UserDefaultKey.swift */; };
 		5E5E5557274514F6002FE126 /* RecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E5556274514F6002FE126 /* RecordCoordinator.swift */; };
 		5E5E55592745151D002FE126 /* DefaultRecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E55582745151D002FE126 /* DefaultRecordCoordinator.swift */; };
@@ -385,6 +386,7 @@
 		5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewModel.swift; sourceTree = "<group>"; };
 		5E53FF05274F471C002EE49C /* license.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = license.txt; sourceTree = "<group>"; };
 		5E53FF07274F5B75002EE49C /* ImageEditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageEditButton.swift; sourceTree = "<group>"; };
+		5E53FF09274FE831002EE49C /* FilePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePath.swift; sourceTree = "<group>"; };
 		5E5E555227450662002FE126 /* UserDefaultKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultKey.swift; sourceTree = "<group>"; };
 		5E5E5556274514F6002FE126 /* RecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinator.swift; sourceTree = "<group>"; };
 		5E5E55582745151D002FE126 /* DefaultRecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRecordCoordinator.swift; sourceTree = "<group>"; };
@@ -1595,6 +1597,7 @@
 				B03A563D2745E7EF00C5C2F2 /* FirebaseCollection.swift */,
 				3D62255827495ED400E4A327 /* Configuration.swift */,
 				AE263BE1274DDD62004A61E5 /* NoticeMode.swift */,
+				5E53FF09274FE831002EE49C /* FilePath.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -2109,6 +2112,7 @@
 				B0C8517F274E608F0070BB66 /* MateListFirestoreDTO.swift in Sources */,
 				5E5E556627458FE9002FE126 /* WeekdayView.swift in Sources */,
 				B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */,
+				5E53FF0A274FE831002EE49C /* FilePath.swift in Sources */,
 				3DF4C86027355A3E00A4B229 /* Date+Formatter.swift in Sources */,
 				5E5FDD1A273FC9A6000F4666 /* DefaultSignUpCoordinator.swift in Sources */,
 				B0CB4D1C27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		5E4E7A9F2730214700C6B762 /* MateRunningModeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */; };
 		5E4E7AA12730513500C6B762 /* MateRunningModeSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */; };
 		5E53FF06274F471C002EE49C /* license.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5E53FF05274F471C002EE49C /* license.txt */; };
+		5E53FF08274F5B75002EE49C /* ImageEditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E53FF07274F5B75002EE49C /* ImageEditButton.swift */; };
 		5E5E555327450662002FE126 /* UserDefaultKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E555227450662002FE126 /* UserDefaultKey.swift */; };
 		5E5E5557274514F6002FE126 /* RecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E5556274514F6002FE126 /* RecordCoordinator.swift */; };
 		5E5E55592745151D002FE126 /* DefaultRecordCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5E55582745151D002FE126 /* DefaultRecordCoordinator.swift */; };
@@ -383,6 +384,7 @@
 		5E4E7A9E2730214700C6B762 /* MateRunningModeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewController.swift; sourceTree = "<group>"; };
 		5E4E7AA02730513500C6B762 /* MateRunningModeSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunningModeSettingViewModel.swift; sourceTree = "<group>"; };
 		5E53FF05274F471C002EE49C /* license.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = license.txt; sourceTree = "<group>"; };
+		5E53FF07274F5B75002EE49C /* ImageEditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageEditButton.swift; sourceTree = "<group>"; };
 		5E5E555227450662002FE126 /* UserDefaultKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultKey.swift; sourceTree = "<group>"; };
 		5E5E5556274514F6002FE126 /* RecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCoordinator.swift; sourceTree = "<group>"; };
 		5E5E55582745151D002FE126 /* DefaultRecordCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRecordCoordinator.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 			isa = PBXGroup;
 			children = (
 				3D622590274E617E00E4A327 /* NotificationTableViewCell.swift */,
+				5E53FF07274F5B75002EE49C /* ImageEditButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2051,6 +2054,7 @@
 				B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */,
 				3DF4C8662737687900A4B229 /* DefaultRunningResultRepository.swift in Sources */,
 				5E5E5564274586CD002FE126 /* CalendarCell.swift in Sources */,
+				5E53FF08274F5B75002EE49C /* ImageEditButton.swift in Sources */,
 				AE77C2002744DAD8005EDEE0 /* AddMateViewController.swift in Sources */,
 				5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */,
 				AE77C2062744ED3D005EDEE0 /* AddMateViewModel.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import RxSwift
 
-final class DefaultFirestoreRepository {
+final class DefaultFirestoreRepository: FirestoreRepository {
     private let urlSession: URLSessionNetworkService
     
     init(urlSessionService: URLSessionNetworkService) {

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
@@ -39,11 +39,11 @@ final class DefaultUserRepository: UserRepository {
     func saveUserInfo(uid: String, nickname: String, height: Int, weight: Int) -> Observable<Bool> {
         let data: [String: Any] = [
             "nickname": nickname,
-            "height": height,
-            "weight": weight,
+            "height": Double(height),
+            "weight": Double(weight),
             "time": 0,
-            "distance": 0,
-            "calorie": 0,
+            "distance": 0.0,
+            "calorie": 0.0,
             "mate": [],
             "image": ""
         ]

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
@@ -11,12 +11,26 @@ import RxSwift
 
 final class DefaultMyPageUseCase: MyPageUseCase {
     private let userRepository: UserRepository
+    private let firestoreRepository: FirestoreRepository
     private let disposeBag = DisposeBag()
-    var isNotificationOn = PublishSubject<Bool>()
-    var nickname: String?
     
-    init(userRepository: UserRepository) {
+    var nickname: String?
+    var isNotificationOn = PublishSubject<Bool>()
+    var imageURL = PublishSubject<String>()
+    
+    init(userRepository: UserRepository, firestoreRepository: FirestoreRepository) {
         self.userRepository = userRepository
+        self.firestoreRepository = firestoreRepository
         self.nickname = userRepository.fetchUserNickname()
+    }
+    
+    func loadUserInfo() {
+        guard let nickname = nickname else { return }
+        self.firestoreRepository.fetchUserData(of: nickname)
+            .compactMap { $0 }
+            .subscribe(onNext: { [weak self] userData in
+                self?.imageURL.onNext(userData.image)
+            })
+            .disposed(by: self.disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
@@ -13,8 +13,10 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     private let userRepository: UserRepository
     private let disposeBag = DisposeBag()
     var isNotificationOn = PublishSubject<Bool>()
+    var nickname: String?
     
     init(userRepository: UserRepository) {
         self.userRepository = userRepository
+        self.nickname = userRepository.fetchUserNickname()
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -17,6 +17,7 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
     var nickname: String?
     var height = BehaviorSubject<Double?>(value: nil)
     var weight = BehaviorSubject<Double?>(value: nil)
+    var imageURL = BehaviorSubject<String?>(value: nil)
     
     init(firestoreRepository: FirestoreRepository, with nickname: String?) {
         self.firestoreRepository = firestoreRepository
@@ -43,6 +44,7 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
                 self.userData = userData
                 self.height.onNext(userData.height)
                 self.weight.onNext(userData.weight)
+                self.imageURL.onNext(userData.image)
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -10,8 +10,16 @@ import Foundation
 import RxSwift
 
 final class DefaultProfileEditUseCase: ProfileEditUseCase {
+    private let userRepository: UserRepository
+    private let disposeBag = DisposeBag()
+    
     var height = BehaviorSubject<Int?>(value: nil)
     var weight = BehaviorSubject<Int?>(value: nil)
+    var nickname = BehaviorSubject<String>(value: "")
+    
+    init(userRepository: UserRepository) {
+        self.userRepository = userRepository
+    }
     
     func getCurrentHeight() {
         guard let currentHeight = try? self.height.value() else { return }
@@ -26,5 +34,6 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
     func loadUserInfo() {
         self.height.onNext(175)
         self.weight.onNext(65)
+        self.nickname.onNext(self.userRepository.fetchUserNickname() ?? "")
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -7,6 +7,24 @@
 
 import Foundation
 
+import RxSwift
+
 final class DefaultProfileEditUseCase: ProfileEditUseCase {
+    var height = BehaviorSubject<Int?>(value: nil)
+    var weight = BehaviorSubject<Int?>(value: nil)
     
+    func getCurrentHeight() {
+        guard let currentHeight = try? self.height.value() else { return }
+        self.height.onNext(currentHeight)
+    }
+    
+    func getCurrentWeight() {
+        guard let currentWeight = try? self.weight.value() else { return }
+        self.weight.onNext(currentWeight)
+    }
+    
+    func loadUserInfo() {
+        self.height.onNext(175)
+        self.weight.onNext(65)
+    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/MyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/MyPageUseCase.swift
@@ -10,4 +10,5 @@ import Foundation
 import RxSwift
 
 protocol MyPageUseCase {
+    var nickname: String? { get }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/MyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/MyPageUseCase.swift
@@ -11,4 +11,6 @@ import RxSwift
 
 protocol MyPageUseCase {
     var nickname: String? { get }
+    var imageURL: PublishSubject<String> { get set }
+    func loadUserInfo()
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -12,6 +12,7 @@ import RxSwift
 protocol ProfileEditUseCase {
     var height: BehaviorSubject<Int?> { get set }
     var weight: BehaviorSubject<Int?> { get set }
+    var nickname: BehaviorSubject<String> { get set }
     func getCurrentHeight()
     func getCurrentWeight()
     func loadUserInfo()

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -14,7 +14,9 @@ protocol ProfileEditUseCase {
     var height: BehaviorSubject<Double?> { get set }
     var weight: BehaviorSubject<Double?> { get set }
     var imageURL: BehaviorSubject<String?> { get set }
+    var saveResult: PublishSubject<Bool> { get set }
     func getCurrentHeight()
     func getCurrentWeight()
     func loadUserInfo()
+    func saveUserInfo()
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+import RxSwift
+
 protocol ProfileEditUseCase {
-    
+    var height: BehaviorSubject<Int?> { get set }
+    var weight: BehaviorSubject<Int?> { get set }
+    func getCurrentHeight()
+    func getCurrentWeight()
+    func loadUserInfo()
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -13,6 +13,7 @@ protocol ProfileEditUseCase {
     var nickname: String? { get }
     var height: BehaviorSubject<Double?> { get set }
     var weight: BehaviorSubject<Double?> { get set }
+    var imageURL: BehaviorSubject<String?> { get set }
     func getCurrentHeight()
     func getCurrentWeight()
     func loadUserInfo()

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -15,8 +15,6 @@ protocol ProfileEditUseCase {
     var weight: BehaviorSubject<Double?> { get set }
     var imageURL: BehaviorSubject<String?> { get set }
     var saveResult: PublishSubject<Bool> { get set }
-    func getCurrentHeight()
-    func getCurrentWeight()
     func loadUserInfo()
     func saveUserInfo()
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -10,9 +10,9 @@ import Foundation
 import RxSwift
 
 protocol ProfileEditUseCase {
-    var height: BehaviorSubject<Int?> { get set }
-    var weight: BehaviorSubject<Int?> { get set }
-    var nickname: BehaviorSubject<String> { get set }
+    var nickname: String? { get }
+    var height: BehaviorSubject<Double?> { get set }
+    var weight: BehaviorSubject<Double?> { get set }
     func getCurrentHeight()
     func getCurrentWeight()
     func loadUserInfo()

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -25,6 +25,9 @@ final class DefaultMyPageCoordinator: MyPageCoordinator {
             myPageUseCase: DefaultMyPageUseCase(
                 userRepository: DefaultUserRepository(
                     networkService: DefaultFireStoreNetworkService()
+                ),
+                firestoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
                 )
             )
         )
@@ -38,11 +41,11 @@ final class DefaultMyPageCoordinator: MyPageCoordinator {
         notificationCoordinator.start()
     }
     
-    func showProfileEditFlow() {
+    func showProfileEditFlow(with nickname: String) {
         let profileEditCoordinator = DefaultProfileEditCoordinator(self.navigationController)
         profileEditCoordinator.finishDelegate = self
         self.childCoordinators.append(profileEditCoordinator)
-        profileEditCoordinator.start()
+        profileEditCoordinator.pushProfileEditViewController(with: nickname)
     }
     
     func showLicenseFlow() {

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultProfileEditCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultProfileEditCoordinator.swift
@@ -25,7 +25,11 @@ final class DefaultProfileEditCoordinator: ProfileEditCoordinator {
         let profileEditViewController = ProfileEditViewController()
         profileEditViewController.viewModel = ProfileEditViewModel(
             profileEditCoordinator: self,
-            profileEditUseCase: DefaultProfileEditUseCase()
+            profileEditUseCase: DefaultProfileEditUseCase(
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
+                )
+            )
         )
         self.navigationController.pushViewController(profileEditViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultProfileEditCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultProfileEditCoordinator.swift
@@ -17,11 +17,9 @@ final class DefaultProfileEditCoordinator: ProfileEditCoordinator {
         self.navigationController = navigationController
     }
     
-    func start() {
-        self.pushProfileEditViewController()
-    }
-    
-    func pushProfileEditViewController() {
+    func start() {  }
+
+    func pushProfileEditViewController(with nickname: String) {
         let profileEditViewController = ProfileEditViewController()
         profileEditViewController.viewModel = ProfileEditViewModel(
             profileEditCoordinator: self,
@@ -29,7 +27,7 @@ final class DefaultProfileEditCoordinator: ProfileEditCoordinator {
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 ),
-                with: "Jungwon"
+                with: nickname
             )
         )
         self.navigationController.pushViewController(profileEditViewController, animated: true)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultProfileEditCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultProfileEditCoordinator.swift
@@ -26,9 +26,10 @@ final class DefaultProfileEditCoordinator: ProfileEditCoordinator {
         profileEditViewController.viewModel = ProfileEditViewModel(
             profileEditCoordinator: self,
             profileEditUseCase: DefaultProfileEditUseCase(
-                userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
-                )
+                firestoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
+                ),
+                with: "Jungwon"
             )
         )
         self.navigationController.pushViewController(profileEditViewController, animated: true)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/Protocol/MyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/Protocol/MyPageCoordinator.swift
@@ -9,6 +9,6 @@ import Foundation
 
 protocol MyPageCoordinator: Coordinator {
     func showNotificationFlow()
-    func showProfileEditFlow()
+    func showProfileEditFlow(with nickname: String)
     func showLicenseFlow()
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/Protocol/ProfileEditCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/Protocol/ProfileEditCoordinator.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol ProfileEditCoordinator: Coordinator {
-    func pushProfileEditViewController()
+    func pushProfileEditViewController(with nickname: String)
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/View/ImageEditButton.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/View/ImageEditButton.swift
@@ -1,0 +1,71 @@
+//
+//  ImageEditButton.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/25.
+//
+
+import UIKit
+
+final class ImageEditButton: UIView {
+    private(set) lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .lightGray
+        imageView.layer.cornerRadius = 40
+        
+        imageView.snp.makeConstraints { make in
+            make.width.height.equalTo(80)
+        }
+        return imageView
+    }()
+    
+    private lazy var cameraIconView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 12
+        view.snp.makeConstraints { make in
+            make.width.height.equalTo(24)
+        }
+        
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "camera.fill")
+        imageView.tintColor = .systemGray5
+        imageView.snp.makeConstraints { make in
+            make.width.height.equalTo(20)
+        }
+        
+        view.addSubview(imageView)
+        imageView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureUI()
+    }
+}
+
+private extension ImageEditButton {
+    func configureUI() {
+        self.addSubview(self.profileImageView)
+        self.profileImageView.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+        
+        self.addSubview(self.cameraIconView)
+        self.cameraIconView.snp.makeConstraints { make in
+            make.right.bottom.equalToSuperview()
+        }
+        
+        self.snp.makeConstraints { make in
+            make.width.height.equalTo(86)
+        }
+    }
+}

--- a/MateRunner/MateRunner/Presentation/MyPageScene/View/ImageEditButton.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/View/ImageEditButton.swift
@@ -12,6 +12,7 @@ final class ImageEditButton: UIView {
         let imageView = UIImageView()
         imageView.backgroundColor = .lightGray
         imageView.layer.cornerRadius = 40
+        imageView.clipsToBounds = true
         
         imageView.snp.makeConstraints { make in
             make.width.height.equalTo(80)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/LicenseViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/LicenseViewController.swift
@@ -10,10 +10,8 @@ import UIKit
 final class LicenseViewController: UIViewController {
     private lazy var licenseTextView: UITextView = {
         let textView = UITextView()
-        let path = Bundle.main.path(forResource: "license", ofType: "txt") ?? ""
-        let licenseText = try? String(contentsOfFile: path)
-        
-        textView.text = licenseText
+        let path = FilePath.license
+        textView.text = try? String(contentsOfFile: path)
         textView.font = .systemFont(ofSize: 14)
         textView.isEditable = false
         textView.isSelectable = false

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -37,8 +37,6 @@ final class MyPageViewController: UIViewController {
     
     private lazy var nicknameLabel: UILabel = {
         let label = UILabel()
-        // TODO: User 닉네임 바인딩
-        label.text = "OOO"
         label.font = .notoSans(size: 18, family: .bold)
         return label
     }()
@@ -122,6 +120,7 @@ final class MyPageViewController: UIViewController {
 private extension MyPageViewController {
     func bindViewModel() {
         guard let viewModel = self.viewModel else { return }
+        
         let input = MyPageViewModel.Input(
             viewDidLoadEvent: Observable<Void>.just(()),
             notificationButtonDidTapEvent: notificationButton.rx.tap.asObservable(),
@@ -134,12 +133,19 @@ private extension MyPageViewController {
             logoutButtonDidTapEvent: logoutButton.rx.tap.asObservable(),
             withdrawalButtonDidTapEvent: withdrawalButton.rx.tap.asObservable()
         )
+        
         let output = viewModel.transform(from: input, disposeBag: self.disposeBag)
+        
         output.isNotificationOn
             .asDriver(onErrorJustReturn: false)
             .drive { [weak self] isNotificationOn in
                 self?.notificationSwitch.setOn(isNotificationOn, animated: false)
             }
+            .disposed(by: self.disposeBag)
+        
+        output.nickname
+            .asDriver()
+            .drive(self.nicknameLabel.rx.text)
             .disposed(by: self.disposeBag)
     }
     

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -31,7 +31,7 @@ final class MyPageViewController: UIViewController {
         let imageView = UIImageView()
         imageView.layer.masksToBounds = true
         imageView.layer.cornerRadius = 40
-        imageView.backgroundColor = .gray
+        imageView.backgroundColor = .lightGray
         return imageView
     }()
     

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -143,6 +143,13 @@ private extension MyPageViewController {
             }
             .disposed(by: self.disposeBag)
         
+        output.imageURL
+            .asDriver()
+            .drive(onNext: { [weak self] imageURL in
+                self?.profileImageView.setImage(with: imageURL)
+            })
+            .disposed(by: self.disposeBag)
+        
         output.nickname
             .asDriver()
             .drive(self.nicknameLabel.rx.text)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
@@ -7,12 +7,81 @@
 
 import UIKit
 
-class ProfileEditViewController: UIViewController {
+final class ProfileEditViewController: UIViewController {
     var viewModel: ProfileEditViewModel?
+    
+    private lazy var doneButton = UIBarButtonItem(title: "완료", style: .done, target: nil, action: nil)
+    private lazy var imageEditButton = ImageEditButton()
+    private lazy var heightTextField = PickerTextField()
+    private lazy var weightTextField = PickerTextField()
+    private lazy var heightSection = self.createInputSection(text: "키", textField: self.heightTextField)
+    private lazy var weightSection = self.createInputSection(text: "몸무게", textField: self.weightTextField)
+    
+    private lazy var nicknameLabel: UILabel = {
+        let label = UILabel()
+        // TODO: User 닉네임 바인딩
+        label.text = "OOO"
+        label.font = .notoSans(size: 18, family: .bold)
+        return label
+    }()
+    
+    private lazy var inputStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 30
+        
+        stackView.addArrangedSubview(self.heightSection)
+        stackView.addArrangedSubview(self.weightSection)
+        return stackView
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.tabBarController?.tabBar.isHidden = true
+    }
+}
 
-        self.view.backgroundColor = .cyan
+private extension ProfileEditViewController {
+    func configureUI() {
+        self.view.backgroundColor = .systemBackground
+        self.navigationItem.rightBarButtonItem = self.doneButton
+        
+        self.view.addSubview(self.imageEditButton)
+        self.imageEditButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.view.safeAreaLayoutGuide).inset(32)
+        }
+        
+        self.view.addSubview(self.nicknameLabel)
+        self.nicknameLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.imageEditButton.snp.bottom).offset(17)
+        }
+        
+        self.view.addSubview(self.inputStackView)
+        self.inputStackView.snp.makeConstraints { make in
+            make.left.right.equalToSuperview().inset(20)
+            make.top.equalTo(self.nicknameLabel.snp.bottom).offset(30)
+        }
+    }
+    
+    func createInputSection(text: String, textField: UITextField) -> UIStackView {
+        let titleLabel = UILabel()
+        titleLabel.font = .notoSans(size: 18, family: .regular)
+        titleLabel.text = text
+        
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 4
+        
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(textField)
+        return stackView
     }
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
@@ -107,6 +107,13 @@ private extension ProfileEditViewController {
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         
+        output?.imageURL
+            .asDriver()
+            .drive(onNext: { [weak self] imageURL in
+                self?.imageEditButton.profileImageView.setImage(with: imageURL)
+            })
+            .disposed(by: self.disposeBag)
+        
         output?.nickname
             .asDriver()
             .drive(self.nicknameLabel.rx.text)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
@@ -106,6 +106,12 @@ private extension ProfileEditViewController {
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
+        
+        output?.nickname
+            .asDriver()
+            .drive(self.nicknameLabel.rx.text)
+            .disposed(by: self.disposeBag)
+        
         self.bindHeightTextField(output: output)
         self.bindWeightTextField(output: output)
     }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
@@ -22,7 +22,6 @@ final class ProfileEditViewController: UIViewController {
     
     private lazy var nicknameLabel: UILabel = {
         let label = UILabel()
-        label.text = "OOO"
         label.font = .notoSans(size: 18, family: .bold)
         return label
     }()

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import RxRelay
+import RxCocoa
 import RxSwift
 
 final class MyPageViewModel {
@@ -35,15 +35,16 @@ final class MyPageViewModel {
     struct Output {
         var isNotificationOn = PublishRelay<Bool>()
         var nickname = BehaviorRelay<String>(value: "")
+        var imageURL = BehaviorRelay<String>(value: "")
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
         input.viewDidLoadEvent
-            .subscribe { _ in
-                
-            }
+            .subscribe(onNext: { [weak self] in
+                self?.myPageUseCase.loadUserInfo()
+            })
             .disposed(by: disposeBag)
         
         input.notificationButtonDidTapEvent
@@ -53,9 +54,11 @@ final class MyPageViewModel {
             .disposed(by: disposeBag)
         
         input.profileEditButtonDidTapEvent
-            .subscribe { _ in
-                self.myPageCoordinator?.showProfileEditFlow()
-            }
+            .asDriver(onErrorJustReturn: ())
+            .drive(onNext: { [weak self] in
+                guard let nickname = self?.myPageUseCase.nickname else { return }
+                self?.myPageCoordinator?.showProfileEditFlow(with: nickname)
+            })
             .disposed(by: disposeBag)
         
         input.notificationSwitchValueDidChangeEvent
@@ -73,6 +76,10 @@ final class MyPageViewModel {
         Observable.just(self.myPageUseCase.nickname)
             .compactMap { $0 }
             .bind(to: output.nickname)
+            .disposed(by: disposeBag)
+        
+        self.myPageUseCase.imageURL
+            .bind(to: output.imageURL)
             .disposed(by: disposeBag)
         
         return output

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -34,6 +34,7 @@ final class MyPageViewModel {
     
     struct Output {
         var isNotificationOn = PublishRelay<Bool>()
+        var nickname = BehaviorRelay<String>(value: "")
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -67,6 +68,11 @@ final class MyPageViewModel {
             .subscribe { _ in
                 self.myPageCoordinator?.showLicenseFlow()
             }
+            .disposed(by: disposeBag)
+        
+        Observable.just(self.myPageUseCase.nickname)
+            .compactMap { $0 }
+            .bind(to: output.nickname)
             .disposed(by: disposeBag)
         
         return output

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -57,7 +57,7 @@ final class ProfileEditViewModel {
             .disposed(by: disposeBag)
         
         input.heightPickerSelectedRow
-            .map { $0 + 100 }
+            .map { Double($0 + 100) }
             .bind(to: self.profileEditUseCase.height)
             .disposed(by: disposeBag)
         
@@ -68,7 +68,7 @@ final class ProfileEditViewModel {
             .disposed(by: disposeBag)
         
         input.weightPickerSelectedRow
-            .map { $0 + 20 }
+            .map { Double($0 + 20) }
             .bind(to: self.profileEditUseCase.weight)
             .disposed(by: disposeBag)
     }
@@ -79,7 +79,7 @@ final class ProfileEditViewModel {
         self.profileEditUseCase.height
             .compactMap { $0 }
             .subscribe(onNext: { height in
-                let row = height - 100
+                let row = Int(height) - 100
                 output.heightPickerRow.accept(row)
                 output.heightFieldText.accept(output.heightRange.value[row])
             })
@@ -88,13 +88,13 @@ final class ProfileEditViewModel {
         self.profileEditUseCase.weight
             .compactMap { $0 }
             .subscribe(onNext: { weight in
-                let row = weight - 20
+                let row = Int(weight) - 20
                 output.weightPickerRow.accept(row)
                 output.weightFieldText.accept(output.weightRange.value[row])
             })
             .disposed(by: disposeBag)
         
-        self.profileEditUseCase.nickname
+        Observable.just(self.profileEditUseCase.nickname)
             .compactMap { $0 }
             .bind(to: output.nickname)
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -30,6 +30,7 @@ final class ProfileEditViewModel {
         var weightFieldText = BehaviorRelay<String>(value: "")
         var weightRange = BehaviorRelay<[String]>(value: [Int](20...300).map { "\($0) kg" })
         var weightPickerRow = BehaviorRelay<Int?>(value: nil)
+        var nickname = BehaviorRelay<String>(value: "")
     }
     
     init(profileEditCoordinator: ProfileEditCoordinator, profileEditUseCase: ProfileEditUseCase) {
@@ -91,6 +92,11 @@ final class ProfileEditViewModel {
                 output.weightPickerRow.accept(row)
                 output.weightFieldText.accept(output.weightRange.value[row])
             })
+            .disposed(by: disposeBag)
+        
+        self.profileEditUseCase.nickname
+            .compactMap { $0 }
+            .bind(to: output.nickname)
             .disposed(by: disposeBag)
         
         return output

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -7,15 +7,92 @@
 
 import Foundation
 
+import RxRelay
+import RxSwift
+
 final class ProfileEditViewModel {
     private weak var profileEditCoordinator: ProfileEditCoordinator?
     private let profileEditUseCase: ProfileEditUseCase
     
-    init(
-        profileEditCoordinator: ProfileEditCoordinator,
-        profileEditUseCase: ProfileEditUseCase
-    ) {
+    struct Input {
+        let viewDidLoadEvent: Observable<Void>
+        let heightTextFieldDidTapEvent: Observable<Void>
+        let heightPickerSelectedRow: Observable<Int>
+        let weightTextFieldDidTapEvent: Observable<Void>
+        let weightPickerSelectedRow: Observable<Int>
+        let doneButtonDidTapEvent: Observable<Void>
+    }
+    
+    struct Output {
+        var heightFieldText = BehaviorRelay<String>(value: "")
+        var heightRange = BehaviorRelay<[String]>(value: [Int](100...250).map { "\($0) cm" })
+        var heightPickerRow = BehaviorRelay<Int?>(value: nil)
+        var weightFieldText = BehaviorRelay<String>(value: "")
+        var weightRange = BehaviorRelay<[String]>(value: [Int](20...300).map { "\($0) kg" })
+        var weightPickerRow = BehaviorRelay<Int?>(value: nil)
+    }
+    
+    init(profileEditCoordinator: ProfileEditCoordinator, profileEditUseCase: ProfileEditUseCase) {
         self.profileEditCoordinator = profileEditCoordinator
         self.profileEditUseCase = profileEditUseCase
+    }
+    
+    func transform(from input: Input, disposeBag: DisposeBag) -> Output {
+        self.configureInput(input, disposeBag: disposeBag)
+        return self.createOutput(from: input, disposeBag: disposeBag)
+    }
+    
+    private func configureInput(_ input: Input, disposeBag: DisposeBag) {
+        input.viewDidLoadEvent
+            .subscribe(onNext: { [weak self] in
+                self?.profileEditUseCase.loadUserInfo()
+            })
+            .disposed(by: disposeBag)
+        
+        input.heightTextFieldDidTapEvent
+            .subscribe(onNext: { [weak self] in
+                self?.profileEditUseCase.getCurrentHeight()
+            })
+            .disposed(by: disposeBag)
+        
+        input.heightPickerSelectedRow
+            .map { $0 + 100 }
+            .bind(to: self.profileEditUseCase.height)
+            .disposed(by: disposeBag)
+        
+        input.weightTextFieldDidTapEvent
+            .subscribe(onNext: { [weak self] in
+                self?.profileEditUseCase.getCurrentWeight()
+            })
+            .disposed(by: disposeBag)
+        
+        input.weightPickerSelectedRow
+            .map { $0 + 20 }
+            .bind(to: self.profileEditUseCase.weight)
+            .disposed(by: disposeBag)
+    }
+    
+    private func createOutput(from input: Input, disposeBag: DisposeBag) -> Output {
+        let output = Output()
+        
+        self.profileEditUseCase.height
+            .compactMap { $0 }
+            .subscribe(onNext: { height in
+                let row = height - 100
+                output.heightPickerRow.accept(row)
+                output.heightFieldText.accept(output.heightRange.value[row])
+            })
+            .disposed(by: disposeBag)
+        
+        self.profileEditUseCase.weight
+            .compactMap { $0 }
+            .subscribe(onNext: { weight in
+                let row = weight - 20
+                output.weightPickerRow.accept(row)
+                output.weightFieldText.accept(output.weightRange.value[row])
+            })
+            .disposed(by: disposeBag)
+        
+        return output
     }
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -51,21 +51,9 @@ final class ProfileEditViewModel {
             })
             .disposed(by: disposeBag)
         
-        input.heightTextFieldDidTapEvent
-            .subscribe(onNext: { [weak self] in
-                self?.profileEditUseCase.getCurrentHeight()
-            })
-            .disposed(by: disposeBag)
-        
         input.heightPickerSelectedRow
             .map { Double($0 + 100) }
             .bind(to: self.profileEditUseCase.height)
-            .disposed(by: disposeBag)
-        
-        input.weightTextFieldDidTapEvent
-            .subscribe(onNext: { [weak self] in
-                self?.profileEditUseCase.getCurrentWeight()
-            })
             .disposed(by: disposeBag)
         
         input.weightPickerSelectedRow
@@ -96,20 +84,32 @@ final class ProfileEditViewModel {
             .bind(to: output.nickname)
             .disposed(by: disposeBag)
         
+        input.heightTextFieldDidTapEvent
+            .withLatestFrom(self.profileEditUseCase.height)
+            .compactMap { $0 }
+            .map { Int($0) - 100 }
+            .bind(to: output.heightPickerRow)
+            .disposed(by: disposeBag)
+        
         self.profileEditUseCase.height
             .compactMap { $0 }
             .subscribe(onNext: { height in
                 let row = Int(height) - 100
-                output.heightPickerRow.accept(row)
                 output.heightFieldText.accept(output.heightRange.value[row])
             })
+            .disposed(by: disposeBag)
+        
+        input.weightTextFieldDidTapEvent
+            .withLatestFrom(self.profileEditUseCase.weight)
+            .compactMap { $0 }
+            .map { Int($0) - 20 }
+            .bind(to: output.weightPickerRow)
             .disposed(by: disposeBag)
         
         self.profileEditUseCase.weight
             .compactMap { $0 }
             .subscribe(onNext: { weight in
                 let row = Int(weight) - 20
-                output.weightPickerRow.accept(row)
                 output.weightFieldText.accept(output.weightRange.value[row])
             })
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -31,6 +31,7 @@ final class ProfileEditViewModel {
         var weightRange = BehaviorRelay<[String]>(value: [Int](20...300).map { "\($0) kg" })
         var weightPickerRow = BehaviorRelay<Int?>(value: nil)
         var nickname = BehaviorRelay<String>(value: "")
+        var imageURL = BehaviorRelay<String>(value: "")
     }
     
     init(profileEditCoordinator: ProfileEditCoordinator, profileEditUseCase: ProfileEditUseCase) {
@@ -76,6 +77,11 @@ final class ProfileEditViewModel {
     private func createOutput(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
+        Observable.just(self.profileEditUseCase.nickname)
+            .compactMap { $0 }
+            .bind(to: output.nickname)
+            .disposed(by: disposeBag)
+        
         self.profileEditUseCase.height
             .compactMap { $0 }
             .subscribe(onNext: { height in
@@ -94,9 +100,9 @@ final class ProfileEditViewModel {
             })
             .disposed(by: disposeBag)
         
-        Observable.just(self.profileEditUseCase.nickname)
+        self.profileEditUseCase.imageURL
             .compactMap { $0 }
-            .bind(to: output.nickname)
+            .bind(to: output.imageURL)
             .disposed(by: disposeBag)
         
         return output

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import RxRelay
+import RxCocoa
 import RxSwift
 
 final class ProfileEditViewModel {
@@ -71,6 +71,20 @@ final class ProfileEditViewModel {
         input.weightPickerSelectedRow
             .map { Double($0 + 20) }
             .bind(to: self.profileEditUseCase.weight)
+            .disposed(by: disposeBag)
+        
+        input.doneButtonDidTapEvent
+            .subscribe(onNext: { [weak self] in
+                self?.profileEditUseCase.saveUserInfo()
+            })
+            .disposed(by: disposeBag)
+        
+        self.profileEditUseCase.saveResult
+            .asDriver(onErrorJustReturn: false)
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                self?.profileEditCoordinator?.finish()
+            })
             .disposed(by: disposeBag)
     }
     

--- a/MateRunner/MateRunner/Util/Constant/FilePath.swift
+++ b/MateRunner/MateRunner/Util/Constant/FilePath.swift
@@ -1,0 +1,12 @@
+//
+//  FilePath.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/26.
+//
+
+import Foundation
+
+enum FilePath {
+    static let license = Bundle.main.path(forResource: "license", ofType: "txt") ?? ""
+}


### PR DESCRIPTION
### 📕 Issue Number

*완료하지 않은 이슈라서 Close하지 않습니다.*
Close #



https://user-images.githubusercontent.com/77449223/143448764-8afd9d1e-056f-4262-a83f-cef8c1298799.MP4


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 마이페이지 화면 프로필 사진, 닉네임 표시
- [x] 프로필 편집 화면 프로필 사진, 닉네임, 키, 몸무게 표시
- [x] 프로필 편집 화면 키, 몸무게 서버에 저장  


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 서버에는 Double로 저장한다고 해서 Type Casting을 해주었습니다.

<br/><br/>
