### PR TITLE
결과 표시 버그 수정 & 다크 모드 대응 & 알림 설정 버튼 삭제 & 콜렉션뷰 배경색 표시 문제 해결

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/Home/RunningUseCase/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/RunningUseCase/DefaultRunningUseCase.swift
@@ -245,7 +245,7 @@ final class DefaultRunningUseCase: RunningUseCase {
         targetDistance: Double,
         with distance: Double
     ) -> Bool {
-        return distance >= targetDistance.meter
+        return distance >= targetDistance
     }
     
     private func updateProgress(_ progress: BehaviorSubject<Double>, value: Double) {
@@ -261,7 +261,7 @@ final class DefaultRunningUseCase: RunningUseCase {
     
     private func updateMyDistance(with newDistance: Double) {
         guard let currentData = try? self.runningData.value() else { return }
-        self.runningData.onNext(currentData.makeCopy(myElapsedDistance: newDistance))
+        self.runningData.onNext(currentData.makeCopy(myElapsedDistance: newDistance.kilometer))
     }
     
     private func saveMyRunningRealTimeData() {

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
@@ -16,7 +16,7 @@ final class EmojiViewController: UIViewController {
     
     private lazy var emojiView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         view.layer.masksToBounds = true
         view.layer.cornerRadius = 15
         return view

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
@@ -28,6 +28,7 @@ final class EmojiViewController: UIViewController {
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "default")
+        collectionView.backgroundColor = .systemBackground
         return collectionView
     }()
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/ResultViewController/RunningResultViewController.swift
@@ -23,7 +23,7 @@ class RunningResultViewController: UIViewController {
         let button = UIButton()
         let xImage = UIImage(systemName: "xmark")
         button.setImage(xImage, for: .normal)
-        button.tintColor = .black
+        button.tintColor = .label
         button.contentHorizontalAlignment = .fill
         button.contentVerticalAlignment = .fill
         return button

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RunningViewController.swift
@@ -70,6 +70,7 @@ class RunningViewController: UIViewController {
         label.textAlignment = .center
         label.isHidden = true
         label.font = .notoSans(size: 13, family: .light)
+        label.textColor = .black
         label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
         return label
     }()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SettingViewController/MateRunningModeSettingViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SettingViewController/MateRunningModeSettingViewController.swift
@@ -116,6 +116,7 @@ private extension MateRunningModeSettingViewController {
         emojiLabel.font = UIFont.notoSans(size: 40, family: .regular)
         titleLabel.text = title
         titleLabel.font = UIFont.notoSans(size: 20, family: .bold)
+        titleLabel.textColor = .black
         
         stackView.addArrangedSubview(emojiLabel)
         stackView.addArrangedSubview(titleLabel)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -41,8 +41,6 @@ final class MyPageViewController: UIViewController {
         return label
     }()
     
-    private lazy var notificationSettingView: UIView = UIView()
-    
     private lazy var settingStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -54,7 +52,7 @@ final class MyPageViewController: UIViewController {
     private lazy var profileEditButton: UIButton = {
         let button = UIButton()
         button.setTitle("프로필 편집", for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.label, for: .normal)
         button.titleLabel?.font = .notoSans(size: 13, family: .light)
         button.layer.borderColor = UIColor.systemGray5.cgColor
         button.layer.borderWidth = 1
@@ -63,22 +61,6 @@ final class MyPageViewController: UIViewController {
             make.height.equalTo(40)
         }
         return button
-    }()
-    
-    private lazy var notificationSettingLabel: UILabel = {
-        let label = UILabel()
-        label.text = "알림설정"
-        label.font = .notoSans(size: 15, family: .regular)
-        return label
-    }()
-    
-    private lazy var notificationSwitch: UISwitch = {
-        let switchButton = UISwitch()
-        switchButton.tintColor = .mrPurple
-        switchButton.onTintColor = .mrYellow
-        switchButton.thumbTintColor = .mrPurple
-        switchButton.isOn = true
-        return switchButton
     }()
     
     private lazy var licenseView: UIView = {
@@ -125,23 +107,12 @@ private extension MyPageViewController {
             viewDidLoadEvent: Observable<Void>.just(()),
             notificationButtonDidTapEvent: notificationButton.rx.tap.asObservable(),
             profileEditButtonDidTapEvent: profileEditButton.rx.tap.asObservable(),
-            notificationSwitchValueDidChangeEvent: notificationSwitch.rx.isOn
-                .changed
-                .distinctUntilChanged()
-                .asObservable(),
             licenseButtonDidTapEvent: licenseButton.rx.tap.asObservable(),
             logoutButtonDidTapEvent: logoutButton.rx.tap.asObservable(),
             withdrawalButtonDidTapEvent: withdrawalButton.rx.tap.asObservable()
         )
         
         let output = viewModel.transform(from: input, disposeBag: self.disposeBag)
-        
-        output.isNotificationOn
-            .asDriver(onErrorJustReturn: false)
-            .drive { [weak self] isNotificationOn in
-                self?.notificationSwitch.setOn(isNotificationOn, animated: false)
-            }
-            .disposed(by: self.disposeBag)
         
         output.imageURL
             .asDriver()
@@ -200,22 +171,6 @@ private extension MyPageViewController {
             make.left.right.equalToSuperview()
         }
         
-        self.notificationSettingView.snp.makeConstraints { make in
-            make.left.right.equalToSuperview()
-            make.height.equalTo(60)
-        }
-        
-        self.notificationSettingLabel.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview()
-            make.left.equalToSuperview().offset(20)
-        }
-        
-        self.notificationSwitch.snp.makeConstraints { [weak self] make in
-            guard let self = self else { return }
-            make.right.equalToSuperview().offset(-20)
-            make.centerY.equalTo(self.notificationSettingLabel)
-        }
-        
         self.licenseView.snp.makeConstraints { make in
             make.left.right.equalToSuperview()
             make.height.equalTo(60)
@@ -254,10 +209,6 @@ private extension MyPageViewController {
         self.profileView.addSubview(self.profileEditButton)
         
         self.settingStackView.addArrangedSubview(self.createSeparator())
-        self.settingStackView.addArrangedSubview(self.notificationSettingView)
-        self.notificationSettingView.addSubview(self.notificationSettingLabel)
-        self.notificationSettingView.addSubview(self.notificationSwitch)
-        self.settingStackView.addArrangedSubview(self.createSeparator())
         self.settingStackView.addArrangedSubview(self.licenseView)
         self.licenseView.addSubview(self.licenseLabel)
         self.licenseView.addSubview(self.licenseButton)
@@ -280,7 +231,7 @@ private extension MyPageViewController {
     func createSettingButton(title: String) -> UIButton {
         let button = UIButton()
         button.setTitle(title, for: .normal)
-        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.label, for: .normal)
         button.contentHorizontalAlignment = .left
         button.titleLabel?.font = .notoSans(size: 15, family: .regular)
         button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -26,14 +26,12 @@ final class MyPageViewModel {
         let viewDidLoadEvent: Observable<Void>
         let notificationButtonDidTapEvent: Observable<Void>
         let profileEditButtonDidTapEvent: Observable<Void>
-        let notificationSwitchValueDidChangeEvent: Observable<Bool>
         let licenseButtonDidTapEvent: Observable<Void>
         let logoutButtonDidTapEvent: Observable<Void>
         let withdrawalButtonDidTapEvent: Observable<Void>
     }
     
     struct Output {
-        var isNotificationOn = PublishRelay<Bool>()
         var nickname = BehaviorRelay<String>(value: "")
         var imageURL = BehaviorRelay<String>(value: "")
     }
@@ -58,12 +56,6 @@ final class MyPageViewModel {
             .drive(onNext: { [weak self] in
                 guard let nickname = self?.myPageUseCase.nickname else { return }
                 self?.myPageCoordinator?.showProfileEditFlow(with: nickname)
-            })
-            .disposed(by: disposeBag)
-        
-        input.notificationSwitchValueDidChangeEvent
-            .bind(onNext: { _ in
-                
             })
             .disposed(by: disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
@@ -20,6 +20,7 @@ final class RecordViewController: UIViewController {
     
     private lazy var collectionView: CalendarView = {
         let collectionView = CalendarView()
+        collectionView.backgroundColor = .systemBackground
         return collectionView
     }()
     

--- a/MateRunner/MateRunner/Util/Extension/Double+Formatter.swift
+++ b/MateRunner/MateRunner/Util/Extension/Double+Formatter.swift
@@ -13,7 +13,7 @@ extension Double {
     }
     
     var kilometerString: String {
-        return "\(floor(self.kilometer * 100) / 100)"
+        return "\(floor(self * 100) / 100)"
     }
     
     var kilometer: Double {


### PR DESCRIPTION
### 📕 Issue Number

Close #233
Close #234 
Close #239 
Close #242 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 결과 표시 버그 수정
- [x] 다크 모드 대응
- [x] 알림 설정 버튼 삭제
- [x] 콜렉션뷰 배경색 표시 문제 해결


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 기여도나 달린 거리가 예상한 것과 다르게 표시되는 버그는 단위가 맞춰지지 않아 발생하는 문제였습니다. 미터와 킬로미터가 혼재해 있었는데, db에 올라가는 거리의 단위와 표시되는 거리의 단위를 모두 킬로미터로 통일했습니다. 기존에 올라간 데이터는 단위가 너무 크게 표시되겠지만 이 PR이 머지된 이후의 데이터부터는 버그 없이 잘 동작할거예요! 혹시 이렇게 변경하여 문제가 생긴다면 알려주세요!


- 특이 사항 2

<br/><br/>
