### PR TITLE
이모지 Rest API 전송, FCM 전송

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		AE263BE6274E1755004A61E5 /* DefaultImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BE5274E1755004A61E5 /* DefaultImageCacheService.swift */; };
 		AE263BE9274E1E18004A61E5 /* ImageCacheError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BE8274E1E18004A61E5 /* ImageCacheError.swift */; };
 		AE263BEB274E5D99004A61E5 /* UIImageView+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BEA274E5D99004A61E5 /* UIImageView+ImageCache.swift */; };
+		AE263BED2751438E004A61E5 /* ComplimentEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BEC2751438E004A61E5 /* ComplimentEmoji.swift */; };
 		AE3D14852737C5E600D4A186 /* Mets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D14842737C5E600D4A186 /* Mets.swift */; };
 		AE3D148B273A5D8D00D4A186 /* MateHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */; };
 		AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148C273A5DB400D4A186 /* MateViewModel.swift */; };
@@ -446,6 +447,7 @@
 		AE263BE5274E1755004A61E5 /* DefaultImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageCacheService.swift; sourceTree = "<group>"; };
 		AE263BE8274E1E18004A61E5 /* ImageCacheError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheError.swift; sourceTree = "<group>"; };
 		AE263BEA274E5D99004A61E5 /* UIImageView+ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+ImageCache.swift"; sourceTree = "<group>"; };
+		AE263BEC2751438E004A61E5 /* ComplimentEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplimentEmoji.swift; sourceTree = "<group>"; };
 		AE3D14842737C5E600D4A186 /* Mets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mets.swift; sourceTree = "<group>"; };
 		AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateHeaderView.swift; sourceTree = "<group>"; };
 		AE3D148C273A5DB400D4A186 /* MateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MateViewModel.swift; path = MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -857,6 +859,7 @@
 				B0C85183274E68E00070BB66 /* UserData.swift */,
 				B0C85185274E68FF0070BB66 /* PersonalTotalRecord.swift */,
 				AE263BE3274DDD7F004A61E5 /* Notice.swift */,
+				AE263BEC2751438E004A61E5 /* ComplimentEmoji.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2250,6 +2253,7 @@
 				AE640ECF2736259C00711175 /* CoreMotionService.swift in Sources */,
 				B0F53289273A32E0005A3F11 /* CoordinatorType.swift in Sources */,
 				B0628B94273A1752004FAB0F /* Coordinator.swift in Sources */,
