### PR TITLE
프로필 사진 저장, 불러오기 Rest 레파지토리 구현

### DIFF
--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -93,6 +93,7 @@ protocol FirestoreRepository {
         personalTotalRecord: PersonalTotalRecord, // 저장할 누적기록
         userNickname: String                      // 저장할 사용자의 이름
     ) -> Observable<Void>
+    
     // MARK: - Notice fetch/save/update
     func fetchNotice(
         of userNickname: String
@@ -104,5 +105,14 @@ protocol FirestoreRepository {
     func updateState(
         notice: Notice,
         of userNickname: String
+    ) -> Observable<Void>
+    
+    // MARK: - ProfileImage Read/Update
+    func fetchProfileImage(
+        of userNickname: String             // 프사를 가져올 사용자의 닉네임
+    ) -> Observable<Data>
+    func save(
+        profileImageData: Data,             // 저장할 프사(png)
+        of userNickname: String             // 프사를 저장할 사용자의 닉네임
     ) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -108,11 +108,13 @@ protocol FirestoreRepository {
     ) -> Observable<Void>
     
     // MARK: - ProfileImage Read/Update
-    func fetchProfileImage(
-        of userNickname: String             // 프사를 가져올 사용자의 닉네임
-    ) -> Observable<Data>
     func save(
         profileImageData: Data,             // 저장할 프사(png)
         of userNickname: String             // 프사를 저장할 사용자의 닉네임
+    ) -> Observable<String>
+    func saveAll(                           // 프로필 사진을 업데이트 할 때만 사용
+        userProfile: UserProfile,           // 업데이트할 프로필
+        with newImageData: Data,            // 업데이트할 이미지
+        of userNickname: String             // 상용자 닉네임
     ) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -102,10 +102,12 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
                     emitter.onError(URLSessionNetworkServiceError.unknownError)
                     return
                 }
+                
                 if let error = error {
                     emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                     return
                 }
+                
                 guard 200...299 ~= httpResponse.statusCode else {
                     emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                     return


### PR DESCRIPTION
### 📕 Issue Number

Close #235 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 프로필 사진 저장
- [x] 프로필 사진 불러오기
자세한건 밑에!

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- User에 image 필드가 필요없을지도..?
sdk로 파이어스토어에 업로드를 하면 다운로드 주소가 반환이 되는데, rest로 올리니까 그게 없더라구요.. 그래서 반환된 JSON을 확인해보니까

```swift
{
    "name": "hunihun956/profile.png",
    "bucket": "mate-runner-e232c.appspot.com",
    "generation": "1637869342662748",
    "metageneration": "1",
    "contentType": "image/png",
    "timeCreated": "2021-11-25T19:42:22.672Z",
    "updated": "2021-11-25T19:42:22.672Z",
    "storageClass": "STANDARD",
    "size": "574866",
    "md5Hash": "lbvMRD5igW7wG6PayXX6qg==",
    "contentEncoding": "identity",
    "contentDisposition": "inline; filename*=utf-8''profile.png",
    "crc32c": "8wUM/w==",
    "etag": "CNzA7uKitPQCEAE=",
    "downloadTokens": "56a59a76-74f9-4638-87d5-9791edbff78d"
}
```
이런 내용이었고, 마지막 downloadTokens가 눈에 들어와서 콘솔에서 찾아봤습니다.

<img width="278" alt="스크린샷 2021-11-26 오전 4 45 03" src="https://user-images.githubusercontent.com/46087477/143494203-80bb7bcb-71f8-4796-96d1-6ea43b5e0072.png">

그랬더니 여기에도 액세스 토큰이라는게 있더라구요. 그리고 액세스 토큰을 클릭했더니

```
https://firebasestorage.googleapis.com/v0/b/mate-runner-e232c.appspot.com/o/hunihun956%2Fprofile.png?alt=media&token=56a59a76-74f9-4638-87d5-9791edbff78d
```

이렇게 다운로드 가능한 주소가 튀어나왔습니다. 그래서 다른 주소들은 모두 경로이고 token만 따로 넣어주면 이미지를 받아올 수 있겠다! 라고 생각해서 작업을 시작했습니다.

경로는 루트에서 상용자닉네임으로 디렉토리 하나 들어가고 그 안에 profile.png를 두도록 했습니다.

문제는 토큰을 얻기 위해서 토큰이 없는 이미지의 기본 주소(https://firebasestorage.googleapis.com/v0/b/mate-runner-e232c.appspot.com/o/hunihun956%2Fprofile.png)에 먼저 요청을 보내 json을 받아야하고 json에서 토큰만 빼내서 다시 다운로드 요청을 보내야된다는 것이었습니다.

```swift
private func fetchProfileImageDownLoadToken(of userNickname: String) -> Observable<String> {
        let endPoint = FirebaseStorageConfiguration.baseURL
        + FirebaseStorageConfiguration.projectNamePath
        + "/\(userNickname)%2F"
        + FirebaseStorageConfiguration.profileImageName
        
        return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
            .map({ result -> String in
                switch result {
                case .success(let data):
                    guard let json = self.decode(data: data, to: [String: String].self),
                          let token = json[FirebaseStorageConfiguration.downloadTokens] else {
                              throw FirestoreRepositoryError.decodingError
                          }
                    return token
                case .failure(let error):
                    throw error
                }
            })
    }
```
따라서 이렇게 먼저 json을 딕셔너리로 디코딩해서(다행스럽게도 여기는 상세타입에 대한 key-value 맵핑이없어요ㅎㅎ 우리가 아는 그 제이슨~) 토큰만 이미 알아둔 키값으로 빼와서 반환하고,

```swift
private func fetchImage(of userNickname: String, with downloadToken: String) -> Observable<Data> {
        let endPoint = FirebaseStorageConfiguration.baseURL
        + FirebaseStorageConfiguration.projectNamePath
        + "/\(userNickname)%2F"
        + FirebaseStorageConfiguration.profileImageName
        + "?"+[FirebaseStorageConfiguration.altMediaParameter,
               FirebaseStorageConfiguration.tokenParameter + downloadToken
        ].joined(separator: "&")
        
        return self.urlSession.get(url: endPoint, headers: nil)
            .map({ result -> Data in
                switch result {
                case .success(let data):
                    return data
                case .failure(let error):
                    throw error
                }
            })
    }
```
그 다음에 토큰값을 뒤에 붙여서 이미지 다운로드 요청을 보냈습니다. 여기서 계속 403이 와서 한참헤매고 있었는데 제가 이미지 받을거면서 HTTP 헤더에 컨텐트 타입을 json으로 해두고 있었어요..

그리고 마지막으로 위의 두 작업을 순차적으로 진행할 수 있도록 래핑하는 함수를 외부에 열어두었습니다.

```swift
    func fetchProfileImage(of userNickname: String) -> Observable<Data> {
        return self.fetchProfileImageDownLoadToken(of: userNickname)
            .flatMap({ downloadToken -> Observable<Data> in
                return self.fetchImage(of: userNickname, with: downloadToken)
            })
    }
```

- 그럼 토큰을 유저정보에 저장하고 거기로 다운로드 요청만 보내면 되지 않나?
저도 처음엔 그렇게 생각이 들었는데, 파이어베이스 토큰이 영구적인지 계속 갱신되는건지 확실하지가 않아서(토큰 관련 문서가 있긴한데 제대로 안읽어봤어요ㅠ) 안전하게 두번의 요청을 보내는 방식을 선택했구요, 이미지가 바뀔때마다 토큰값을 유저에 다시 갱신해주어야하는데 지금 처럼 투 페이스로 요청하면 아예 User에 이미지 관련 필드가 없어도 될 것 같습니다.

- 이미지가 저장이 안되어 있을 때는?
404 NOT FOUND가 옵니다! 오후에 빡세게 오류 구체화를 해놔서 쉽게 알 수 있었어요! 그래서 지금 방식을 유지한다면, 요청을 보내보고 error가 스트림에 오면 catchAndReturn 같은걸 뷰모델이나 뷰컨에서 해서 기본 이미지를 넣어주면 될 것 같아요.

- 캐싱
캐싱이나 패치 해온 이미지를 어떻게 처리할지는 일단은 제 영역은 아닌 것 같아서 고려하지 않고 레파지토리에 이미지를 불러오고 저장하는 메서드만 만들어뒀습니다!

- 덮어쓰기
테스트 결과 마지막으로 올린 데이터로 덮어씌워집니다!

- 마지막 한 마디
내일 일어날 수 있겠죠..? 하하
<br/><br/>
