### PR TITLE
누적기록 업데이트, URLSession서비스 개선

### DIFF
--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -45,6 +45,18 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         })
     }
     
+    func saveAll(
+        runningResult: RunningResult,
+        personalTotalRecord: PersonalTotalRecord,
+        userNickname: String
+    ) -> Observable<Void> {
+        return Observable.zip(
+            self.save(runningResult: runningResult, to: userNickname),
+            self.save(totalRecord: personalTotalRecord, of: userNickname),
+            resultSelector: { _, _ in }
+        )
+    }
+    
     func fetchResult(of nickname: String, from startDate: Date, to endDate: Date) -> Observable<[RunningResult]> {
         let endPoint = FirestoreConfiguration.baseURL
         + FirestoreConfiguration.documentsPath
@@ -150,7 +162,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         + FirestoreCollectionPath.recordsPath
         + "/\(runningID)"
         + FirestoreCollectionPath.emojiPath
-        
+                
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> [String: Emoji] in
                 switch result {

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -30,7 +30,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         + "/\(runningResult.runningID)"
         
         guard let dto = try? RunningResultFirestoreDTO(runningResult: runningResult) else {
-            return Observable.error(FirebaseServiceError.typeMismatchError)
+            return Observable.error(FirestoreRepositoryError.encodingError)
         }
         
         return self.urlSession.patch(
@@ -199,7 +199,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
             .map({ result -> UserData in
                 switch result {
                 case .success(let data):
-                    guard let dto = try? JSONDecoder().decode(UserDataFirestoreDTO.self, from: data) else {
+                    guard let dto = self.decode(data: data, to: UserDataFirestoreDTO.self) else {
                         throw FirestoreRepositoryError.decodingError
                     }
                     return dto.toDomain()
@@ -329,7 +329,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
             .map({ result -> [String] in
                 switch result {
                 case .success(let data):
-                    guard let mates = try? JSONDecoder().decode(MateListFirestoreDTO.self, from: data) else {
+                    guard let mates = self.decode(data: data, to: MateListFirestoreDTO.self) else {
                         throw FirestoreRepositoryError.decodingError
                     }
                     return mates.toDomain()

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -243,14 +243,11 @@ final class DefaultFirestoreRepository: FirestoreRepository {
            FirestoreFieldParameter.readMask + FirestoreField.image
         ].joined(separator: "&")
         
-        print(endPoint)
-        
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> UserProfile in
                 switch result {
                 case .success(let data):
                     guard let dto = self.decode(data: data, to: UserProfileFirestoreDTO.self) else {
-                        print("errro")
                         throw FirestoreRepositoryError.decodingError
                     }
                     return dto.toDomain()
@@ -404,7 +401,6 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         do {
             return try JSONDecoder().decode(target, from: data)
         } catch {
-            NSLog(error.localizedDescription)
             return nil
         }
     }

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import RxSwift
 
-final class DefaultFirestoreRepository {
+final class DefaultFirestoreRepository: FirestoreRepository {
     private let urlSession: URLSessionNetworkService
     
     init(urlSessionService: URLSessionNetworkService) {
@@ -86,6 +86,7 @@ final class DefaultFirestoreRepository {
         + "/\(userNickname)"
         
         let dto = EmojiFirestoreDTO(emoji: emoji.text(), userNickname: userNickname)
+        
         return self.urlSession.patch(
             ["fields": dto],
             url: endPoint,

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -404,31 +404,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         })
     }
     
-    func remove(mate nickname: String, from targetNickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreConfiguration.commitKey
-        
-        return self.urlSession.post(
-            FirestoreQuery.remove(mate: nickname, from: targetNickname),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
-    }
-    
-    private func decode<T: Decodable>(data: Data, to target: T.Type) -> T? {
-        do {
-            return try JSONDecoder().decode(target, from: data)
-        } catch {
-            return nil
-        }
-    }
-    
+    // MARK: - Notice Read/Update
     func fetchNotice(of userNickname: String) -> Observable<[Notice]> {
         let endPoint = FirestoreConfiguration.baseURL
         + FirestoreConfiguration.documentsPath
@@ -462,11 +438,15 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         let dto = NoticeDTO(from: notice)
         
         return self.urlSession.post(
-            ["fields": dto],
+            [FirestoreField.fields: dto],
             url: endPoint,
             headers: FirestoreConfiguration.defaultHeaders
-        )
-            .map({ _ in })
+        ).map({ result in
+            switch result {
+            case .success: break
+            case .failure(let error): throw error
+            }
+        })
     }
     
     func updateState(notice: Notice, of userNickname: String) -> Observable<Void> {
@@ -474,11 +454,40 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         let dto = NoticeDTO(from: notice)
         
         return self.urlSession.patch(
-            ["fields": dto],
+            [FirestoreField.fields: dto],
             url: endPoint,
             headers: FirestoreConfiguration.defaultHeaders
-        )
-            .map({ _ in })
+        ).map({ result in
+            switch result {
+            case .success: break
+            case .failure(let error): throw error
+            }
+        })
+    }
+    
+    func remove(mate nickname: String, from targetNickname: String) -> Observable<Void> {
+        let endPoint = FirestoreConfiguration.baseURL
+        + FirestoreConfiguration.documentsPath
+        + FirestoreConfiguration.commitKey
+        
+        return self.urlSession.post(
+            FirestoreQuery.remove(mate: nickname, from: targetNickname),
+            url: endPoint,
+            headers: FirestoreConfiguration.defaultHeaders
+        ).map({ result in
+            switch result {
+            case .success: break
+            case .failure(let error): throw error
+            }
+        })
+    }
+    
+    private func decode<T: Decodable>(data: Data, to target: T.Type) -> T? {
+        do {
+            return try JSONDecoder().decode(target, from: data)
+        } catch {
+            return nil
+        }
     }
 }
 

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -81,4 +81,10 @@ protocol FirestoreRepository {
         mate nickname: String,             // 제거할 메이트의 닉네임
         from targetNickname: String        // 친구를 제거할 대상 사용자의 닉네임
     ) -> Observable<Void>
+    
+    func saveAll(
+        runningResult: RunningResult,             // 저장할 달리기 결과
+        personalTotalRecord: PersonalTotalRecord, // 저장할 누적기록
+        userNickname: String                      // 저장할 사용자의 이름
+    ) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -44,9 +44,9 @@ protocol FirestoreRepository {
     ) -> Observable<[String: Emoji]>
     
     // MARK: - UserInformation Read/Update/Delete
-    func fetchUserData(
-        of nickname: String             // 정보를 가져올 사용자의 닉네임
-    ) -> Observable<UserData>
+    func fetchUserProfile(
+        of nickname: String
+    ) -> Observable<UserProfile>
     func save(
         userProfile: UserProfile,       // 추가할 사용자 프로필(키, 몸무게, 프사) 정보 객체
         of userNickname: String         // 추가할 사용자의 닉네임
@@ -61,13 +61,16 @@ protocol FirestoreRepository {
         of nickname: String                // 누적기록을 가져올 사용자의 닉네임
     ) -> Observable<PersonalTotalRecord>
     
-    // MARK: - User Update/Delete
+    // MARK: - User Read/Update/Delete
     func save(
         user: UserData                     // 추가할 전체 사용자 정보 객체
     ) -> Observable<Void>
     func remove(
         user nickname: String)             // 전체 사용자 정보를 삭제할 사용자의 닉네임
     -> Observable<Void>
+    func fetchUserData(
+        of nickname: String             // 정보를 가져올 사용자의 닉네임
+    ) -> Observable<UserData>
     
     // MARK: - Mate Read/Update/Delete
     func fetchMate(
@@ -81,7 +84,6 @@ protocol FirestoreRepository {
         mate nickname: String,             // 제거할 메이트의 닉네임
         from targetNickname: String        // 친구를 제거할 대상 사용자의 닉네임
     ) -> Observable<Void>
-    
     func saveAll(
         runningResult: RunningResult,             // 저장할 달리기 결과
         personalTotalRecord: PersonalTotalRecord, // 저장할 누적기록

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -19,12 +19,12 @@ protocol FirestoreRepository {
         of nickname: String,            // 조회할 사용자의 닉네임
         from startDate: Date,           // 필터링 시작 날짜
         to endDate: Date                // 필터링 끝 날짜
-    ) -> Observable<[RunningResult]?>
+    ) -> Observable<[RunningResult]>
     func fetchResult(
         of nickname: String,            // 조회할 사용자의 닉네임
         from startOffset: Int,          // 조회를 시작할 인덱스
         by limit: Int                   // 한번에 가져올 최대 개수
-    ) -> Observable<[RunningResult]?>
+    ) -> Observable<[RunningResult]>
     
     // MARK: - Emoji Update/Read/Delete
     func save(
@@ -46,7 +46,7 @@ protocol FirestoreRepository {
     // MARK: - UserInformation Read/Update/Delete
     func fetchUserData(
         of nickname: String             // 정보를 가져올 사용자의 닉네임
-    ) -> Observable<UserData?>
+    ) -> Observable<UserData>
     func save(
         userProfile: UserProfile,       // 추가할 사용자 프로필(키, 몸무게, 프사) 정보 객체
         of userNickname: String         // 추가할 사용자의 닉네임
@@ -59,7 +59,7 @@ protocol FirestoreRepository {
     ) -> Observable<Void>
     func fetchTotalPeronsalRecord(
         of nickname: String                // 누적기록을 가져올 사용자의 닉네임
-    ) -> Observable<PersonalTotalRecord?>
+    ) -> Observable<PersonalTotalRecord>
     
     // MARK: - User Update/Delete
     func save(
@@ -72,7 +72,7 @@ protocol FirestoreRepository {
     // MARK: - Mate Read/Update/Delete
     func fetchMate(
         of nickname: String                // 메이트목록을 가져올 사용자의 닉네임
-    ) -> Observable<[String]?>
+    ) -> Observable<[String]>
     func save(
         mate nickname: String,             // 메이트로 추가할 사용자의 닉네임
         to targetNickname: String          // 대상 사용자의 닉네임

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -79,7 +79,7 @@ protocol FirestoreRepository {
     func fetchFilteredMate(
         from text: String,                 // 필터링 기준 텍스트
         of nickname: String                // 메이트목록을 가져올 사용자의 닉네임
-    ) -> Observable<[String]?>
+    ) -> Observable<[String]>
     func save(
         mate nickname: String,             // 메이트로 추가할 사용자의 닉네임
         to targetNickname: String          // 대상 사용자의 닉네임
@@ -92,11 +92,11 @@ protocol FirestoreRepository {
         runningResult: RunningResult,             // 저장할 달리기 결과
         personalTotalRecord: PersonalTotalRecord, // 저장할 누적기록
         userNickname: String                      // 저장할 사용자의 이름
-    
+    ) -> Observable<Void>
     // MARK: - Notice fetch/save/update
     func fetchNotice(
         of userNickname: String
-    ) -> Observable<[Notice]?>
+    ) -> Observable<[Notice]>
     func save(
         notice: Notice,
         of userNickname: String

--- a/MateRunner/MateRunner/Domain/Model/PersonalTotalRecord.swift
+++ b/MateRunner/MateRunner/Domain/Model/PersonalTotalRecord.swift
@@ -11,4 +11,12 @@ struct PersonalTotalRecord {
     let distance: Double
     let time: Int
     let calorie: Double
+    
+    func createCumulativeRecord(distance: Double, time: Int, calorie: Double) -> Self {
+        return PersonalTotalRecord(
+            distance: self.distance + distance,
+            time: self.time + time,
+            calorie: self.calorie + calorie
+        )
+    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
@@ -14,5 +14,4 @@ protocol RunningResultUseCase: EmojiDidSelectDelegate {
     var runningResult: RunningResult { get set }
     var selectedEmoji: PublishRelay<Emoji> { get set }
     func saveRunningResult() -> Observable<Void>
-    func fetchUserNickname() -> String?
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
@@ -7,12 +7,11 @@
 
 import Foundation
 
-import RxSwift
 import RxRelay
+import RxSwift
 
 protocol RunningResultUseCase: EmojiDidSelectDelegate {
     var runningResult: RunningResult { get set }
     var selectedEmoji: PublishRelay<Emoji> { get set }
     func saveRunningResult() -> Observable<Void>
-    func updatePersonalToalRecord() -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningResultUseCase.swift
@@ -14,4 +14,5 @@ protocol RunningResultUseCase: EmojiDidSelectDelegate {
     var runningResult: RunningResult { get set }
     var selectedEmoji: PublishRelay<Emoji> { get set }
     func saveRunningResult() -> Observable<Void>
+    func updatePersonalToalRecord() -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Home/ResultUseCase/DefaultRunningResultUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/ResultUseCase/DefaultRunningResultUseCase.swift
@@ -26,10 +26,10 @@ final class DefaultRunningResultUseCase: RunningResultUseCase {
     func saveRunningResult() -> Observable<Void> {
         self.fetchCurrentTotalRecord()
             .flatMap({ currentRecord -> Observable<Void> in
-                let newRecord = PersonalTotalRecord(
-                    distance: currentRecord.distance + self.runningResult.userElapsedDistance,
-                    time: currentRecord.time + self.runningResult.userElapsedTime,
-                    calorie: currentRecord.calorie + self.runningResult.calorie
+                let newRecord = currentRecord.createCumulativeRecord(
+                    distance: self.runningResult.userElapsedDistance,
+                    time: self.runningResult.userElapsedTime,
+                    calorie: self.runningResult.calorie
                 )
                 return self.firestoreRepository.saveAll(
                     runningResult: self.runningResult,

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultMateUseCase.swift
@@ -50,7 +50,7 @@ final class DefaultMateUseCase: MateUseCase {
         Observable.zip( mate.map { nickname in
             self.firestoreRepository.fetchUserData(of: nickname)
                 .map({ user in
-                    mateList[nickname] = user?.image
+                    mateList[nickname] = user.image
                 })
         })
             .subscribe { [weak self] _ in

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -27,7 +27,6 @@ final class DefaultProfileUseCase: ProfileUseCase {
     func fetchUserInfo(_ nickname: String) {
         self.firestoreRepository.fetchUserData(of: nickname)
             .subscribe(onNext: { [weak self] mate in
-                guard let mate = mate else { return }
                 self?.userInfo.onNext(mate)
             })
             .disposed(by: self.disposeBag)
@@ -37,7 +36,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
         var recordList: [RunningResult] = []
         self.firestoreRepository.fetchResult(of: nickname, from: 0, by: 20)
             .subscribe(onNext: { [weak self] records in
-                records?.forEach { record in
+                records.forEach { record in
                     self?.firestoreRepository.fetchEmojis(of: record.runningID, from: nickname)
                         .subscribe(onNext: { emoji in
                             recordList.append(

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -103,7 +103,6 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
                     return
                 }
                 if let error = error {
-                    NSLog(error.localizedDescription)
                     emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                     return
                 }
@@ -145,7 +144,6 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
                     return
                 }
                 if let error = error {
-                    NSLog(error.localizedDescription)
                     emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                     return
                 }

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -9,8 +9,44 @@ import Foundation
 
 import RxSwift
 
-enum URLSessionNetworkServiceError: Error {
-    case error
+enum URLSessionNetworkServiceError: Int, Error, CustomStringConvertible {
+    var description: String { self.errorDescription }
+    
+    case emptyDataError
+    case responseDecodingError
+    case payloadEncodingError
+    case unknownError
+    case invalidURLError
+    case invalidRequestError = 400
+    case authenticationError = 401
+    case forbiddenError = 403
+    case notFoundError = 404
+    case notAllowedHTTPMethodError = 405
+    case timeoutError = 408
+    case internalServerError = 500
+    case notSupportedError = 501
+    case badGatewayError = 502
+    case invalidServiceError = 503
+    
+    var errorDescription: String {
+        switch self {
+        case .invalidURLError: return "INVALID_URL_ERROR"
+        case .invalidRequestError: return "400:INVALID_REQUEST_ERROR"
+        case .authenticationError: return "401:AUTHENTICATION_FAILURE_ERROR"
+        case .forbiddenError: return "403:FORBIDDEN_ERROR"
+        case .notFoundError: return "404:NOT_FOUND_ERROR"
+        case .notAllowedHTTPMethodError: return "405:NOT_ALLOWED_HTTP_METHOD_ERROR"
+        case .timeoutError: return "408:TIMEOUT_ERROR"
+        case .internalServerError: return "500:INTERNAL_SERVER_ERROR"
+        case .notSupportedError: return "501:NOT_SUPPORTED_ERROR"
+        case .badGatewayError: return "502:BAD_GATEWAY_ERROR"
+        case .invalidServiceError: return "503:INVALID_SERVICE_ERROR"
+        case .responseDecodingError: return "RESPONSE_DECODING_ERROR"
+        case .payloadEncodingError: return "REQUEST_BODY_ENCODING_ERROR"
+        case .unknownError: return "UNKNOWN_ERROR"
+        case .emptyDataError: return "RESPONSE_DATA_EMPTY_ERROR"
+        }
+    }
 }
 
 final class DefaultURLSessionNetworkService: URLSessionNetworkService {
@@ -21,106 +57,108 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
         static let delete = "DELETE"
     }
     
-    func post<T: Codable>(_ data: T, url urlString: String, headers: [String: String]?) -> Observable<Data> {
-        return self.requestWithBody(data, url: urlString, headers: headers, method: HTTPMethod.post)
+    func post<T: Codable>(
+        _ data: T,
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>> {
+        return self.request(with: data, url: urlString, headers: headers, method: HTTPMethod.post)
     }
     
-    func patch<T: Codable>(_ data: T, url urlString: String, headers: [String: String]?) -> Observable<Data> {
-        return self.requestWithBody(data, url: urlString, headers: headers, method: HTTPMethod.patch)
+    func patch<T: Codable>(
+        _ data: T,
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>> {
+        return self.request(with: data, url: urlString, headers: headers, method: HTTPMethod.patch)
     }
     
-    func delete(url urlString: String, headers: [String: String]? = nil) -> Observable<Void> {
-        return Observable<Void>.create { observer in
-            guard let url = URL(string: urlString) else {
-                observer.onError(URLSessionNetworkServiceError.error)
-                observer.onCompleted()
-                return Disposables.create()
-            }
-            
-            var request = URLRequest(url: url)
-            request.httpMethod = HTTPMethod.delete
-            
-            headers?.forEach({ header in
-                request.addValue(header.value, forHTTPHeaderField: header.key)
-            })
-            
-            let task = URLSession.shared.dataTask(with: request) { _, _, error in
-                if let error = error {
-                    observer.onError(error)
-                } else {
-                    observer.onNext(())
-                }
-                
-                observer.onCompleted()
-            }
-            task.resume()
-            
-            return Disposables.create {
-                task.cancel()
-            }
-        }
+    func delete(
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>> {
+        return self.request(url: urlString, headers: headers, method: HTTPMethod.delete)
     }
     
-    func get(url urlString: String, headers: [String: String]?) -> Observable<Data> {
-        return Observable<Data>.create { observer in
-            guard let url = URL(string: urlString) else {
-                      observer.onError(URLSessionNetworkServiceError.error)
-                      observer.onCompleted()
-                      return Disposables.create()
-                  }
-            
-            var request = URLRequest(url: url)
-            request.httpMethod = HTTPMethod.get
-            
-            headers?.forEach({ header in
-                request.addValue(header.value, forHTTPHeaderField: header.key)
-            })
-            
-            let task = URLSession.shared.dataTask(with: request) { data, _, error in
-                if let error = error {
-                    observer.onError(error)
-                }
-                if let data = data {
-                    observer.onNext(data)
-                }
-                observer.onCompleted()
-            }
-            task.resume()
-            
-            return Disposables.create {
-                task.cancel()
-            }
-        }
+    func get(
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>> {
+        return self.request(url: urlString, headers: headers, method: HTTPMethod.get)
     }
     
-    private func requestWithBody<T: Codable>(
-        _ data: T, url urlString: String,
+    private func request(
+        url urlString: String,
         headers: [String: String]? = nil,
         method: String
-    ) -> Observable<Data> {
-        return Observable<Data>.create { observer in
-            guard let url = URL(string: urlString),
-                  let httpBody = self.createPostPayload(from: data) else {
-                      observer.onError(URLSessionNetworkServiceError.error)
-                      observer.onCompleted()
-                      return Disposables.create()
-                  }
-            
-            var request = URLRequest(url: url)
-            request.httpMethod = method
-            request.httpBody = httpBody
-            headers?.forEach({ header in
-                request.addValue(header.value, forHTTPHeaderField: header.key)
-            })
-            
-            let task = URLSession.shared.dataTask(with: request) { data, _, error in
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>> {
+        guard let url = URL(string: urlString) else {
+            return Observable.error(URLSessionNetworkServiceError.invalidURLError)
+        }
+        return Observable<Result<Data, URLSessionNetworkServiceError>>.create { emitter in
+            let request = self.createHTTPRequest(of: url, with: headers, httpMethod: method)
+            let task = URLSession.shared.dataTask(with: request) { data, reponse, error in
+                guard let httpResponse = reponse as? HTTPURLResponse else {
+                    emitter.onError(URLSessionNetworkServiceError.unknownError)
+                    return
+                }
                 if let error = error {
-                    observer.onError(error)
+                    NSLog(error.localizedDescription)
+                    emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
+                    return
                 }
-                if let data = data {
-                    observer.onNext(data)
+                guard 200...299 ~= httpResponse.statusCode else {
+                    emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
+                    return
                 }
-                observer.onCompleted()
+                guard let data = data else {
+                    emitter.onNext(.failure(.emptyDataError))
+                    return
+                }
+                emitter.onNext(.success(data))
+                emitter.onCompleted()
+            }
+            task.resume()
+            
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+    
+    private func request<T: Codable>(
+        with bodyData: T,
+        url urlString: String,
+        headers: [String: String]? = nil,
+        method: String
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>> {
+        guard let url = URL(string: urlString),
+              let httpBody = self.createPostPayload(from: bodyData) else {
+                  return Observable.error(URLSessionNetworkServiceError.emptyDataError)
+              }
+        return Observable<Result<Data, URLSessionNetworkServiceError>>.create { emitter in
+            let request = self.createHTTPRequest(of: url, with: headers, httpMethod: method, with: httpBody)
+            
+            let task = URLSession.shared.dataTask(with: request) { data, reponse, error in
+                guard let httpResponse = reponse as? HTTPURLResponse else {
+                    emitter.onError(URLSessionNetworkServiceError.unknownError)
+                    return
+                }
+                if let error = error {
+                    NSLog(error.localizedDescription)
+                    emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
+                    return
+                }
+                guard 200...299 ~= httpResponse.statusCode else {
+                    emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
+                    return
+                }
+                guard let data = data else {
+                    emitter.onNext(.failure(.emptyDataError))
+                    return
+                }
+                emitter.onNext(.success(data))
+                emitter.onCompleted()
             }
             task.resume()
             
@@ -135,5 +173,28 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
             return data
         }
         return try? JSONEncoder().encode(requestBody)
+    }
+    
+    private func configureHTTPError(errorCode: Int) -> Error {
+        return URLSessionNetworkServiceError(rawValue: errorCode)
+        ?? URLSessionNetworkServiceError.unknownError
+    }
+    
+    private func createHTTPRequest(
+        of url: URL,
+        with headers: [String: String]?,
+        httpMethod: String,
+        with body: Data? = nil
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        headers?.forEach({ header in
+            request.addValue(header.value, forHTTPHeaderField: header.key)
+        })
+        if let body = body {
+            request.httpBody = body
+        }
+        
+        return request
     }
 }

--- a/MateRunner/MateRunner/Network/Protocol/URLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/Protocol/URLSessionNetworkService.swift
@@ -10,8 +10,22 @@ import Foundation
 import RxSwift
 
 protocol URLSessionNetworkService {
-    func post<T: Codable>(_ data: T, url urlString: String, headers: [String: String]?) -> Observable<Data>
-    func patch<T: Codable>(_ data: T, url urlString: String, headers: [String: String]?) -> Observable<Data>
-    func delete(url urlString: String, headers: [String: String]?) -> Observable<Void>
-    func get(url urlString: String, headers: [String: String]?) -> Observable<Data>
+    func post<T: Codable>(
+        _ data: T,
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>>
+    func patch<T: Codable>(
+        _ data: T,
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>>
+    func delete(
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>>
+    func get(
+        url urlString: String,
+        headers: [String: String]?
+    ) -> Observable<Result<Data, URLSessionNetworkServiceError>>
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -139,8 +139,8 @@ final class DefaultRunningCoordinator: RunningCoordinator {
     
     private func createRunningResultUseCase(with runningResult: RunningResult) -> RunningResultUseCase {
         return DefaultRunningResultUseCase(
-            runningResultRepository: DefaultRunningResultRepository(
-                fireStoreService: DefaultFireStoreNetworkService()
+            firestoreRepository: DefaultFirestoreRepository(
+                urlSessionService: DefaultURLSessionNetworkService()
             ),
             runningResult: runningResult
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/RaceRunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/RaceRunningResultViewModel.swift
@@ -82,7 +82,7 @@ final class RaceRunningResultViewModel {
         
         let dateTime = runningResult?.dateTime ?? Date()
         let coordinates = self.pointsToCoordinate2D(from: runningResult?.points ?? [])
-        let userNickname = self.runningResultUseCase.fetchUserNickname() ?? self.errorAlternativeText
+        let userNickname = runningResult?.resultOwner ?? self.errorAlternativeText
         let isUserWinner = runningResult?.isUserWinner ?? false
         let isCanceled = runningResult?.isCanceled ?? false
         let userDistance = runningResult?.userElapsedDistance.string() ?? self.errorAlternativeText

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/TeamRunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/TeamRunningResultViewModel.swift
@@ -83,7 +83,7 @@ final class TeamRunningResultViewModel {
         let mateNickName = runningResult?.runningSetting.mateNickname ?? self.errorAlternativeText
         let calorie = String(Int(runningResult?.calorie ?? 0))
         let userTime = runningResult?.userElapsedTime ?? 0
-        let userNickname = self.runningResultUseCase.fetchUserNickname() ?? self.errorAlternativeText
+        let userNickname = runningResult?.resultOwner ?? self.errorAlternativeText
         let isCanceled = runningResult?.isCanceled ?? false
         let totalDistance = runningResult?.totalDistance.kilometerString ?? self.errorAlternativeText
         let contributionRate = self.convertToPercentageString(from: runningResult?.contribution ?? 0)


### PR DESCRIPTION
### 📕 Issue Number

Close #224 
Close #221 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 누적기록 업데이트
- [x] 에러에 유연하게 대처할 수 있게 URLSession 서비스 개선 

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 누적기록 업데이트 방식
누적기록은 기존 기록을 한번 패칭해와서 현재 달리기 기록을 더해 다시 저장해주어야합니다. 그래서 유즈케이스에서는 현재 누적 기록만 레파지토리에서 가져와서 달리기결과 데이터와 합쳐 새로운 누적기록을 만들고 달리기 기록과 함께 레파지토리에 보내주는 흐름입니다.


    ```swift
    func saveRunningResult() -> Observable<Void> {
            self.fetchCurrentTotalRecord()
                .flatMap({ currentRecord -> Observable<Void> in
                    let newRecord = PersonalTotalRecord(
                        distance: currentRecord.distance + self.runningResult.userElapsedDistance,
                        time: currentRecord.time + self.runningResult.userElapsedTime,
                        calorie: currentRecord.calorie + self.runningResult.calorie
                    )
                    return self.firestoreRepository.saveAll(
                        runningResult: self.runningResult,
                        personalTotalRecord: newRecord,
                        userNickname: self.runningResult.resultOwner
                    )
                })
        }
    ```
    현재 기록의 fetching이 선행되어야 해서 flatMap으로 누적기록과 달리기 결과를 저장하는 메서드 호출을 엮어주었습니다.
    
    ```swift
        func saveAll(
            runningResult: RunningResult,
            personalTotalRecord: PersonalTotalRecord,
            userNickname: String
        ) -> Observable<Void> {
            return Observable.zip(
                self.save(runningResult: runningResult, to: userNickname),
                self.save(totalRecord: personalTotalRecord, of: userNickname),
                resultSelector: { _, _ in }
            )
        }
    ```
    레파지토리에서는 가지고 있던 누적기록 업데이트, 결과 업데이트를 각각 부르고 zip으로 합쳐주어서 양쪽 모두 잘 끝났을 때 반환되도록 합니다. 혹시 네이밍이 애매한 것 같으면 추천해주세요..

- fetchUserProfile 추가 
제가 UserProfile을 save만 만들어뒀더라구요.. fetch도 추가적으로 정의해주었습니다.

- URLSession서비스 개선 
    에러처리가 안되어 있다보니 오류를 확인하기가 너무 힘들어서 URLSession서비스에 오류상황을 구체화하고 유연하게 대응할 수 있도록 변경했습니다. 에러코드는 파이어베이스 문서 스펙 https://firebase.google.com/docs/reference/rest/database#section-api-usage 을 참고하고 추가적으로 잘 알려진 코드들을 에러로 정의했습니다.

    ```swift
    var errorDescription: String {
            switch self {
            case .invalidURLError: return "INVALID_URL_ERROR"
            case .invalidRequestError: return "400:INVALID_REQUEST_ERROR"
            case .authenticationError: return "401:AUTHENTICATION_FAILURE_ERROR"
            case .forbiddenError: return "403:FORBIDDEN_ERROR"
            case .notFoundError: return "404:NOT_FOUND_ERROR"
            case .notAllowedHTTPMethodError: return "405:NOT_ALLOWED_HTTP_METHOD_ERROR"
            case .timeoutError: return "408:TIMEOUT_ERROR"
            case .internalServerError: return "500:INTERNAL_SERVER_ERROR"
            case .notSupportedError: return "501:NOT_SUPPORTED_ERROR"
            case .badGatewayError: return "502:BAD_GATEWAY_ERROR"
            case .invalidServiceError: return "503:INVALID_SERVICE_ERROR"
            case .responseDecodingError: return "RESPONSE_DECODING_ERROR"
            case .payloadEncodingError: return "REQUEST_BODY_ENCODING_ERROR"
            case .unknownError: return "UNKNOWN_ERROR"
            case .emptyDataError: return "RESPONSE_DATA_EMPTY_ERROR"
            }
        }
    ```
        
    이제 네트워크 통신 중 발생하는 에러가 먼저 throw 되고, 레파지토리에서 디코딩이나 인코딩 시에 에러가 발생하면 그때는 새로운 에러로 스트림에 throw됩니다. 
        
    URLSessionService 에서 무조건 Result 객체를 반환하고 레자피토리에서 이에 대한 처리를 해주도록 수정했습니다. 멘토링 때 나눴던 이야기들을 떠올리면서 진행했어요. 서버에서 에러가 날라오면 항상 스트림에 에러가 들어가고, 에러가 없을 때는 먼저 응답코드를 보고 200번대인지 판단하고, 마지막으로 응답데이터가 nil인지 까지 확인한 뒤에 결과를 반환합니다. 

     ```swift
        return Observable<Result<Data, URLSessionNetworkServiceError>>.create { emitter in
                    let request = self.createHTTPRequest(of: url, with: headers, httpMethod: method)
                    let task = URLSession.shared.dataTask(with: request) { data, reponse, error in
                        guard let httpResponse = reponse as? HTTPURLResponse else {
                            emitter.onError(URLSessionNetworkServiceError.unknownError)
                            return
                        }
                        if let error = error {
                            emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                            return
                        }
                        guard 200...299 ~= httpResponse.statusCode else {
                            emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                            return
                        }
                        guard let data = data else {
                            emitter.onNext(.failure(.emptyDataError))
                            return
                        }
                        emitter.onNext(.success(data))
                        emitter.onCompleted()
                    }
                    task.resume()
     ```

    URLSessionService에서 통신에 대한 에러처리가 되고, 레파지토리는 디코딩, 인코딩에 대한 에러처리를 했기 때문에 더 이상 nil값을 반환받는 경우가 없어져 레파지토리의 데이터 반환 타입에서 옵셔널을 모두 제거할 수 있었습니다.
    
    URLSessionService가 변경되어서 다른 코드에 영향이 있을 것 같은데 제가 마지막으로 머지한 뒤에 전체적으로 타입만 맞춰서 수정하고 다시 푸쉬하도록 하겠습니다.
<br/><br/>
