### PR TITLE
프로필 정보 편집 기능 구현

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		5EBDA076273B938E00FC9707 /* TeamResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBDA075273B938E00FC9707 /* TeamResultView.swift */; };
 		5EBDA078273BA7ED00FC9707 /* RaceRunningResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBDA077273BA7ED00FC9707 /* RaceRunningResultViewController.swift */; };
 		5EBDA07A273BAAEC00FC9707 /* RaceResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBDA079273BAAEC00FC9707 /* RaceResultView.swift */; };
+		5EC0AF0727521ACA00239606 /* MateRunnerActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0AF0627521ACA00239606 /* MateRunnerActivityIndicatorView.swift */; };
 		5ED367D02745ECE800901765 /* RecordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED367CF2745ECE800901765 /* RecordCell.swift */; };
 		5ED367D52746229500901765 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED367D42746229500901765 /* RecordViewModel.swift */; };
 		5ED367D92746246800901765 /* RecordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED367D82746246800901765 /* RecordUseCase.swift */; };
@@ -426,6 +427,7 @@
 		5EBDA075273B938E00FC9707 /* TeamResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamResultView.swift; sourceTree = "<group>"; };
 		5EBDA077273BA7ED00FC9707 /* RaceRunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResultViewController.swift; sourceTree = "<group>"; };
 		5EBDA079273BAAEC00FC9707 /* RaceResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceResultView.swift; sourceTree = "<group>"; };
+		5EC0AF0627521ACA00239606 /* MateRunnerActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateRunnerActivityIndicatorView.swift; sourceTree = "<group>"; };
 		5ED367CF2745ECE800901765 /* RecordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCell.swift; sourceTree = "<group>"; };
 		5ED367D42746229500901765 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		5ED367D82746246800901765 /* RecordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordUseCase.swift; sourceTree = "<group>"; };
@@ -885,6 +887,7 @@
 				5ED367CF2745ECE800901765 /* RecordCell.swift */,
 				5EE0EC45274D156E00555D6E /* EmojiListView.swift */,
 				5EE0EC47274D1A2200555D6E /* EmojiView.swift */,
+				5EC0AF0627521ACA00239606 /* MateRunnerActivityIndicatorView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2219,6 +2222,7 @@
 				5E171E6527325691001C003B /* RunningSetting.swift in Sources */,
 				B0C85184274E68E00070BB66 /* UserData.swift in Sources */,
 				AE3D149F273BDB5800D4A186 /* Double+Formatter.swift in Sources */,
