### PR TITLE
메이트관련 Rest API 전환 및 이모지, 화면전환

### DIFF
--- a/MateRunner/MateRunner/Data/Network/DataMapping/RunningResultFirestoreDTO.swift
+++ b/MateRunner/MateRunner/Data/Network/DataMapping/RunningResultFirestoreDTO.swift
@@ -121,11 +121,13 @@ struct RunningResultFirestoreDTO: Codable {
         }
         
         let runningSetting = RunningSetting(
+            sessionId: self.runningID.value,
             mode: RunningMode(rawValue: self.mode.value),
             targetDistance: self.targetDistance.value,
             mateNickname: self.mateNickname?.value,
             dateTime: Date().convertToyyyyMMddTHHmmssSSZ(dateString: self.dateTime.value)
         )
+        
         let runningData = RunningData(
             myRunningRealTimeData: RunningRealTimeData(
                 elapsedDistance: self.userElapsedDistance.value,

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -247,7 +247,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
             })
     }
     
-    func fetchFilteredMate(from text: String, of nickname: String) -> Observable<[String]?> { // ***
+    func fetchFilteredMate(from text: String, of nickname: String) -> Observable<[String]?> {
         let endPoint = FirestoreConfiguration.baseURL
         + FirestoreConfiguration.documentsPath
         + FirestoreCollectionPath.userPath

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -118,7 +118,6 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         + FirestoreCollectionPath.recordsPath
         + "/\(runningID)"
         + FirestoreCollectionPath.emojiPath
-        
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ data -> [String: Emoji] in
                 guard let documents = try? JSONDecoder().decode(DocumentsValue.self, from: data) else { return [:] }

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
@@ -72,7 +72,7 @@ final class DefaultUserRepository: UserRepository {
         return self.networkService.readDTO(
             UserProfileDTO(),
             collection: FirebaseCollection.user,
-            document: nickname
+            document: "hunihun956"
         )
     }
 

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -73,6 +73,10 @@ protocol FirestoreRepository {
     func fetchMate(
         of nickname: String                // 메이트목록을 가져올 사용자의 닉네임
     ) -> Observable<[String]?>
+    func fetchFilteredMate(
+        from text: String,                 // 필터링 기준 텍스트
+        of nickname: String                // 메이트목록을 가져올 사용자의 닉네임
+    ) -> Observable<[String]?>
     func save(
         mate nickname: String,             // 메이트로 추가할 사용자의 닉네임
         to targetNickname: String          // 대상 사용자의 닉네임

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -44,18 +44,4 @@ final class DefaultMateRepository: MateRepository {
     func fetchFCMToken(of mate: String)-> Observable<String> {
         return self.realtimeNetworkService.fetchFCMToken(of: mate)
     }
-    
-    // TODO: saveRequestMate RestAPI로 변경
-//    func saveRequestMate(_ notice: Notice?) -> Observable<Void> {
-//        guard let notice = notice else {
-//            return Observable.error(FirebaseServiceError.nilDataError)
-//        }
-//
-//        return self.fireStoreNetworkService.writeDTO(
-//            NoticeDTO(from: notice),
-//            collection: "Notification",
-//            document: notice.receiver,
-//            key: notice.sender
-////        )
-//    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -11,43 +11,15 @@ import RxRelay
 import RxSwift
 
 final class DefaultMateRepository: MateRepository {
-    let fireStoreNetworkService: FireStoreNetworkService
     let realtimeNetworkService: RealtimeDatabaseNetworkService
     let urlSessionNetworkService: URLSessionNetworkService
     
     init(
-        fireStoreNetworkService: FireStoreNetworkService,
         realtimeNetworkService: RealtimeDatabaseNetworkService,
         urlSessionNetworkService: URLSessionNetworkService
     ) {
-        self.fireStoreNetworkService = fireStoreNetworkService
         self.realtimeNetworkService = realtimeNetworkService
         self.urlSessionNetworkService = urlSessionNetworkService
-    }
-    
-    func fetchMateNickname() -> Observable<[String]> {
-        return self.fireStoreNetworkService.fetchData(
-            type: [String].self,
-            collection: FirebaseCollection.user,
-            document: "yujin",
-            field: "mate"
-        )
-    }
-    
-    func fetchMateProfileImage(from nickname: String) -> Observable<String> {
-        return self.fireStoreNetworkService.fetchData(
-            type: String.self,
-            collection: FirebaseCollection.user,
-            document: nickname,
-            field: "image"
-        )
-    }
-    
-    func fetchFilteredNickname(text: String) -> Observable<[String]> {
-        return self.fireStoreNetworkService.fetchFilteredDocument(
-            collection: FirebaseCollection.user,
-            with: text
-        )
     }
     
     func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> {
@@ -73,16 +45,17 @@ final class DefaultMateRepository: MateRepository {
         return self.realtimeNetworkService.fetchFCMToken(of: mate)
     }
     
-    func saveRequestMate(_ notice: Notice?) -> Observable<Void> {
-        guard let notice = notice else {
-            return Observable.error(FirebaseServiceError.nilDataError)
-        }
-        
-        return self.fireStoreNetworkService.writeDTO(
-            NoticeDTO(from: notice),
-            collection: "Notification",
-            document: notice.receiver,
-            key: notice.sender
-        )
-    }
+    // TODO: saveRequestMate RestAPI로 변경
+//    func saveRequestMate(_ notice: Notice?) -> Observable<Void> {
+//        guard let notice = notice else {
+//            return Observable.error(FirebaseServiceError.nilDataError)
+//        }
+//
+//        return self.fireStoreNetworkService.writeDTO(
+//            NoticeDTO(from: notice),
+//            collection: "Notification",
+//            document: notice.receiver,
+//            key: notice.sender
+////        )
+//    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
@@ -10,10 +10,7 @@ import Foundation
 import RxSwift
 
 protocol MateRepository {
-    func fetchMateNickname() -> Observable<[String]>
-    func fetchMateProfileImage(from nickname: String) -> Observable<String>
-    func fetchFilteredNickname(text: String) -> Observable<[String]>
     func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> 
     func fetchFCMToken(of mate: String)-> Observable<String>
-    func saveRequestMate(_ notice: Notice?) -> Observable<Void>
+//    func saveRequestMate(_ notice: Notice?) -> Observable<Void> //TODO: saveRequestMate RestAPI로 변경
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Common/DefaultEmojiUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/DefaultEmojiUseCase.swift
@@ -13,6 +13,8 @@ final class DefaultEmojiUseCase: EmojiUseCase {
     var selectedEmoji: PublishSubject<Emoji> = PublishSubject()
     weak var delegate: EmojiDidSelectDelegate?
     
+    init() {}
+    
     init(delegate: EmojiDidSelectDelegate) {
         self.delegate = delegate
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -12,7 +12,7 @@ import RxSwift
 
 final class DefaultMateUseCase: MateUseCase {
     private let mateRepository: MateRepository
-    private let fireStoreRepository: FirestoreRepository
+    private let firestoreRepository: FirestoreRepository
     private let disposeBag = DisposeBag()
     var mateList: PublishSubject<MateList> = PublishSubject()
     var didLoadMate: PublishSubject<Bool> = PublishSubject()
@@ -20,14 +20,14 @@ final class DefaultMateUseCase: MateUseCase {
     
     init(
         mateRepository: MateRepository,
-        fireStoreRepository: FirestoreRepository
+        firestoreRepository: FirestoreRepository
     ) {
         self.mateRepository = mateRepository
-        self.fireStoreRepository = fireStoreRepository
+        self.firestoreRepository = firestoreRepository
     }
     
     func fetchMateList() {
-        self.fireStoreRepository.fetchMate(of: "yujin")
+        self.firestoreRepository.fetchMate(of: "yujin")
             .subscribe(onNext: { [weak self] mate in
                 self?.fetchMateImage(mate: mate ?? [])
             })
@@ -35,7 +35,7 @@ final class DefaultMateUseCase: MateUseCase {
     }
     
     func fetchMateInfo(name: String) {
-        self.fireStoreRepository.fetchFilteredMate(from: name, of: "yujin")
+        self.firestoreRepository.fetchFilteredMate(from: name, of: "yujin")
             .subscribe(onNext: { [weak self] mate in
                 self?.fetchMateImage(mate: mate ?? [])
             })
@@ -45,7 +45,7 @@ final class DefaultMateUseCase: MateUseCase {
     func fetchMateImage(mate: [String]) {
         var mateList: [String: String] = [:]
         Observable.zip( mate.map { nickname in
-            self.fireStoreRepository.fetchUserData(of: nickname)
+            self.firestoreRepository.fetchUserData(of: nickname)
                 .map({ user in
                     mateList[nickname] = user?.image
                 })

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -84,11 +84,11 @@ final class DefaultMateUseCase: MateUseCase {
             receiver: mate,
             mode: NoticeMode.requestMate
         )
-        self.mateRepository.saveRequestMate(notice)
-            .subscribe(onNext: { [weak self] in
-                self?.didRequestMate.onNext(true)
-            })
-            .disposed(by: self.disposeBag)
+//        self.mateRepository.saveRequestMate(notice)
+//            .subscribe(onNext: { [weak self] in
+//                self?.didRequestMate.onNext(true)
+//            })
+//            .disposed(by: self.disposeBag)
     }
     
     private func filterText(_ mate: MateList, from text: String) -> Observable<MateList> {

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 final class DefaultProfileUseCase: ProfileUseCase {
-    private let fireStoreRepository: FirestoreRepository
+    private let firestoreRepository: FirestoreRepository
     private let userRepository: UserRepository
     private let disposeBag = DisposeBag()
     var userInfo: PublishSubject<UserData> = PublishSubject()
@@ -18,13 +18,14 @@ final class DefaultProfileUseCase: ProfileUseCase {
     
     init(
         userRepository: UserRepository,
-        fireStoreRepository: FirestoreRepository) {
+        firestoreRepository: FirestoreRepository
+    ) {
         self.userRepository = userRepository
-        self.fireStoreRepository = fireStoreRepository
+        self.firestoreRepository = firestoreRepository
     }
     
     func fetchUserInfo(_ nickname: String) {
-        self.fireStoreRepository.fetchUserData(of: nickname)
+        self.firestoreRepository.fetchUserData(of: nickname)
             .subscribe(onNext: { [weak self] mate in
                 guard let mate = mate else { return }
                 self?.userInfo.onNext(mate)
@@ -34,10 +35,10 @@ final class DefaultProfileUseCase: ProfileUseCase {
     
     func fetchRecordList(nickname: String) {
         var recordList: [RunningResult] = []
-        self.fireStoreRepository.fetchResult(of: nickname, from: 0, by: 20)
+        self.firestoreRepository.fetchResult(of: nickname, from: 0, by: 20)
             .subscribe(onNext: { [weak self] records in
                 records?.forEach { record in
-                    self?.fireStoreRepository.fetchEmojis(of: record.runningID, from: nickname)
+                    self?.firestoreRepository.fetchEmojis(of: record.runningID, from: nickname)
                         .subscribe(onNext: { emoji in
                             recordList.append(
                                 RunningResult(

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -11,11 +11,15 @@ import RxSwift
 
 final class DefaultProfileUseCase: ProfileUseCase {
     private let fireStoreRepository: FirestoreRepository
+    private let userRepository: UserRepository
     private let disposeBag = DisposeBag()
     var userInfo: PublishSubject<UserData> = PublishSubject()
     var recordInfo: PublishSubject<[RunningResult]> = PublishSubject()
     
-    init(fireStoreRepository: FirestoreRepository) {
+    init(
+        userRepository: UserRepository,
+        fireStoreRepository: FirestoreRepository) {
+        self.userRepository = userRepository
         self.fireStoreRepository = fireStoreRepository
     }
     
@@ -34,6 +38,10 @@ final class DefaultProfileUseCase: ProfileUseCase {
                 self?.recordInfo.onNext(records ?? [])
             })
             .disposed(by: disposeBag)
+    }
+    
+    func fetchUserNickname() -> String? {
+        self.userRepository.fetchUserNickname()
     }
     
 //    func resultToRecordList(from result: UserResultDTO) -> [RunningResult] {

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -10,37 +10,37 @@ import Foundation
 import RxSwift
 
 final class DefaultProfileUseCase: ProfileUseCase {
-    private let userRepository: UserRepository
+    private let fireStoreRepository: FirestoreRepository
     private let disposeBag = DisposeBag()
-    var userInfo: PublishSubject<UserProfileDTO> = PublishSubject()
+    var userInfo: PublishSubject<UserData> = PublishSubject()
     var recordInfo: PublishSubject<[RunningResult]> = PublishSubject()
     
-    init(repository: UserRepository) {
-        self.userRepository = repository
+    init(fireStoreRepository: FirestoreRepository) {
+        self.fireStoreRepository = fireStoreRepository
     }
     
     func fetchUserInfo(_ nickname: String) {
-        self.userRepository.fetchUserInfo(nickname)
+        self.fireStoreRepository.fetchUserData(of: nickname)
             .subscribe(onNext: { [weak self] mate in
+                guard let mate = mate else { return }
                 self?.userInfo.onNext(mate)
             })
             .disposed(by: self.disposeBag)
     }
     
     func fetchRecordList(nickname: String) {
-        self.userRepository.fetchRecordList(nickname)
-            .map { self.resultToRecordList(from: $0) }
+        self.fireStoreRepository.fetchResult(of: nickname, from: 0, by: 10)
             .subscribe(onNext: { [weak self] records in
-                self?.recordInfo.onNext(records)
+                self?.recordInfo.onNext(records ?? [])
             })
             .disposed(by: disposeBag)
     }
     
-    func resultToRecordList(from result: UserResultDTO) -> [RunningResult] {
-        var recordList: [RunningResult] = []
-        result.records.values.forEach { record in
-            recordList.append(record.toDomain())
-        }
-        return recordList
-    }
+//    func resultToRecordList(from result: UserResultDTO) -> [RunningResult] {
+//        var recordList: [RunningResult] = []
+//        result.records.values.forEach { record in
+//            recordList.append(record.toDomain())
+//        }
+//        return recordList
+//    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 protocol ProfileUseCase {
-    var userInfo: PublishSubject<UserProfileDTO> { get set }
+    var userInfo: PublishSubject<UserData> { get set }
     var recordInfo: PublishSubject<[RunningResult]> { get set }
     func fetchUserInfo(_ nickname: String)
     func fetchRecordList(nickname: String)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
@@ -14,4 +14,5 @@ protocol ProfileUseCase {
     var recordInfo: PublishSubject<[RunningResult]> { get set }
     func fetchUserInfo(_ nickname: String)
     func fetchRecordList(nickname: String)
+    func fetchUserNickname() -> String?
 }

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
@@ -13,7 +13,7 @@ import RxCocoa
 final class EmojiViewModel {
     let emojiObservable = Observable.of(Emoji.allCases)
     private let emojiUseCase: EmojiUseCase
-    private weak var coordinator: RunningCoordinator?
+    private weak var coordinator: EmojiCoordinator?
     
     struct Input {
       let emojiCellTapEvent: Observable<IndexPath>
@@ -25,7 +25,7 @@ final class EmojiViewModel {
     }
     
     init(
-        coordinator: RunningCoordinator,
+        coordinator: EmojiCoordinator,
         emojiUseCase: DefaultEmojiUseCase
     ) {
         self.coordinator = coordinator

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -123,7 +123,7 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
                 mateRepository: DefaultMateRepository(
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
-                ), fireStoreRepository: DefaultFirestoreRepository(
+                ), firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 )
             )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -120,10 +120,11 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
         inviteMateViewController.mateViewModel = MateViewModel(
             coordinator: DefaultMateCoordinator(UINavigationController()),
             mateUseCase: DefaultMateUseCase(
-                repository: DefaultMateRepository(
-                    fireStoreNetworkService: DefaultFireStoreNetworkService(),
+                mateRepository: DefaultMateRepository(
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
+                ), fireStoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/RunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/RunningCoordinator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol RunningCoordinator: Coordinator {
+protocol RunningCoordinator: EmojiCoordinator {
     func pushRunningViewController(with settingData: RunningSetting?)
     func pushRunningResultViewController(with runningResult: RunningResult?)
     func pushTeamRunningResultViewController(with runningResult: RunningResult?)

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
@@ -27,10 +27,11 @@ final class DefaultAddMateCoordinator: AddMateCoordinator {
         addMateViewController.viewModel = AddMateViewModel(
             coordinator: self,
             mateUseCase: DefaultMateUseCase(
-                repository: DefaultMateRepository(
-                    fireStoreNetworkService: DefaultFireStoreNetworkService(),
+                mateRepository: DefaultMateRepository(
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
+                ), fireStoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
@@ -30,7 +30,7 @@ final class DefaultAddMateCoordinator: AddMateCoordinator {
                 mateRepository: DefaultMateRepository(
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
-                ), fireStoreRepository: DefaultFirestoreRepository(
+                ), firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 )
             )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -23,10 +23,11 @@ final class DefaultMateCoordinator: MateCoordinator {
         self.mateViewController.mateViewModel = MateViewModel(
             coordinator: self,
             mateUseCase: DefaultMateUseCase(
-                repository: DefaultMateRepository(
-                    fireStoreNetworkService: DefaultFireStoreNetworkService(),
+                mateRepository: DefaultMateRepository(
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
+                ), fireStoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -26,7 +26,7 @@ final class DefaultMateCoordinator: MateCoordinator {
                 mateRepository: DefaultMateRepository(
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
-                ), fireStoreRepository: DefaultFirestoreRepository(
+                ), firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 )
             )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -18,7 +18,7 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
     }
-
+    
     func start() {
         self.pushMateProfileViewController()
     }
@@ -29,6 +29,9 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
             nickname: self.user ?? "",
             coordinator: self,
             profileUseCase: DefaultProfileUseCase(
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
+                ),
                 fireStoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -29,8 +29,8 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
             nickname: self.user ?? "",
             coordinator: self,
             profileUseCase: DefaultProfileUseCase(
-                repository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                fireStoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -36,7 +36,7 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
                 userRepository: DefaultUserRepository(
                     networkService: DefaultFireStoreNetworkService()
                 ),
-                fireStoreRepository: DefaultFirestoreRepository(
+                firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 )
             )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol EmojiCoordinator: Coordinator {
+    
+}
+
 final class DefaultMateProfileCoordinator: MateProfileCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     weak var settingFinishDelegate: SettingCoordinatorDidFinishDelegate?
@@ -51,5 +55,13 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
             )
         )
         self.navigationController.pushViewController(recordDetailViewController, animated: true)
+    }
+    
+    func presentEmojiModal() {
+        let emojiViewController = EmojiViewController()
+        emojiViewController.viewModel = EmojiViewModel(
+            coordinator: self, emojiUseCase: DefaultEmojiUseCase()
+        )
+        self.navigationController.present(emojiViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -36,4 +36,17 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
         )
         self.navigationController.pushViewController(mateProfileViewController, animated: true)
     }
+    
+    func pushRecordDetailViewController(with runningResult: RunningResult) {
+        let recordDetailViewController = RecordDetailViewController()
+        recordDetailViewController.viewModel = RecordDetailViewModel(
+            recordDetailUseCase: DefaultRecordDetailUseCase(
+                userRepository: DefaultUserRepository(
+                    networkService: DefaultFireStoreNetworkService()
+                ),
+                with: runningResult
+            )
+        )
+        self.navigationController.pushViewController(recordDetailViewController, animated: true)
+    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-protocol MateProfileCoordinator: Coordinator {
+protocol MateProfileCoordinator: EmojiCoordinator {
     func pushMateProfileViewController()
     func pushRecordDetailViewController(with runningResult: RunningResult)
+    func presentEmojiModal()
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol MateProfileCoordinator: Coordinator {
     func pushMateProfileViewController()
+    func pushRecordDetailViewController(with runningResult: RunningResult)
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
@@ -10,13 +10,13 @@ import UIKit
 import RxCocoa
 import RxSwift
 
-protocol SendEmojiDelegate: AnyObject {
+protocol HeartButtonDidTapDelegate: AnyObject {
     func heartButtonDidTap()
 }
 
 final class MateRecordTableViewCell: RecordCell {
     private let disposeBag = DisposeBag()
-    weak var delegate: SendEmojiDelegate?
+    weak var delegate: HeartButtonDidTapDelegate?
     
     private lazy var heartButton: UIButton = {
         let button = UIButton()

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
@@ -25,10 +25,21 @@ final class MateRecordTableViewCell: RecordCell {
         self.configureButton()
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.heartButton.setImage(UIImage(systemName: "heart"), for: .normal)
+        self.heartButton.isEnabled = true
+    }
+    
     override func updateUI(record: RunningResult) {
         super.updateUI(record: record)
-        
-        // TODO: 하트 관련 로직 필요
+    }
+    
+    func updateHeartButton(nickname: String, sender: [String]) {
+        if sender.contains("yujin") {
+            self.heartButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+            self.heartButton.isEnabled = false
+        }
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
@@ -7,7 +7,17 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
+
+protocol SendEmojiDelegate: AnyObject {
+    func heartButtonDidTap()
+}
+
 final class MateRecordTableViewCell: RecordCell {
+    private let disposeBag = DisposeBag()
+    weak var delegate: SendEmojiDelegate?
+    
     private lazy var heartButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "heart"), for: .normal)
@@ -52,5 +62,14 @@ private extension MateRecordTableViewCell {
             make.right.equalToSuperview().inset(15)
             make.top.equalToSuperview().offset(15)
         }
+        self.bindUI()
+    }
+    
+    func bindUI() {
+        self.heartButton.rx.tap
+            .bind { [weak self] in
+                self?.delegate?.heartButtonDidTap()
+            }
+            .disposed(by: self.disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -140,7 +140,11 @@ extension MateProfileViewController: UITableViewDataSource {
             ) as? MateRecordTableViewCell else { return UITableViewCell() }
             
             guard let result = self.viewModel?.recordInfo else { return UITableViewCell() }
-            cell.updateUI(record: result[indexPath.row])
+            let nickname = self.viewModel?.fetchUserNickname()
+            let record = result[indexPath.row]
+            cell.updateUI(record: record)
+            let emoji = record.emojis ?? [:]
+            cell.updateHeartButton(nickname: "yujin", sender: Array(emoji.keys))
             return cell
         default:
             return UITableViewCell()

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -139,6 +139,7 @@ extension MateProfileViewController: UITableViewDataSource {
                 for: indexPath
             ) as? MateRecordTableViewCell else { return UITableViewCell() }
             
+            cell.delegate = self
             guard let result = self.viewModel?.recordInfo else { return UITableViewCell() }
             let nickname = self.viewModel?.fetchUserNickname()
             let record = result[indexPath.row]
@@ -187,5 +188,12 @@ extension MateProfileViewController: UITableViewDataSource {
         let record = self.viewModel?.recordInfo?[indexPath.row]
         guard let record = record else { return }
         self.viewModel?.moveToDetail(record: record)
+    }
+}
+
+// MARK: - SendEmojiDelegate
+
+extension MateProfileViewController: SendEmojiDelegate {
+    func heartButtonDidTap() {
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -195,5 +195,6 @@ extension MateProfileViewController: UITableViewDataSource {
 
 extension MateProfileViewController: SendEmojiDelegate {
     func heartButtonDidTap() {
+        self.viewModel?.moveToEmoji()
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -13,7 +13,7 @@ enum MateProfileTableViewValue: CGFloat {
     case profileSectionCellHeight = 300
     case recordSectionCellHeight = 130
     case headerHeight = 50
-
+    
     func value() -> CGFloat {
         return self.rawValue
     }
@@ -22,7 +22,7 @@ enum MateProfileTableViewValue: CGFloat {
 enum MateProfileTableViewSection: Int {
     case profileSection = 0
     case recordSection = 1
-
+    
     func number() -> Int {
         return self.rawValue
     }
@@ -76,7 +76,7 @@ private extension MateProfileViewController {
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
-
+        
         output?.loadProfile
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: { [weak self] _ in
@@ -110,11 +110,11 @@ extension MateProfileViewController: UITableViewDelegate {
 
 // MARK: - UITableViewDataSource
 
- extension MateProfileViewController: UITableViewDataSource {
+extension MateProfileViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {
         case MateProfileTableViewSection.profileSection.number():
@@ -122,7 +122,7 @@ extension MateProfileViewController: UITableViewDelegate {
                 withIdentifier: MateProfilTableViewCell.identifier,
                 for: indexPath
             ) as? MateProfilTableViewCell else { return UITableViewCell() }
-
+            
             cell.addShadow(location: .bottom, color: .mrGray, opacity: 0.4, radius: 5.0)
             guard let profile = self.viewModel?.mateInfo else { return UITableViewCell() }
             cell.updateUI(
@@ -146,7 +146,7 @@ extension MateProfileViewController: UITableViewDelegate {
             return UITableViewCell()
         }
     }
-
+    
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         switch section {
         case MateProfileTableViewSection.recordSection.number():
@@ -155,18 +155,18 @@ extension MateProfileViewController: UITableViewDelegate {
             return 0
         }
     }
-
+    
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let header = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: MateHeaderView.identifier) as? MateHeaderView else {
                 return UITableViewHeaderFooterView()
             }
-
+        
         guard let profile = self.viewModel?.mateInfo else { return UITableViewHeaderFooterView() }
         header.updateUI(nickname: profile.nickname)
         return header
     }
-
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case MateProfileTableViewSection.profileSection.number():
@@ -177,8 +177,11 @@ extension MateProfileViewController: UITableViewDelegate {
             return 0
         }
     }
-
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        기록 결과화면 전환
+        tableView.deselectRow(at: indexPath, animated: true)
+        let record = self.viewModel?.recordInfo?[indexPath.row]
+        guard let record = record else { return }
+        self.viewModel?.moveToDetail(record: record)
     }
- }
+}

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -193,7 +193,7 @@ extension MateProfileViewController: UITableViewDataSource {
 
 // MARK: - SendEmojiDelegate
 
-extension MateProfileViewController: SendEmojiDelegate {
+extension MateProfileViewController: HeartButtonDidTapDelegate {
     func heartButtonDidTap() {
         self.viewModel?.moveToEmoji()
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -128,9 +128,9 @@ extension MateProfileViewController: UITableViewDelegate {
             cell.updateUI(
                 imageURL: profile.image,
                 nickname: profile.nickname,
-                time: "\(profile.time)",
-                distance: "\(profile.distance)",
-                calorie: "\(profile.calorie)"
+                time: profile.time.timeString,
+                distance: profile.distance.kilometerString,
+                calorie: profile.calorie.calorieString
             )
             return cell
         case MateProfileTableViewSection.recordSection.number():

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -74,4 +74,8 @@ final class MateProfileViewModel: NSObject {
     func moveToDetail(record: RunningResult) {
         self.coordinator?.pushRecordDetailViewController(with: record)
     }
+    
+    func fetchUserNickname() -> String? {
+        self.profileUseCase.fetchUserNickname()
+    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -70,4 +70,8 @@ final class MateProfileViewModel: NSObject {
         
         return output
     }
+    
+    func moveToDetail(record: RunningResult) {
+        self.coordinator?.pushRecordDetailViewController(with: record)
+    }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -13,7 +13,7 @@ import RxSwift
 final class MateProfileViewModel: NSObject {
     private let profileUseCase: ProfileUseCase
     weak var coordinator: MateProfileCoordinator?
-    var mateInfo: UserProfileDTO?
+    var mateInfo: UserData?
     var recordInfo: [RunningResult]?
     
     struct Input {
@@ -29,7 +29,16 @@ final class MateProfileViewModel: NSObject {
         coordinator: MateProfileCoordinator,
         profileUseCase: ProfileUseCase
     ) {
-        self.mateInfo = UserProfileDTO()
+        self.mateInfo = UserData(
+            nickname: "",
+            image: "",
+            time: 0,
+            distance: 0,
+            calorie: 0,
+            height: 0,
+            weight: 0,
+            mate: []
+        )
         self.coordinator = coordinator
         self.profileUseCase = profileUseCase
     }
@@ -40,8 +49,8 @@ final class MateProfileViewModel: NSObject {
         input.viewDidLoadEvent
             .subscribe(onNext: { [weak self] in
                 guard let nickname = self?.mateInfo?.nickname else { return }
-                self?.profileUseCase.fetchUserInfo(nickname)
-                self?.profileUseCase.fetchRecordList(nickname: nickname)
+                self?.profileUseCase.fetchUserInfo("hunihun956")
+                self?.profileUseCase.fetchRecordList(nickname: "hunihun956")
             })
             .disposed(by: disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -75,6 +75,10 @@ final class MateProfileViewModel: NSObject {
         self.coordinator?.pushRecordDetailViewController(with: record)
     }
     
+    func moveToEmoji() {
+        self.coordinator?.presentEmojiModal()
+    }
+    
     func fetchUserNickname() -> String? {
         self.profileUseCase.fetchUserNickname()
     }


### PR DESCRIPTION
### 📕 Issue Number

Close #229 #228 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 메이트 목록, 메이트 프로필 Rest API 로 변경
- [x] 이모지 모달


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
아까 줌에서 여훈님과 말했던 코디네이터는 .. 그게 알고보니까 &가 두가지를 다 채택하는 타입이 와야하는거였더라구요.. 그래서 최상위 Coodinator를 채택하는 EmojiCoodinator가 있고 그 코디네이터를 메이트와 러닝 코디네이터가 채택하고 있는 구조입니다..! 일단 이렇게 해뒀는데 나중에 좀 더 리팩토링 하거나 하면 좋을것 같습니다!

- 특이 사항 2
급하게 짜느라 코드가 좀.. 지저분합니다 🥲 특히 runningResult를 이모지까지 fetch하고 set하는 부분이 좀 지저분한데.. 이것도 얼른 리팩토링 하겠습니다!

- 특이 사항 3
여훈님과 해결한 이모지 fetch관련 러닝ID 관련 부분 피알에 포함시켰고 제가 파이어스토어레포지토리에 추가한 메서드는 이름 필터링 쿼리관련한 `fetchFilteredMate` 추가했습니다!

<br/><br/>