+				AE263BED2751438E004A61E5 /* ComplimentEmoji.swift in Sources */,
 				5E5FDD1E273FCC24000F4666 /* SignUpViewController.swift in Sources */,
 				3D62254F2745EE3000E4A327 /* RunningViewController.swift in Sources */,
 				AE77C1FB2743DD59005EDEE0 /* DefaultMateRepository.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -122,8 +122,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
             [FirestoreField.fields: dto],
             url: endPoint,
             headers: FirestoreConfiguration.defaultHeaders
-        ).debug()
-            .map({ result in
+        ).map({ result in
             switch result {
             case .success: break
             case .failure(let error):

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -118,15 +118,16 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         + "/\(userNickname)"
         
         let dto = EmojiFirestoreDTO(emoji: emoji.text(), userNickname: userNickname)
-        
         return self.urlSession.patch(
             [FirestoreField.fields: dto],
             url: endPoint,
             headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
+        ).debug()
+            .map({ result in
             switch result {
             case .success: break
-            case .failure(let error): throw error
+            case .failure(let error):
+                throw error
             }
         })
     }
@@ -168,11 +169,11 @@ final class DefaultFirestoreRepository: FirestoreRepository {
                 switch result {
                 case .success(let data):
                     guard let documents = self.decode(data: data, to: DocumentsValue.self) else {
-                        throw FirestoreRepositoryError.decodingError
+                        return [:]
                     }
                     return self.parseEmojiFromDocuments(documents)
                 case .failure(let error):
-                    throw error
+                    return [:]
                 }
             })
     }

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -92,7 +92,7 @@ final class DefaultInviteMateRepository: InviteMateRepository {
     
     func sendInvitation(_ invitation: Invitation, fcmToken: String) -> Observable<Void> {
         let dto = MessagingRequestDTO(
-            title: "함께 달리기 초대",
+            title: "💌 함께 달리기 초대",
             body: "메이트 \(invitation.host)님의 초대장이 도착했습니다!",
             data: invitation,
             to: fcmToken

--- a/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/DefaultMateRepository.swift
@@ -24,9 +24,28 @@ final class DefaultMateRepository: MateRepository {
     
     func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> {
         let dto = MessagingRequestDTO(
-            title: "메이트 요청",
+            title: "🤝 메이트 요청",
             body: "메이트 요청이 도착했습니다!",
             data: MateRequest(sender: sender),
+            to: fcmToken
+        )
+        
+        return self.urlSessionNetworkService.post(
+            dto,
+            url: "https://fcm.googleapis.com/fcm/send",
+            headers: [
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": Configuration.fcmServerKey
+            ]
+        ).map({ _ in })
+    }
+    
+    func sendEmoji(from sender: String, fcmToken: String) -> Observable<Void> {
+        let dto = MessagingRequestDTO(
+            title: "💝 이모지 도착",
+            body: "\(sender)님이 칭찬 이모지를 보냈어요!",
+            data: ComplimentEmoji(sender: sender),
             to: fcmToken
         )
         

--- a/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Mate/Protocol/MateRepository.swift
@@ -12,5 +12,5 @@ import RxSwift
 protocol MateRepository {
     func sendRequestMate(from sender: String, fcmToken: String) -> Observable<Void> 
     func fetchFCMToken(of mate: String)-> Observable<String>
-//    func saveRequestMate(_ notice: Notice?) -> Observable<Void> //TODO: saveRequestMate RestAPI로 변경
+    func sendEmoji(from sender: String, fcmToken: String) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Domain/Model/ComplimentEmoji.swift
+++ b/MateRunner/MateRunner/Domain/Model/ComplimentEmoji.swift
@@ -1,0 +1,23 @@
+//
+//  ComplimentEmoji.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/27.
+//
+
+import Foundation
+
+struct ComplimentEmoji: Codable {
+    let sender: String
+
+    init(sender: String) {
+        self.sender = sender
+    }
+    
+    init?(from dictionary: [AnyHashable: Any]) {
+        guard let sender = dictionary["sender"] as? String else {
+                  return nil
+              }
+        self.init(sender: sender)
+    }
+}

--- a/MateRunner/MateRunner/Domain/Model/RunningResult.swift
+++ b/MateRunner/MateRunner/Domain/Model/RunningResult.swift
@@ -64,6 +64,10 @@ class RunningResult {
         self.calorie = newCalorie
     }
     
+    func updateEmoji(to newEmojis: [String: Emoji]) {
+        self.emojis = newEmojis
+    }
+    
     func addPoint(_ point: Point) {
         self.points.append(point)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Common/DefaultEmojiUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/DefaultEmojiUseCase.swift
@@ -14,10 +14,10 @@ final class DefaultEmojiUseCase: EmojiUseCase {
     var selectedEmoji: PublishSubject<Emoji> = PublishSubject()
     weak var delegate: EmojiDidSelectDelegate?
     private let disposeBag = DisposeBag()
-
-    init(firestoreRepository: FirestoreRepository) {
-        self.firestoreRepository = firestoreRepository
-    }
+    
+//    init(firestoreRepository: FirestoreRepository) {
+//        self.firestoreRepository = firestoreRepository
+//    }
     
     init(
         firestoreRepository: FirestoreRepository,
@@ -26,15 +26,13 @@ final class DefaultEmojiUseCase: EmojiUseCase {
         self.firestoreRepository = firestoreRepository
         self.delegate = delegate
     }
-
+    
     func sendEmoji(
         _ emoji: Emoji,
         to mateNickname: String,
         of runningID: String,
         from userNickname: String
     ) {
-        self.delegate?.emojiDidSelect(selectedEmoji: emoji)
-        self.selectedEmoji.onNext(emoji)
         self.firestoreRepository.save(
             emoji: emoji,
             to: mateNickname,
@@ -43,6 +41,11 @@ final class DefaultEmojiUseCase: EmojiUseCase {
         ).subscribe(onNext: { [weak self] _ in
             self?.selectedEmoji.onNext(emoji)
         })
-        .disposed(by: self.disposeBag)
+            .disposed(by: self.disposeBag)
+    }
+    
+    func selectEmoji(_ emoji: Emoji) {
+        self.delegate?.emojiDidSelect(selectedEmoji: emoji)
+        self.selectedEmoji.onNext(emoji)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Common/DefaultEmojiUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/DefaultEmojiUseCase.swift
@@ -14,11 +14,7 @@ final class DefaultEmojiUseCase: EmojiUseCase {
     var selectedEmoji: PublishSubject<Emoji> = PublishSubject()
     weak var delegate: EmojiDidSelectDelegate?
     private let disposeBag = DisposeBag()
-    
-//    init(firestoreRepository: FirestoreRepository) {
-//        self.firestoreRepository = firestoreRepository
-//    }
-    
+ 
     init(
         firestoreRepository: FirestoreRepository,
         delegate: EmojiDidSelectDelegate

--- a/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/EmojiUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/EmojiUseCase.swift
@@ -17,4 +17,5 @@ protocol EmojiUseCase {
         of runningID: String,
         from userNickname: String
     )
+    func selectEmoji(_ emoji: Emoji)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/EmojiUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/EmojiUseCase.swift
@@ -11,5 +11,10 @@ import RxSwift
 
 protocol EmojiUseCase {
     var selectedEmoji: PublishSubject<Emoji> { get set }
-    func sendEmoji(_ emoji: Emoji)
+    func sendEmoji(
+        _ emoji: Emoji,
+        to mateNickname: String,
+        of runningID: String,
+        from userNickname: String
+    )
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/EmojiUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Common/Protocol/EmojiUseCase.swift
@@ -18,4 +18,5 @@ protocol EmojiUseCase {
         from userNickname: String
     )
     func selectEmoji(_ emoji: Emoji)
+    func sendComplimentEmoji(to mate: String)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -51,7 +51,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
                                     isCanceled: record.isCanceled
                                 )
                             )
-                            self?.recordInfo.onNext(recordList) //TODO: 리팩토링 필요한 부분
+                            self?.recordInfo.onNext(recordList) // TODO: 리팩토링 필요한 부분
                         })
                         .disposed(by: self?.disposeBag ?? DisposeBag())
                 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -51,7 +51,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
                                     isCanceled: record.isCanceled
                                 )
                             )
-                            self?.recordInfo.onNext(recordList)
+                            self?.recordInfo.onNext(recordList) //TODO: 리팩토링 필요한 부분
                         })
                         .disposed(by: self?.disposeBag ?? DisposeBag())
                 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -15,6 +15,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
     private let disposeBag = DisposeBag()
     var userInfo: PublishSubject<UserData> = PublishSubject()
     var recordInfo: PublishSubject<[RunningResult]> = PublishSubject()
+    var selectEmoji: PublishSubject<Bool> = PublishSubject()
     
     init(
         userRepository: UserRepository,
@@ -63,4 +64,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
         self.userRepository.fetchUserNickname()
     }
     
+    func emojiDidSelect(selectedEmoji: Emoji) {
+        self.selectEmoji.onNext(true)
+    }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -34,30 +34,22 @@ final class DefaultProfileUseCase: ProfileUseCase {
     }
     
     func fetchRecordList(nickname: String) {
-        var recordList: [RunningResult] = []
         self.firestoreRepository.fetchResult(of: nickname, from: 0, by: 20)
             .subscribe(onNext: { [weak self] records in
-                records.forEach { record in
+                Observable.zip( records.map { record in
                     self?.firestoreRepository.fetchEmojis(of: record.runningID, from: nickname)
-                        .subscribe(onNext: { emoji in
-                            recordList.append(
-                                RunningResult(
-                                    userNickname: nickname,
-                                    runningSetting: record.runningSetting,
-                                    userElapsedDistance: record.userElapsedDistance,
-                                    userElapsedTime: record.userElapsedTime,
-                                    calorie: record.calorie,
-                                    points: record.points,
-                                    emojis: emoji,
-                                    isCanceled: record.isCanceled
-                                )
-                            )
-                            self?.recordInfo.onNext(recordList) // TODO: 리팩토링 필요한 부분
-                        })
-                        .disposed(by: self?.disposeBag ?? DisposeBag())
-                }
+                        .map({ emoji in
+                            let result = record
+                            result.updateEmoji(to: emoji)
+                            return result
+                        }) ??  Observable.of(record)
+                })
+                    .subscribe { [weak self] list in
+                        self?.recordInfo.onNext(list)
+                    }
+                    .disposed(by: self?.disposeBag ?? DisposeBag())
             })
-            .disposed(by: disposeBag)
+            .disposed(by: self.disposeBag)
     }
     
     func fetchUserNickname() -> String? {

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -15,7 +15,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
     private let disposeBag = DisposeBag()
     var userInfo: PublishSubject<UserData> = PublishSubject()
     var recordInfo: PublishSubject<[RunningResult]> = PublishSubject()
-    var selectEmoji: PublishSubject<Bool> = PublishSubject()
+    var selectEmoji: PublishSubject<Emoji> = PublishSubject()
     
     init(
         userRepository: UserRepository,
@@ -65,6 +65,6 @@ final class DefaultProfileUseCase: ProfileUseCase {
     }
     
     func emojiDidSelect(selectedEmoji: Emoji) {
-        self.selectEmoji.onNext(true)
+        self.selectEmoji.onNext(selectedEmoji)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
@@ -9,10 +9,12 @@ import Foundation
 
 import RxSwift
 
-protocol ProfileUseCase {
+protocol ProfileUseCase: EmojiDidSelectDelegate {
     var userInfo: PublishSubject<UserData> { get set }
     var recordInfo: PublishSubject<[RunningResult]> { get set }
+    var selectEmoji: PublishSubject<Bool> { get set }
     func fetchUserInfo(_ nickname: String)
     func fetchRecordList(nickname: String)
     func fetchUserNickname() -> String?
+    func emojiDidSelect(selectedEmoji: Emoji)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
@@ -12,7 +12,7 @@ import RxSwift
 protocol ProfileUseCase: EmojiDidSelectDelegate {
     var userInfo: PublishSubject<UserData> { get set }
     var recordInfo: PublishSubject<[RunningResult]> { get set }
-    var selectEmoji: PublishSubject<Bool> { get set }
+    var selectEmoji: PublishSubject<Emoji> { get set }
     func fetchUserInfo(_ nickname: String)
     func fetchRecordList(nickname: String)
     func fetchUserNickname() -> String?

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -95,6 +95,7 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
         guard let url = URL(string: urlString) else {
             return Observable.error(URLSessionNetworkServiceError.invalidURLError)
         }
+
         return Observable<Result<Data, URLSessionNetworkServiceError>>.create { emitter in
             let request = self.createHTTPRequest(of: url, with: headers, httpMethod: method)
             let task = URLSession.shared.dataTask(with: request) { data, reponse, error in
@@ -137,7 +138,6 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
               }
         return Observable<Result<Data, URLSessionNetworkServiceError>>.create { emitter in
             let request = self.createHTTPRequest(of: url, with: headers, httpMethod: method, with: httpBody)
-            
             let task = URLSession.shared.dataTask(with: request) { data, reponse, error in
                 guard let httpResponse = reponse as? HTTPURLResponse else {
                     emitter.onError(URLSessionNetworkServiceError.unknownError)

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/EmojiViewController.swift
@@ -27,6 +27,7 @@ final class EmojiViewController: UIViewController {
         layout.minimumLineSpacing = 15
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .systemBackground
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "default")
         return collectionView
     }()

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
@@ -47,6 +47,7 @@ final class EmojiViewModel {
                     from: ""
                 )
                 self?.emojiUseCase.selectEmoji(emoji)
+                self?.emojiUseCase.sendComplimentEmoji(to: "yjsimul")
             })
             .disposed(by: disposeBag)
       

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
@@ -14,6 +14,8 @@ final class EmojiViewModel {
     let emojiObservable = Observable.of(Emoji.allCases)
     private let emojiUseCase: EmojiUseCase
     private weak var coordinator: EmojiCoordinator?
+    var mateNickname: String?
+    var runningID: String?
     
     struct Input {
       let emojiCellTapEvent: Observable<IndexPath>
@@ -38,7 +40,12 @@ final class EmojiViewModel {
         input.emojiCellTapEvent
             .subscribe(onNext: { [weak self] indexPath in
                 guard let emoji = self?.emoji(at: indexPath.row) else { return }
-                self?.emojiUseCase.sendEmoji(emoji)
+                self?.emojiUseCase.sendEmoji(
+                    emoji,
+                    to: self?.mateNickname ?? "",
+                    of: self?.runningID ?? "",
+                    from: ""
+                )
             })
             .disposed(by: disposeBag)
       

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/EmojiViewModel.swift
@@ -46,6 +46,7 @@ final class EmojiViewModel {
                     of: self?.runningID ?? "",
                     from: ""
                 )
+                self?.emojiUseCase.selectEmoji(emoji)
             })
             .disposed(by: disposeBag)
       

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -80,6 +80,10 @@ final class DefaultRunningCoordinator: RunningCoordinator {
             emojiUseCase: DefaultEmojiUseCase(
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
+                ),
+                mateRepository: DefaultMateRepository(
+                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
+                    urlSessionNetworkService: DefaultURLSessionNetworkService()
                 ), delegate: usecase
             )
         )

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -77,7 +77,11 @@ final class DefaultRunningCoordinator: RunningCoordinator {
         let emojiViewController = EmojiViewController()
         emojiViewController.viewModel = EmojiViewModel(
             coordinator: self,
-            emojiUseCase: DefaultEmojiUseCase(delegate: usecase)
+            emojiUseCase: DefaultEmojiUseCase(
+                firestoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
+                ), delegate: usecase
+            )
         )
         self.navigationController.present(emojiViewController, animated: true)
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -67,6 +67,9 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
             coordinator: self, emojiUseCase: DefaultEmojiUseCase(
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
+                ), mateRepository: DefaultMateRepository(
+                    realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
+                    urlSessionNetworkService: DefaultURLSessionNetworkService()
                 ), delegate: usecase
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -57,11 +57,17 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
         self.navigationController.pushViewController(recordDetailViewController, animated: true)
     }
     
-    func presentEmojiModal() {
+    func presentEmojiModal(mate: String, runningID: String) {
         let emojiViewController = EmojiViewController()
         emojiViewController.viewModel = EmojiViewModel(
-            coordinator: self, emojiUseCase: DefaultEmojiUseCase()
+            coordinator: self, emojiUseCase: DefaultEmojiUseCase(
+                firestoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
+                )
+            )
         )
+        emojiViewController.viewModel?.runningID = runningID
+        emojiViewController.viewModel?.mateNickname = mate
         self.navigationController.present(emojiViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -57,13 +57,17 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
         self.navigationController.pushViewController(recordDetailViewController, animated: true)
     }
     
-    func presentEmojiModal(mate: String, runningID: String) {
+    func presentEmojiModal(
+        connectedTo usecase: ProfileUseCase,
+        mate: String,
+        runningID: String
+    ) {
         let emojiViewController = EmojiViewController()
         emojiViewController.viewModel = EmojiViewModel(
             coordinator: self, emojiUseCase: DefaultEmojiUseCase(
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
-                )
+                ), delegate: usecase
             )
         )
         emojiViewController.viewModel?.runningID = runningID

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
@@ -10,5 +10,9 @@ import Foundation
 protocol MateProfileCoordinator: EmojiCoordinator {
     func pushMateProfileViewController()
     func pushRecordDetailViewController(with runningResult: RunningResult)
-    func presentEmojiModal(mate: String, runningID: String)
+    func presentEmojiModal(
+        connectedTo usecase: ProfileUseCase,
+        mate: String,
+        runningID: String
+    )
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/Protocol/MateProfileCoordinator.swift
@@ -10,5 +10,5 @@ import Foundation
 protocol MateProfileCoordinator: EmojiCoordinator {
     func pushMateProfileViewController()
     func pushRecordDetailViewController(with runningResult: RunningResult)
-    func presentEmojiModal()
+    func presentEmojiModal(mate: String, runningID: String)
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
@@ -11,13 +11,14 @@ import RxCocoa
 import RxSwift
 
 protocol HeartButtonDidTapDelegate: AnyObject {
-    func heartButtonDidTap()
+    func heartButtonDidTap(runningID: String)
 }
 
 final class MateRecordTableViewCell: RecordCell {
     private let disposeBag = DisposeBag()
     weak var delegate: HeartButtonDidTapDelegate?
-    
+    private var recordRunningID = ""
+
     private lazy var heartButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "heart"), for: .normal)
@@ -43,6 +44,7 @@ final class MateRecordTableViewCell: RecordCell {
     
     override func updateUI(record: RunningResult) {
         super.updateUI(record: record)
+        self.recordRunningID = record.runningID
     }
     
     func updateHeartButton(nickname: String, sender: [String]) {
@@ -68,7 +70,7 @@ private extension MateRecordTableViewCell {
     func bindUI() {
         self.heartButton.rx.tap
             .bind { [weak self] in
-                self?.delegate?.heartButtonDidTap()
+                self?.delegate?.heartButtonDidTap(runningID: self?.recordRunningID ?? "")
             }
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateRecordTableViewCell.swift
@@ -11,13 +11,13 @@ import RxCocoa
 import RxSwift
 
 protocol HeartButtonDidTapDelegate: AnyObject {
-    func heartButtonDidTap(runningID: String)
+    func heartButtonDidTap(row selectIndex: Int)
 }
 
 final class MateRecordTableViewCell: RecordCell {
     private let disposeBag = DisposeBag()
     weak var delegate: HeartButtonDidTapDelegate?
-    private var recordRunningID = ""
+    var indexPathRow = 0
 
     private lazy var heartButton: UIButton = {
         let button = UIButton()
@@ -44,7 +44,6 @@ final class MateRecordTableViewCell: RecordCell {
     
     override func updateUI(record: RunningResult) {
         super.updateUI(record: record)
-        self.recordRunningID = record.runningID
     }
     
     func updateHeartButton(nickname: String, sender: [String]) {
@@ -70,7 +69,8 @@ private extension MateRecordTableViewCell {
     func bindUI() {
         self.heartButton.rx.tap
             .bind { [weak self] in
-                self?.delegate?.heartButtonDidTap(runningID: self?.recordRunningID ?? "")
+                guard let indexPathRow = self?.indexPathRow else { return }
+                self?.delegate?.heartButtonDidTap(row: indexPathRow)
             }
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -194,7 +194,7 @@ extension MateProfileViewController: UITableViewDataSource {
 // MARK: - SendEmojiDelegate
 
 extension MateProfileViewController: HeartButtonDidTapDelegate {
-    func heartButtonDidTap() {
-        self.viewModel?.moveToEmoji()
+    func heartButtonDidTap(runningID: String) {
+        self.viewModel?.moveToEmoji(runningID: runningID)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -95,10 +95,14 @@ private extension MateProfileViewController {
             .disposed(by: self.disposeBag)
         
         self.viewModel?.selectEmoji
-            .asDriver(onErrorJustReturn: false)
-            .drive(onNext: { [weak self] _ in
-                print("??")
-//                self?.viewModel
+            .asDriver(onErrorJustReturn: .clap)
+            .drive(onNext: { [weak self] emoji in
+                guard let index = self?.viewModel?.selectedIndex else { return }
+                self?.viewModel?.recordInfo?[index].addEmoji(emoji, from: "yujin")
+                self?.tableView.reloadSections(
+                    IndexSet(1...1),
+                    with: .none
+                )
             })
             .disposed(by: self.disposeBag)
     }
@@ -149,6 +153,7 @@ extension MateProfileViewController: UITableViewDataSource {
             ) as? MateRecordTableViewCell else { return UITableViewCell() }
             
             cell.delegate = self
+            cell.indexPathRow = indexPath.row
             guard let result = self.viewModel?.recordInfo else { return UITableViewCell() }
             let nickname = self.viewModel?.fetchUserNickname()
             let record = result[indexPath.row]
@@ -203,7 +208,9 @@ extension MateProfileViewController: UITableViewDataSource {
 // MARK: - SendEmojiDelegate
 
 extension MateProfileViewController: HeartButtonDidTapDelegate {
-    func heartButtonDidTap(runningID: String) {
-        self.viewModel?.moveToEmoji(runningID: runningID)
+    func heartButtonDidTap(row selectIndex: Int) {
+        guard let result = self.viewModel?.recordInfo?[selectIndex] else { return }
+        self.viewModel?.selectedIndex = selectIndex
+        self.viewModel?.moveToEmoji(record: result)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -89,7 +89,16 @@ private extension MateProfileViewController {
             .drive(onNext: { [weak self] _ in
                 self?.tableView.reloadSections(
                     IndexSet(1...1),
-                    with: .none)
+                    with: .none
+                )
+            })
+            .disposed(by: self.disposeBag)
+        
+        self.viewModel?.selectEmoji
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { [weak self] _ in
+                print("??")
+//                self?.viewModel
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -75,8 +75,8 @@ final class MateProfileViewModel: NSObject {
         self.coordinator?.pushRecordDetailViewController(with: record)
     }
     
-    func moveToEmoji() {
-        self.coordinator?.presentEmojiModal()
+    func moveToEmoji(runningID: String) {
+        self.coordinator?.presentEmojiModal(mate: self.mateInfo?.nickname ?? "", runningID: runningID)
     }
     
     func fetchUserNickname() -> String? {

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -13,9 +13,10 @@ import RxSwift
 final class MateProfileViewModel: NSObject {
     private let profileUseCase: ProfileUseCase
     weak var coordinator: MateProfileCoordinator?
-    var selectEmoji: PublishSubject<Bool> = PublishSubject()
+    var selectEmoji: PublishSubject<Emoji> = PublishSubject()
     var mateInfo: UserData?
     var recordInfo: [RunningResult]?
+    var selectedIndex: Int?
     
     struct Input {
         let viewDidLoadEvent: Observable<Void>
@@ -70,8 +71,8 @@ final class MateProfileViewModel: NSObject {
             .disposed(by: disposeBag)
         
         self.profileUseCase.selectEmoji
-            .subscribe(onNext: { [weak self] _ in
-                self?.selectEmoji.onNext(true)
+            .subscribe(onNext: { [weak self] emoji in
+                self?.selectEmoji.onNext(emoji)
             })
             .disposed(by: disposeBag)
         
@@ -82,11 +83,11 @@ final class MateProfileViewModel: NSObject {
         self.coordinator?.pushRecordDetailViewController(with: record)
     }
     
-    func moveToEmoji(runningID: String) {
+    func moveToEmoji(record: RunningResult) {
         self.coordinator?.presentEmojiModal(
             connectedTo: self.profileUseCase,
             mate: self.mateInfo?.nickname ?? "",
-            runningID: runningID
+            runningID: record.runningID
         )
     }
     

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -13,6 +13,7 @@ import RxSwift
 final class MateProfileViewModel: NSObject {
     private let profileUseCase: ProfileUseCase
     weak var coordinator: MateProfileCoordinator?
+    var selectEmoji: PublishSubject<Bool> = PublishSubject()
     var mateInfo: UserData?
     var recordInfo: [RunningResult]?
     
@@ -68,6 +69,12 @@ final class MateProfileViewModel: NSObject {
             })
             .disposed(by: disposeBag)
         
+        self.profileUseCase.selectEmoji
+            .subscribe(onNext: { [weak self] _ in
+                self?.selectEmoji.onNext(true)
+            })
+            .disposed(by: disposeBag)
+        
         return output
     }
     
@@ -76,7 +83,11 @@ final class MateProfileViewModel: NSObject {
     }
     
     func moveToEmoji(runningID: String) {
-        self.coordinator?.presentEmojiModal(mate: self.mateInfo?.nickname ?? "", runningID: runningID)
+        self.coordinator?.presentEmojiModal(
+            connectedTo: self.profileUseCase,
+            mate: self.mateInfo?.nickname ?? "",
+            runningID: runningID
+        )
     }
     
     func fetchUserNickname() -> String? {


### PR DESCRIPTION
### 📕 Issue Number

Close #210 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 이모지 전송 Rest API 연결
- [x] 이모지 FCM 전송
- [x] 이모지 전송 후 하트버튼이 채워진 하트로 변경
![Simulator Screen Recording - iPhone 13 - 2021-11-27 at 02 07 30](https://user-images.githubusercontent.com/41044154/143613951-efcc8ecf-5696-4646-92d5-cae6645b0c24.gif)
<img src="https://user-images.githubusercontent.com/41044154/143613944-3d22227d-321e-40aa-bf17-ba1dfce52ba9.PNG" width=50% height=50%>
### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
이모지를 전송하고 돌아왔을 때 하트버튼이 채워져있는 부분을 구현하기에서 어떤 cell의 하트버튼이 채워져서 다시 reload가 되어져야 하는지에 대해 고민을 많이 했습니다. 서버로부터 다시 fetch해서 리로드를 하기에는 비효율적으로 느껴졌기 때문에 눌린 cell의 인덱스값으로 뷰모델이 들고있는 기록리스트 같은 인덱스의 RunningResult에 있는 이모지 필드를 업데이트 시킨 후 리로드를 했습니다!
이 과정에서 cell이 자신의 인덱스값에 대한 프로퍼티를 하나 들고있게 되었는데 이 부분을 이렇게 구현하지 않으면 다른 방법이 아무리 생각해도(..) 떠오르지 않아 이렇게 구현하게 되었습니다.. 더 좋은 방법이 생각나신다면 코멘트 부탁드리겠습니다..!!

- 특이 사항 2
현재 이모지 전송 FCM은 친구프로필에서 이모지 전송했을때만 보내지고 있습니다!
이렇게 한 이유는 경쟁모드를 생각했을때 메이트의 운동이 끝나지 않은 시점에 FCM이 전송되는 경우가 있을것 같아서 일단은 이렇게 했습니다 운동중 화면인데 그 운동에 대한 칭찬이모지를 받는 시나리오가 좀 어색하게 느껴졌습니다!


<br/><br/>