+				5EC0AF0727521ACA00239606 /* MateRunnerActivityIndicatorView.swift in Sources */,
 				3D622553274904D900E4A327 /* URLSessionNetworkService.swift in Sources */,
 				5ED367D52746229500901765 /* RecordViewModel.swift in Sources */,
 				B0A0DA1E27441A0B004DDC71 /* HomeUseCase.swift in Sources */,

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
@@ -25,7 +25,7 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     }
     
     func loadUserInfo() {
-        guard let nickname = nickname else { return }
+        guard let nickname = self.nickname else { return }
         self.firestoreRepository.fetchUserData(of: nickname)
             .compactMap { $0 }
             .subscribe(onNext: { [weak self] userData in

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/ProfileEditUseCase.swift
@@ -16,5 +16,5 @@ protocol ProfileEditUseCase {
     var imageURL: BehaviorSubject<String?> { get set }
     var saveResult: PublishSubject<Bool> { get set }
     func loadUserInfo()
-    func saveUserInfo()
+    func saveUserInfo(imageData: Data)
 }

--- a/MateRunner/MateRunner/Presentation/Common/View/MateRunnerActivityIndicatorView.swift
+++ b/MateRunner/MateRunner/Presentation/Common/View/MateRunnerActivityIndicatorView.swift
@@ -1,0 +1,26 @@
+//
+//  MateRunnerActivityIndicatorView.swift
+//  MateRunner
+//
+//  Created by 이정원 on 2021/11/27.
+//
+
+import UIKit
+
+final class MateRunnerActivityIndicatorView: UIActivityIndicatorView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    convenience init(color: UIColor) {
+        self.init(frame: CGRect(x: 0, y: 0, width: 90, height: 90))
+        self.color = color
+        self.hidesWhenStopped = true
+        self.style = .large
+        self.startAnimating()
+    }
+}

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -104,7 +104,8 @@ private extension MyPageViewController {
         guard let viewModel = self.viewModel else { return }
         
         let input = MyPageViewModel.Input(
-            viewDidLoadEvent: Observable<Void>.just(()),
+            // viewDidLoadEvent: Observable<Void>.just(()),
+            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map { _ in },
             notificationButtonDidTapEvent: notificationButton.rx.tap.asObservable(),
             profileEditButtonDidTapEvent: profileEditButton.rx.tap.asObservable(),
             licenseButtonDidTapEvent: licenseButton.rx.tap.asObservable(),

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -104,7 +104,6 @@ private extension MyPageViewController {
         guard let viewModel = self.viewModel else { return }
         
         let input = MyPageViewModel.Input(
-            // viewDidLoadEvent: Observable<Void>.just(()),
             viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map { _ in },
             notificationButtonDidTapEvent: notificationButton.rx.tap.asObservable(),
             profileEditButtonDidTapEvent: profileEditButton.rx.tap.asObservable(),

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
@@ -19,6 +19,7 @@ final class ProfileEditViewController: UIViewController {
     private lazy var weightTextField = PickerTextField()
     private lazy var heightSection = self.createInputSection(text: "키", textField: self.heightTextField)
     private lazy var weightSection = self.createInputSection(text: "몸무게", textField: self.weightTextField)
+    private lazy var activityIndicator = MateRunnerActivityIndicatorView(color: .mrPurple)
     
     private lazy var nicknameLabel: UILabel = {
         let label = UILabel()
@@ -87,6 +88,16 @@ private extension ProfileEditViewController {
                 self.present(self.imagePickerController, animated: true)
             })
             .disposed(by: self.disposeBag)
+        
+        self.doneButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                self.view.addSubview(self.activityIndicator)
+                self.activityIndicator.snp.makeConstraints { make in
+                    make.centerX.centerY.equalToSuperview()
+                }
+            })
+            .disposed(by: self.disposeBag)
     }
     
     func bindViewModel() {
@@ -96,7 +107,9 @@ private extension ProfileEditViewController {
             heightPickerSelectedRow: self.heightTextField.pickerView.rx.itemSelected.map { $0.row },
             weightTextFieldDidTapEvent: self.weightTextField.rx.controlEvent(.editingDidBegin).asObservable(),
             weightPickerSelectedRow: self.weightTextField.pickerView.rx.itemSelected.map { $0.row },
-            doneButtonDidTapEvent: self.doneButton.rx.tap.asObservable()
+            doneButtonDidTapEvent: self.doneButton.rx.tap.asObservable().map { [weak self] in
+                self?.imageEditButton.profileImageView.image?.pngData()
+            }
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -23,7 +23,7 @@ final class MyPageViewModel {
     }
     
     struct Input {
-        let viewDidLoadEvent: Observable<Void>
+        let viewWillAppearEvent: Observable<Void>
         let notificationButtonDidTapEvent: Observable<Void>
         let profileEditButtonDidTapEvent: Observable<Void>
         let licenseButtonDidTapEvent: Observable<Void>
@@ -39,7 +39,7 @@ final class MyPageViewModel {
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        input.viewDidLoadEvent
+        input.viewWillAppearEvent
             .subscribe(onNext: { [weak self] in
                 self?.myPageUseCase.loadUserInfo()
             })

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/ProfileEditViewModel.swift
@@ -20,7 +20,7 @@ final class ProfileEditViewModel {
         let heightPickerSelectedRow: Observable<Int>
         let weightTextFieldDidTapEvent: Observable<Void>
         let weightPickerSelectedRow: Observable<Int>
-        let doneButtonDidTapEvent: Observable<Void>
+        let doneButtonDidTapEvent: Observable<Data?>
     }
     
     struct Output {
@@ -62,8 +62,9 @@ final class ProfileEditViewModel {
             .disposed(by: disposeBag)
         
         input.doneButtonDidTapEvent
-            .subscribe(onNext: { [weak self] in
-                self?.profileEditUseCase.saveUserInfo()
+            .subscribe(onNext: { [weak self] imageData in
+                guard let imageData = imageData else { return }
+                self?.profileEditUseCase.saveUserInfo(imageData: imageData)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
### 📕 Issue Number

Close #226 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역


https://user-images.githubusercontent.com/77449223/143682020-78c8b807-9fb4-4d1d-a966-7d25d6f8b26e.MP4

- [x] 수정한 프로필 정보 저장
- [x] 마이페이지 화면 보일때마다 프로필 이미지 새로고침

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 기존 `fetchUserData`로 프로필 정보를 받던 걸 `fetchUserProfile` 로 수정하였습니다.
- 여훈님께서 구현해주신 `saveAll`을 이용해 이미지를 업로드하였고, 완료되기까지 ActivityIndicator를 표시하였습니다.
- 마이페이지 화면의 `viewDidLoadEvent`를 `viewWillAppearEvent`로 수정하여 화면이 보일 때마다 새로운 프로필 이미지를 가져오도록 하였습니다.

<br/><br/>
