### PR TITLE
달리기 초대장, 메이트 요청 푸시알림을 통해 알림센터, 달리기모드 진입, 모든 화면에서 초대장 팝업 구현

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		B015E86E2735864F0000AA47 /* MockSingleRunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */; };
 		B015E8712735896D0000AA47 /* BehaviorRelayProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E32DC642731004D000E525B /* BehaviorRelayProperty.swift */; };
 		B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */; };
+		B02D49802752AE6800B22249 /* NotificationCenterKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02D497F2752AE6800B22249 /* NotificationCenterKey.swift */; };
 		B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD7273BA987001657FE /* HomeCoordinator.swift */; };
 		B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */; };
 		B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */; };
@@ -246,6 +247,7 @@
 		B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */; };
 		B08D15C5273964880095AC00 /* SingleRunningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDAFD1527352372009BAEAA /* SingleRunningViewModel.swift */; };
 		B08D15C92739649A0095AC00 /* RunningUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB9A8127356AFF00533EF7 /* RunningUseCase.swift */; };
+		B095EABA2752AFED001A70F4 /* InvitationReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */; };
 		B0A0DA1E27441A0B004DDC71 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */; };
 		B0A0DA2027441AD5004DDC71 /* LocationAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0DA1F27441AD5004DDC71 /* LocationAuthorizationStatus.swift */; };
 		B0A0DA222744A126004DDC71 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0DA212744A126004DDC71 /* Region.swift */; };
@@ -515,6 +517,7 @@
 		B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleRunningViewModelTests.swift; sourceTree = "<group>"; };
 		B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSingleRunningUseCase.swift; sourceTree = "<group>"; };
 		B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewController.swift; sourceTree = "<group>"; };
+		B02D497F2752AE6800B22249 /* NotificationCenterKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterKey.swift; sourceTree = "<group>"; };
 		B02FCAD7273BA987001657FE /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeCoordinator.swift; sourceTree = "<group>"; };
 		B02FCADB273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinatorDidFinishDelegate.swift; sourceTree = "<group>"; };
@@ -551,6 +554,7 @@
 		B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResult.swift; sourceTree = "<group>"; };
 		B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRunningResult.swift; sourceTree = "<group>"; };
 		B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleRunningViewController.swift; sourceTree = "<group>"; };
+		B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationReceivable.swift; sourceTree = "<group>"; };
 		B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
 		B0A0DA1F27441AD5004DDC71 /* LocationAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAuthorizationStatus.swift; sourceTree = "<group>"; };
 		B0A0DA212744A126004DDC71 /* Region.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
@@ -1598,6 +1602,7 @@
 				3D62255827495ED400E4A327 /* Configuration.swift */,
 				AE263BE1274DDD62004A61E5 /* NoticeMode.swift */,
 				5E53FF09274FE831002EE49C /* FilePath.swift */,
+				B02D497F2752AE6800B22249 /* NotificationCenterKey.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -1659,6 +1664,7 @@
 				B0628B93273A1752004FAB0F /* Coordinator.swift */,
 				B0F53290273A370B005A3F11 /* AppCoordinator.swift */,
 				B0F5328A273A3397005A3F11 /* TabBarCoordinator.swift */,
+				B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -2157,6 +2163,7 @@
 				3DAF2D832743A05700AC5FEA /* InvitationViewModel.swift in Sources */,
 				B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */,
 				5E7DEE7B273FA78F002E1374 /* DefaultLoginCoordinator.swift in Sources */,
+				B095EABA2752AFED001A70F4 /* InvitationReceivable.swift in Sources */,
 				3D62258B274E0B5500E4A327 /* DefaultProfileEditUseCase.swift in Sources */,
 				3D62257D274E07CF00E4A327 /* ProfileEditViewController.swift in Sources */,
 				AE263BE4274DDD7F004A61E5 /* Notice.swift in Sources */,
@@ -2227,6 +2234,7 @@
 				3DF6D07E27301F1100991DC3 /* SingleRunningResultViewController.swift in Sources */,
 				AE263BE9274E1E18004A61E5 /* ImageCacheError.swift in Sources */,
 				3DAF2D7B27439F7E00AC5FEA /* InvitationRepository.swift in Sources */,
+				B02D49802752AE6800B22249 /* NotificationCenterKey.swift in Sources */,
 				AE6A6F562730E450005A3A5C /* UIView+ShadowEffect.swift in Sources */,
 				3D62255927495ED400E4A327 /* Configuration.swift in Sources */,
 				B02FCADC273BB306001657FE /* SettingCoordinatorDidFinishDelegate.swift in Sources */,

--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -96,6 +96,27 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
+        print(userInfo)
+        
+        userInfo[NotificationCenterKey.sender] != nil
+        ? self.configureMateRequestNotification(with: userInfo)
+        : self.configureInvitation(with: userInfo)
+        
+        completionHandler()
+    }
+    
+    
+    private func configureMateRequestNotification(with userInfo: [AnyHashable: Any]) {
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
+              let appCoordinator = sceneDelegate.appCoordinator,
+              let tabBarCoordinator = appCoordinator.findCoordinator(type: .tab) as? TabBarCoordinator,
+              let myPageCoordinator = appCoordinator.findCoordinator(type: .mypage) as? MyPageCoordinator else { return }
+        tabBarCoordinator.selectPage(.mypage)
+        // TODO: push NotificationViewController after integrates mypage subcoordinators
+        myPageCoordinator.showNotificationFlow()
+    }
+    
+    private func configureInvitation(with userInfo: [AnyHashable: Any]) {
         guard let invitation = Invitation(from: userInfo) else { return }
         
         NotificationCenter.default.post(
@@ -103,7 +124,9 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
             object: nil,
             userInfo: [NotificationCenterKey.invitation: invitation]
         )
-        
-        completionHandler()
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 }

--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -96,7 +96,6 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
-        print(userInfo)
         
         userInfo[NotificationCenterKey.sender] != nil
         ? self.configureMateRequestNotification(with: userInfo)

--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -120,7 +120,7 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
         guard let invitation = Invitation(from: userInfo) else { return }
         
         NotificationCenter.default.post(
-            name: NotificationCenterKey.invitationDidRecieve,
+            name: NotificationCenterKey.invitationDidReceive,
             object: nil,
             userInfo: [NotificationCenterKey.invitation: invitation]
         )

--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -99,9 +99,9 @@ extension AppDelegate : UNUserNotificationCenterDelegate {
         guard let invitation = Invitation(from: userInfo) else { return }
         
         NotificationCenter.default.post(
-            name: Notification.Name("noti"),
+            name: NotificationCenterKey.invitationDidRecieve,
             object: nil,
-            userInfo: ["invitation": invitation]
+            userInfo: [NotificationCenterKey.invitation: invitation]
         )
         
         completionHandler()

--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -14,18 +14,20 @@ import FirebaseMessaging
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    func application(_ application: UIApplication,didFinishLaunchingWithOptions launchOptions:[UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions:[UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         FirebaseApp.configure()
         
         UNUserNotificationCenter.current().delegate = self
         Messaging.messaging().delegate = self
-            
+        
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter
-          .current()
-          .requestAuthorization(
-            options: authOptions,completionHandler: { (_, _) in }
-          )
+            .current()
+            .requestAuthorization(options: authOptions, completionHandler: { (_, _) in })
+        
         application.registerForRemoteNotifications()
         
         if let nickName = UserDefaults.standard.string(forKey: "nickname") {
@@ -34,19 +36,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        
-    }
-
     // MARK: - Core Data stack
-
+    
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "MateRunner")
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
@@ -56,9 +58,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         })
         return container
     }()
-
+    
     // MARK: - Core Data Saving support
-
+    
     func saveContext () {
         let context = persistentContainer.viewContext
         if context.hasChanges {
@@ -81,19 +83,26 @@ extension AppDelegate : MessagingDelegate {
 }
 
 extension AppDelegate : UNUserNotificationCenterDelegate {
-    func userNotificationCenter(_ center: UNUserNotificationCenter,willPresent notification: UNNotification,withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.alert, .badge, .sound])
     }
-
-    func userNotificationCenter(_ center: UNUserNotificationCenter,didReceive response: UNNotificationResponse,withCompletionHandler completionHandler: @escaping () -> Void) {
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
         let userInfo = response.notification.request.content.userInfo
+        guard let invitation = Invitation(from: userInfo) else { return }
         
-        guard let invitation = Invitation(from: userInfo),
-              let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
-              let appCoordinator = sceneDelegate.appCoordinator
-        else { return }
-        
-        appCoordinator.showInvitationFlow(with: invitation)
+        NotificationCenter.default.post(
+            name: Notification.Name("noti"),
+            object: nil,
+            userInfo: ["invitation": invitation]
+        )
         
         completionHandler()
     }

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let navigationController = UINavigationController()
         
-        self.window?.tintColor = .mrPurple
         self.window = UIWindow(windowScene: windowScene)
+        self.window?.tintColor = .mrPurple
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
         

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -39,13 +39,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let notificationResponse = connectionOptions.notificationResponse else { return }
         let userInfo = notificationResponse.notification.request.content.userInfo
         
-        configureInvitation(with: userInfo)
-        
+        userInfo[NotificationCenterKey.sender] != nil
+        ? self.configureMateRequestNotification(with: userInfo)
+        : self.configureInvitation(with: userInfo)
+
         return
     }
     
     private func configureMateRequestNotification(with userInfo: [AnyHashable: Any]) {
-        
+        guard let tabBarCoordinator = self.appCoordinator?.findCoordinator(type: .tab) as? TabBarCoordinator,
+              let myPageCoordinator = self.appCoordinator?.findCoordinator(type: .mypage) as? MyPageCoordinator else { return }
+        tabBarCoordinator.selectPage(.mypage)
+        myPageCoordinator.showNotificationFlow()
     }
     
     private func configureInvitation(with userInfo: [AnyHashable: Any]) {

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -7,6 +7,18 @@
 
 import UIKit
 
+enum NotificationCenterKey {
+    static let invitationDidRecieve = Notification.Name("invitationDidRecieve")
+    static let invitation = "invitation"
+    static let sessionID = "sessionId"
+    static let host = "host"
+    static let mate = "mate"
+    static let inviteTime = "inviteTime"
+    static let mode = "mode"
+    static let targetDistance = "targetDistance"
+    static let sender = "sender"
+}
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
@@ -23,26 +35,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.appCoordinator = DefaultAppCoordinator(navigationController)
         self.appCoordinator?.start()
-        configureInvitation(connectionOptions: connectionOptions)
+        
+        guard let notificationResponse = connectionOptions.notificationResponse else { return }
+        let userInfo = notificationResponse.notification.request.content.userInfo
+        
+        configureInvitation(with: userInfo)
         
         return
     }
     
-    private func configureInvitation(connectionOptions: UIScene.ConnectionOptions) {
-        guard let notificationResponse = connectionOptions.notificationResponse else { return }
-        let userInfo = notificationResponse.notification.request.content.userInfo
+    private func configureMateRequestNotification(with userInfo: [AnyHashable: Any]) {
         
+    }
+    
+    private func configureInvitation(with userInfo: [AnyHashable: Any]) {
         guard let invitation = Invitation(from: userInfo),
               let homeCoordinator = self.appCoordinator?.findCoordinator(type: .home) as? DefaultHomeCoordinator,
               let lastChildViewController = homeCoordinator.navigationController.viewControllers.last ,
               let homeViewController = lastChildViewController as? HomeViewController else { return }
         
-        let invitationViewController = InvitationViewController(
-            mate: invitation.host,
-            mode: invitation.mode,
-            distance: invitation.targetDistance
-        )
-        
+        let invitationViewController = InvitationViewController()
         invitationViewController.viewModel = InvitationViewModel(
             coordinator: homeCoordinator,
             invitationUseCase: DefaultInvitationUseCase(invitation: invitation)

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -38,30 +38,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let notificationResponse = connectionOptions.notificationResponse else { return }
         let userInfo = notificationResponse.notification.request.content.userInfo
-        
-        userInfo[NotificationCenterKey.sender] != nil
-        ? self.configureMateRequestNotification(with: userInfo)
-        : self.configureInvitation(with: userInfo)
+        self.configureInvitation(with: userInfo)
 
         return
     }
     
-    private func configureMateRequestNotification(with userInfo: [AnyHashable: Any]) {
-        guard let tabBarCoordinator = self.appCoordinator?.findCoordinator(type: .tab) as? TabBarCoordinator,
-              let myPageCoordinator = self.appCoordinator?.findCoordinator(type: .mypage) as? MyPageCoordinator else { return }
-        tabBarCoordinator.selectPage(.mypage)
-        myPageCoordinator.showNotificationFlow()
-    }
-    
     private func configureInvitation(with userInfo: [AnyHashable: Any]) {
         guard let invitation = Invitation(from: userInfo),
+              let tabBarCoordinator = self.appCoordinator?.findCoordinator(type: .tab) as? TabBarCoordinator,
               let homeCoordinator = self.appCoordinator?.findCoordinator(type: .home) as? DefaultHomeCoordinator,
               let lastChildViewController = homeCoordinator.navigationController.viewControllers.last ,
               let homeViewController = lastChildViewController as? HomeViewController else { return }
         
         let invitationViewController = InvitationViewController()
         invitationViewController.viewModel = InvitationViewModel(
-            coordinator: homeCoordinator,
+            coordinator: tabBarCoordinator,
             invitationUseCase: DefaultInvitationUseCase(invitation: invitation)
         )
         

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -7,18 +7,6 @@
 
 import UIKit
 
-enum NotificationCenterKey {
-    static let invitationDidRecieve = Notification.Name("invitationDidRecieve")
-    static let invitation = "invitation"
-    static let sessionID = "sessionId"
-    static let host = "host"
-    static let mate = "mate"
-    static let inviteTime = "inviteTime"
-    static let mode = "mode"
-    static let targetDistance = "targetDistance"
-    static let sender = "sender"
-}
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -8,48 +8,38 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
     var appCoordinator: AppCoordinator?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
+        let navigationController = UINavigationController()
+        
+        self.window?.tintColor = .mrPurple
         self.window = UIWindow(windowScene: windowScene)
-        guard appCoordinator != nil else {
-            let navigationController: UINavigationController = .init()
-            
-            self.window?.tintColor = .mrPurple
-            
-            self.window?.rootViewController = navigationController
-            self.window?.makeKeyAndVisible()
-            
-            self.appCoordinator = DefaultAppCoordinator(navigationController)
-            self.appCoordinator?.start()
-            return
+        self.window?.rootViewController = navigationController
+        self.window?.makeKeyAndVisible()
+        
+        self.appCoordinator = DefaultAppCoordinator(navigationController)
+        self.appCoordinator?.start()
+        
+        if let notificationResponse = connectionOptions.notificationResponse {
+            let userInfo = notificationResponse.notification.request.content.userInfo
+            guard let invitation = Invitation(from: userInfo) else { return }
+            NotificationCenter.default.post(
+                name: Notification.Name("noti"),
+                object: nil,
+                userInfo: ["invitation": invitation]
+            )
         }
+        return
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        
-    }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
-        
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
-
-
+    
+    
 }
 

--- a/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Home/DefaultInviteMateRepository.swift
@@ -70,15 +70,15 @@ final class DefaultInviteMateRepository: InviteMateRepository {
         return Observable<(Bool, Bool)>.create { [weak self] observer in
             self?.ref.child("session").child("\(sessionId)").observe(DataEventType.value, with: { snapshot in
 
-                guard let isRecieved = snapshot.childSnapshot(forPath: "isReceived").value as? Bool,
+                guard let isReceived = snapshot.childSnapshot(forPath: "isReceived").value as? Bool,
                       let isAccepted = snapshot.childSnapshot(forPath: "isAccepted").value as? Bool else {
                           observer.onError(MockError.unknown)
                           observer.onCompleted()
                           return
                       }
 
-                if isRecieved || isAccepted {
-                    observer.onNext((isRecieved, isAccepted))
+                if isReceived || isAccepted {
+                    observer.onNext((isReceived, isAccepted))
                     observer.onCompleted()
                 }
             })

--- a/MateRunner/MateRunner/Domain/Model/Invitation.swift
+++ b/MateRunner/MateRunner/Domain/Model/Invitation.swift
@@ -39,13 +39,13 @@ struct Invitation: Codable {
     }
     
     init?(from dictionary: [AnyHashable: Any]) {
-        guard let sessionId = dictionary["sessionId"] as? String,
-              let host = dictionary["host"] as? String,
-              let mate = dictionary["mate"] as? String,
-              let inviteTime = dictionary["inviteTime"] as? String,
-              let modeString = dictionary["mode"] as? String,
+        guard let sessionId = dictionary[NotificationCenterKey.sessionID] as? String,
+              let host = dictionary[NotificationCenterKey.host] as? String,
+              let mate = dictionary[NotificationCenterKey.mate] as? String,
+              let inviteTime = dictionary[NotificationCenterKey.inviteTime] as? String,
+              let modeString = dictionary[NotificationCenterKey.mode] as? String,
+              let targetDistanceString = dictionary[NotificationCenterKey.targetDistance] as? String,
               let mode = RunningMode.init(rawValue: modeString),
-              let targetDistanceString = dictionary["targetDistance"] as? String,
               let targetDistance = Double(targetDistanceString) else {
                   return nil
               }

--- a/MateRunner/MateRunner/Domain/Model/MateRequest.swift
+++ b/MateRunner/MateRunner/Domain/Model/MateRequest.swift
@@ -15,7 +15,7 @@ struct MateRequest: Codable {
     }
     
     init?(from dictionary: [AnyHashable: Any]) {
-        guard let sender = dictionary["sender"] as? String else {
+        guard let sender = dictionary[NotificationCenterKey.sender] as? String else {
                   return nil
               }
         self.init(sender: sender)

--- a/MateRunner/MateRunner/Domain/UseCase/Home/SettingUseCase/DefaultInvitationWaitingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/SettingUseCase/DefaultInvitationWaitingUseCase.swift
@@ -77,12 +77,12 @@ final class DefaultInvitationWaitingUseCase: InvitationWaitingUseCase {
                 self.inviteMateRepository.stopListen(invitation: self.invitation)
                 return PublishRelay<(Bool, Bool)>.just((false, false))
             })
-            .subscribe { [weak self] (isRecieved, isAccepted) in
+            .subscribe { [weak self] (isReceived, isAccepted) in
                 guard let self = self else { return }
-                if isRecieved && isAccepted {
+                if isReceived && isAccepted {
                     self.isAccepted.onNext(true)
                     self.inviteMateRepository.stopListen(invitation: self.invitation)
-                } else if isRecieved && !isAccepted {
+                } else if isReceived && !isAccepted {
                     self.isRejected.onNext(true)
                     self.inviteMateRepository.stopListen(invitation: self.invitation)
                 }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -38,28 +38,6 @@ final class DefaultAppCoordinator: AppCoordinator {
         tabBarCoordinator.start()
         childCoordinators.append(tabBarCoordinator)
     }
-    
-    func showInvitationFlow(with invitation: Invitation) {
-        guard let homeCoordinator = self.findCoordinator(type: .home) as? DefaultHomeCoordinator else { return }
-        
-        let settingCoordinator = self.findCoordinator(type: .setting) as? DefaultRunningSettingCoordinator ??
-        DefaultRunningSettingCoordinator(homeCoordinator.navigationController)
-        homeCoordinator.childCoordinators.append(settingCoordinator)
-        settingCoordinator.finishDelegate = homeCoordinator
-        settingCoordinator.settingFinishDelegate = homeCoordinator
-        
-        let useCase = DefaultInvitationUseCase(invitation: invitation)
-        let viewModel = InvitationViewModel(settingCoordinator: settingCoordinator, invitationUseCase: useCase)
-        let viewController = InvitationViewController(
-            mate: invitation.host,
-            mode: invitation.mode,
-            distance: invitation.targetDistance
-        )
-        viewController.viewModel = viewModel
-        viewController.modalPresentationStyle = .fullScreen
-        
-        settingCoordinator.navigationController.pushViewController(viewController, animated: false)
-    }
 }
 
 extension DefaultAppCoordinator: CoordinatorFinishDelegate {

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol InvitationDidAcceptDelegate: AnyObject {
+    func invitationDidAccept(with runningSetting: RunningSetting)
+}
+
 final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
@@ -16,7 +20,7 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
-        self.tabBarController = .init()
+        self.tabBarController = UITabBarController()
     }
     
     func start() {
@@ -28,7 +32,7 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
     }
     
     func currentPage() -> TabBarPage? {
-        TabBarPage.init(index: self.tabBarController.selectedIndex)
+        TabBarPage(index: self.tabBarController.selectedIndex)
     }
     
     func selectPage(_ page: TabBarPage) {
@@ -77,19 +81,30 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
         case .mate:
             let mateCoordinator = DefaultMateCoordinator(tabNavigationController)
             mateCoordinator.finishDelegate = self
+            mateCoordinator.invitationDidAcceptDelegate = self
             self.childCoordinators.append(mateCoordinator)
             mateCoordinator.start()
         case .record:
             let recordCoordinator = DefaultRecordCoordinator(tabNavigationController)
             recordCoordinator.finishDelegate = self
+            recordCoordinator.invitationDidAcceptDelegate = self
             self.childCoordinators.append(recordCoordinator)
             recordCoordinator.start()
         case .mypage:
             let myPageCoordinator = DefaultMyPageCoordinator(tabNavigationController)
             myPageCoordinator.finishDelegate = self
+            myPageCoordinator.invitationDidAcceptDelegate = self
             self.childCoordinators.append(myPageCoordinator)
             myPageCoordinator.start()
         }
+    }
+}
+
+extension DefaultTabBarCoordinator: InvitationDidAcceptDelegate {
+    func invitationDidAccept(with runningSetting: RunningSetting) {
+        guard let homeCoordinator = self.findCoordinator(type: .home) as? HomeCoordinator else { return }
+        self.selectPage(.home)
+        homeCoordinator.startRunningFromNotification(with: runningSetting)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -20,8 +20,8 @@ final class DefaultTabBarCoordinator: NSObject, TabBarCoordinator {
         super.init()
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(invitationDidRecieve(_:)),
-            name: NotificationCenterKey.invitationDidRecieve,
+            selector: #selector(invitationDidReceive(_:)),
+            name: NotificationCenterKey.invitationDidReceive,
             object: nil
         )
     }
@@ -121,7 +121,7 @@ extension DefaultTabBarCoordinator: InvitationRecievable {
         self.navigationController.dismiss(animated: true)
     }
     
-    @objc func invitationDidRecieve(_ notification: Notification) {
+    @objc func invitationDidReceive(_ notification: Notification) {
         guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
         let invitationViewController = InvitationViewController()
         self.configureInvitationViewController(invitationViewController, invitation: invitation)

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -133,7 +133,6 @@ extension DefaultTabBarCoordinator: InvitationRecievable {
         let useCase = DefaultInvitationUseCase(invitation: invitation)
         let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
         viewController.viewModel = viewModel
-        viewController.modalPresentationStyle = .fullScreen
         viewController.modalPresentationStyle = .overFullScreen
         viewController.hidesBottomBarWhenPushed = true
         viewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/DefaultTabBarCoordinator.swift
@@ -109,7 +109,7 @@ extension DefaultTabBarCoordinator: CoordinatorFinishDelegate {
     }
 }
 
-extension DefaultTabBarCoordinator: InvitationRecievable {
+extension DefaultTabBarCoordinator: InvitationReceivable {
     func invitationDidAccept(with settingData: RunningSetting) {
         self.navigationController.dismiss(animated: true)
         self.selectPage(.home)

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/AppCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/AppCoordinator.swift
@@ -10,5 +10,4 @@ import Foundation
 protocol AppCoordinator: Coordinator {
     func showLoginFlow()
     func showTabBarFlow()
-    func showInvitationFlow(with: Invitation)
 }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/Coordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/Coordinator.swift
@@ -26,11 +26,16 @@ extension Coordinator {
     }
     
     func findCoordinator(type: CoordinatorType) -> Coordinator? {
-        for child in self.childCoordinators {
-            if child.type == type {
-                return child
+        var stack: [Coordinator] = [self]
+        
+        while !stack.isEmpty {
+            let currentCoordinator = stack.removeLast()
+            if currentCoordinator.type == type {
+                return currentCoordinator
             }
-            return child.findCoordinator(type: type)
+            currentCoordinator.childCoordinators.forEach({ child in
+                stack.append(child)
+            })   
         }
         return nil
     }

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/InvitationReceivable.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/InvitationReceivable.swift
@@ -1,0 +1,14 @@
+//
+//  InvitationReceivable.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/28.
+//
+
+import Foundation
+
+protocol InvitationReceivable: AnyObject {
+    func invitationDidReceive(_ notification: Notification)
+    func invitationDidAccept(with settingData: RunningSetting)
+    func invitationDidReject()
+}

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/TabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/TabBarCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol TabBarCoordinator: Coordinator, InvitationRecievable {
+protocol TabBarCoordinator: Coordinator, InvitationReceivable {
     var tabBarController: UITabBarController { get set }
     func selectPage(_ page: TabBarPage)
     func setSelectedIndex(_ index: Int)

--- a/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/TabBarCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/Common/Coordinator/Protocol/TabBarCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol TabBarCoordinator: Coordinator {
+protocol TabBarCoordinator: Coordinator, InvitationRecievable {
     var tabBarController: UITabBarController { get set }
     func selectPage(_ page: TabBarPage)
     func setSelectedIndex(_ index: Int)

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
@@ -63,11 +63,7 @@ private extension InvitationViewController {
 
     }
     
-    func configureUI() {
-        self.tabBarController?.tabBar.isHidden = true
-        self.view.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-        self.view.isOpaque = false
-        
+    func configureUI() {        
         self.view.addSubview(invitationView)
         self.invitationView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()

--- a/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewController/InvitationViewController.swift
@@ -15,16 +15,6 @@ final class InvitationViewController: UIViewController {
     private lazy var invitationView = InvitationView()
     private let disposeBag = DisposeBag()
     
-    init(mate: String, mode: RunningMode, distance: Double) {
-        super.init(nibName: nil, bundle: nil)
-        self.invitationView = InvitationView(mate: mate, mode: mode, distance: distance)
-    }
-    
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        self.configureUI()
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
@@ -37,30 +27,22 @@ final class InvitationViewController: UIViewController {
 private extension InvitationViewController {
     func bindViewModel() {
         let input = InvitationViewModel.Input(
-            viewDidLoadEvent: Observable.just(()),
             acceptButtonDidTapEvent: self.invitationView.acceptButton.rx.tap.asObservable(),
             rejectButtonDidTapEvent: self.invitationView.rejectButton.rx.tap.asObservable())
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
+        guard let output = output else { return }
+    
+        self.invitationView.updateTitleLabel(with: output.host)
+        self.invitationView.updateModeLabel(with: output.mode)
+        self.invitationView.updateDistanceLabel(with: output.targetDistance)
         
-        Driver.zip(
-            output?.host.asDriver(onErrorJustReturn: "") ?? Driver.just(""),
-            output?.mode.asDriver(onErrorJustReturn: .team) ?? Driver.just(.team),
-            output?.targetDistance.asDriver(onErrorJustReturn: 0) ?? Driver.just(0)
-        ).asDriver(onErrorJustReturn: ("", .team, 0))
-            .drive { host, mode, targetDistance in
-                self.invitationView.updateLabelText(mate: host, mode: mode, distance: targetDistance)
-            }
+        output.cancelledAlertShouldShow
+            .filter { $0 }
+            .subscribe(onNext: { [weak self] _ in
+                self?.showAlert(message: "취소된 달리기입니다.")
+            })
             .disposed(by: self.disposeBag)
-        
-        output?.cancelledAlertShouldShow.subscribe(
-            onNext: { [weak self] cancelledAlertShouldShow in
-                if cancelledAlertShouldShow {
-                    self?.showAlert(message: "취소된 달리기입니다.")
-                }
-        })
-            .disposed(by: self.disposeBag)
-
     }
     
     func configureUI() {        

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -21,34 +21,24 @@ final class InvitationViewModel {
     }
 
     struct Input {
-        let viewDidLoadEvent: Observable<Void>
         let acceptButtonDidTapEvent: Observable<Void>
         let rejectButtonDidTapEvent: Observable<Void>
     }
 
     struct Output {
-        var host: PublishRelay<String> = PublishRelay<String>()
-        var mode: PublishRelay<RunningMode> = PublishRelay<RunningMode>()
-        var targetDistance: PublishRelay<Double> = PublishRelay<Double>()
+        var host: String
+        var mode: String
+        var targetDistance: String
         var cancelledAlertShouldShow: PublishRelay<Bool> = PublishRelay<Bool>()
     }
 
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output()
-
-        let invitation = input.viewDidLoadEvent.map { self.invitationUseCase.invitation }
-
-        invitation.map { $0.host }
-        .bind(to: output.host)
-        .disposed(by: disposeBag)
-
-        invitation.map { $0.mode }
-        .bind(to: output.mode)
-        .disposed(by: disposeBag)
-
-        invitation.map { $0.targetDistance }
-        .bind(to: output.targetDistance)
-        .disposed(by: disposeBag)
+        let invitation = self.invitationUseCase.invitation
+        let output = Output(
+            host: invitation.host,
+            mode: "\(invitation.mode == .team ? "🤝": "🤜") \(invitation.mode.title)",
+            targetDistance: invitation.targetDistance.totalDistanceString
+        )
         
         input.acceptButtonDidTapEvent.subscribe(onNext: { [weak self] in
             guard let self = self else { return }

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -11,12 +11,12 @@ import RxRelay
 import RxSwift
 
 final class InvitationViewModel {
-    private weak var settingCoordinator: RunningSettingCoordinator?
+    private weak var coordinator: AppCoordinator?
     private let invitationUseCase: InvitationUseCase
     private let disposeBag = DisposeBag()
 
-    init(settingCoordinator: RunningSettingCoordinator, invitationUseCase: InvitationUseCase) {
-        self.settingCoordinator = settingCoordinator
+    init(coordinator: AppCoordinator, invitationUseCase: InvitationUseCase) {
+        self.coordinator = coordinator
         self.invitationUseCase = invitationUseCase
     }
 
@@ -78,13 +78,13 @@ final class InvitationViewModel {
     }
     
     func finish() {
-        self.settingCoordinator?.finish()
+        self.coordinator?.finish()
     }
     
     private func acceptInvitation() {
         self.invitationUseCase.acceptInvitation()
             .subscribe(onNext: { _ in
-                self.settingCoordinator?.pushRunningPreparationViewController(
+                self.coordinator?.startRunning(
                     with: self.invitationUseCase.invitation.toRunningSetting()
                 )
             })

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -11,11 +11,11 @@ import RxRelay
 import RxSwift
 
 final class InvitationViewModel {
-    private weak var coordinator: AppCoordinator?
+    private weak var coordinator: InvitationRecievable?
     private let invitationUseCase: InvitationUseCase
     private let disposeBag = DisposeBag()
 
-    init(coordinator: AppCoordinator, invitationUseCase: InvitationUseCase) {
+    init(coordinator: InvitationRecievable, invitationUseCase: InvitationUseCase) {
         self.coordinator = coordinator
         self.invitationUseCase = invitationUseCase
     }
@@ -78,15 +78,13 @@ final class InvitationViewModel {
     }
     
     func finish() {
-        self.coordinator?.finish()
+        self.coordinator?.invitationDidReject()
     }
     
     private func acceptInvitation() {
         self.invitationUseCase.acceptInvitation()
             .subscribe(onNext: { _ in
-                self.coordinator?.startRunning(
-                    with: self.invitationUseCase.invitation.toRunningSetting()
-                )
+                self.coordinator?.invitationDidAccept(with: self.invitationUseCase.invitation.toRunningSetting())
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -74,7 +74,9 @@ final class InvitationViewModel {
     private func acceptInvitation() {
         self.invitationUseCase.acceptInvitation()
             .subscribe(onNext: { _ in
-                self.coordinator?.invitationDidAccept(with: self.invitationUseCase.invitation.toRunningSetting())
+                self.coordinator?.invitationDidAccept(
+                    with: self.invitationUseCase.invitation.toRunningSetting()
+                )
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/InvitationViewModel.swift
@@ -11,11 +11,11 @@ import RxRelay
 import RxSwift
 
 final class InvitationViewModel {
-    private weak var coordinator: InvitationRecievable?
+    private weak var coordinator: InvitationReceivable?
     private let invitationUseCase: InvitationUseCase
     private let disposeBag = DisposeBag()
 
-    init(coordinator: InvitationRecievable, invitationUseCase: InvitationUseCase) {
+    init(coordinator: InvitationReceivable, invitationUseCase: InvitationUseCase) {
         self.coordinator = coordinator
         self.invitationUseCase = invitationUseCase
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -103,11 +103,7 @@ extension DefaultHomeCoordinator: InvitationRecievable {
     func invitationDidRecieve(invitation: Invitation) {
         let useCase = DefaultInvitationUseCase(invitation: invitation)
         let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController(
-            mate: invitation.host,
-            mode: invitation.mode,
-            distance: invitation.targetDistance
-        )
+        let invitationViewController = InvitationViewController()
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
         invitationViewController.modalPresentationStyle = .overFullScreen

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -26,7 +26,7 @@ final class DefaultHomeCoordinator: HomeCoordinator {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(notiDidRecieve(_:)),
-            name: Notification.Name("noti"),
+            name: NotificationCenterKey.invitationDidRecieve,
             object: nil
         )
     }
@@ -96,7 +96,7 @@ extension DefaultHomeCoordinator: InvitationRecievable {
     }
     
     @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
+        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
         self.invitationDidRecieve(invitation: invitation)
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -85,6 +85,16 @@ extension DefaultHomeCoordinator: SettingCoordinatorDidFinishDelegate {
 }
 
 extension DefaultHomeCoordinator: InvitationRecievable {
+    func invitationDidAccept(with settingData: RunningSetting) {
+        self.startRunningFromNotification(with: settingData)
+        self.navigationController.tabBarController?.tabBar.isHidden = true
+        self.navigationController.dismiss(animated: true)
+    }
+    
+    func invitationDidReject() {
+        self.navigationController.dismiss(animated: true)
+    }
+    
     @objc func notiDidRecieve(_ notification: Notification) {
         guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
         self.invitationDidRecieve(invitation: invitation)
@@ -100,7 +110,7 @@ extension DefaultHomeCoordinator: InvitationRecievable {
         )
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overCurrentContext
+        invitationViewController.modalPresentationStyle = .overFullScreen
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false
@@ -108,13 +118,4 @@ extension DefaultHomeCoordinator: InvitationRecievable {
         self.navigationController.present(invitationViewController, animated: true)
     }
     
-    func invitationDidAccept(with settingData: RunningSetting) {
-        self.startRunningFromNotification(with: settingData)
-        self.navigationController.tabBarController?.tabBar.isHidden = true
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    func invitationDidReject() {
-        self.navigationController.dismiss(animated: true)
-    }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -7,12 +7,6 @@
 
 import UIKit
 
-protocol InvitationRecievable: AnyObject {
-    func invitationDidRecieve(_ notification: Notification)
-    func invitationDidAccept(with settingData: RunningSetting)
-    func invitationDidReject()
-}
-
 final class DefaultHomeCoordinator: HomeCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -7,8 +7,10 @@
 
 import UIKit
 
-protocol InvitationRecievable: Coordinator {
+protocol InvitationRecievable: AnyObject {
     func invitationDidRecieve(invitation: Invitation)
+    func invitationDidAccept(with settingData: RunningSetting)
+    func invitationDidReject()
 }
 
 final class DefaultHomeCoordinator: HomeCoordinator {
@@ -37,6 +39,13 @@ final class DefaultHomeCoordinator: HomeCoordinator {
         self.navigationController.pushViewController(self.homeViewController, animated: true)
     }
     
+    func start(with settingData: RunningSetting) {
+        let settingCoordinator = DefaultRunningSettingCoordinator(self.navigationController)
+        settingCoordinator.finishDelegate = self
+        settingCoordinator.settingFinishDelegate = self
+        self.childCoordinators.append(settingCoordinator)
+    }
+    
     func showSettingFlow() {
         let settingCoordinator = DefaultRunningSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self
@@ -50,6 +59,14 @@ final class DefaultHomeCoordinator: HomeCoordinator {
         runningCoordinator.finishDelegate = self
         self.childCoordinators.append(runningCoordinator)
         runningCoordinator.pushRunningViewController(with: initialSettingData)
+    }
+    
+    func startRunningFromNotification(with settingData: RunningSetting) {
+        let settingCoordinator = DefaultRunningSettingCoordinator(self.navigationController)
+        settingCoordinator.finishDelegate = self
+        settingCoordinator.settingFinishDelegate = self
+        self.childCoordinators.append(settingCoordinator)
+        settingCoordinator.pushRunningPreparationViewController(with: settingData)
     }
 }
 
@@ -87,7 +104,17 @@ extension DefaultHomeCoordinator: InvitationRecievable {
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false
-        
+
         self.navigationController.present(invitationViewController, animated: true)
+    }
+    
+    func invitationDidAccept(with settingData: RunningSetting) {
+        self.startRunningFromNotification(with: settingData)
+        self.navigationController.tabBarController?.tabBar.isHidden = true
+        self.navigationController.dismiss(animated: true)
+    }
+    
+    func invitationDidReject() {
+        self.navigationController.dismiss(animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultHomeCoordinator.swift
@@ -87,6 +87,7 @@ extension DefaultHomeCoordinator: InvitationRecievable {
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false
-        self.navigationController.viewControllers.last?.present(invitationViewController, animated: true)
+        
+        self.navigationController.present(invitationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -111,6 +111,7 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             ),
             runningPreparationUseCase: DefaultRunningPreparationUseCase()
         )
+        self.navigationController.tabBarController?.tabBar.isHidden = true
         self.navigationController.pushViewController(runningPreparationViewController, animated: true)
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-protocol HomeCoordinator: Coordinator, InvitationRecievable {
+protocol HomeCoordinator: Coordinator {
     func showSettingFlow()
     func showRunningFlow(with initialSettingData: RunningSetting)
-    func startRunningFromNotification(with settingData: RunningSetting)
+    func startRunningFromInvitation(with settingData: RunningSetting)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol HomeCoordinator: Coordinator {
+protocol HomeCoordinator: Coordinator, InvitationRecievable {
     func showSettingFlow()
     func showRunningFlow(with initialSettingData: RunningSetting)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/Protocol/HomeCoordinator.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol HomeCoordinator: Coordinator, InvitationRecievable {
     func showSettingFlow()
     func showRunningFlow(with initialSettingData: RunningSetting)
+    func startRunningFromNotification(with settingData: RunningSetting)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
@@ -56,25 +56,34 @@ final class InvitationView: UIView {
     private lazy var descriptionDistanceLabel = self.createDescriptionLabel(text: "목표거리")
     lazy var rejectButton = self.createInviteButton(text: "거절", color: .mrGray)
     lazy var acceptButton = self.createInviteButton(text: "수락", color: .mrPurple)
-    
-    convenience init(mate: String, mode: RunningMode, distance: Double) {
-        self.init(frame: .zero)
-        self.configureUI(mate: mate, mode: mode, distance: distance)
+
+    func updateTitleLabel(with mateNickname: String) {
+        self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mateNickname)님의\n초대가 도착했습니다!"
     }
     
-    func updateLabelText(mate: String, mode: RunningMode, distance: Double) {
-        self.titleLabel.text = "🏃‍♂️🏃‍♀️\n메이트 \(mate)님의\n초대가 도착했습니다!"
-        self.runningModeLabel.text = "\(mode == .team ? "🤝": "🤜") \(mode.title)"
-        self.distanceLabel.text = distance.string()
+    func updateDistanceLabel(with distance: String) {
+        self.distanceLabel.text = distance
+    }
+    
+    func updateModeLabel(with mode: String) {
+        self.runningModeLabel.text = mode
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureUI()
     }
 }
 
 // MARK: - Private Functions
 
 private extension InvitationView {
-    func configureUI(mate: String, mode: RunningMode, distance: Double) {
-        self.updateLabelText(mate: mate, mode: mode, distance: distance)
-        
+    func configureUI() {
         self.layer.masksToBounds = true
         self.layer.cornerRadius = 10
         self.backgroundColor = .white

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -16,6 +16,7 @@ import SnapKit
 final class HomeViewController: UIViewController {
     var disposeBag = DisposeBag()
     var viewModel: HomeViewModel?
+    var invitationViewController: InvitationViewController?
     
     private lazy var gradientLayer: CAGradientLayer = {
         let layer = CAGradientLayer()
@@ -65,6 +66,13 @@ final class HomeViewController: UIViewController {
         super.viewWillAppear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
         self.tabBarController?.tabBar.isHidden = false
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if let invitationViewController = invitationViewController {
+            self.navigationController?.present(invitationViewController, animated: true)
+        }
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -91,7 +91,7 @@ extension DefaultMateCoordinator: InvitationRecievable {
         )
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overCurrentContext
+        invitationViewController.modalPresentationStyle = .overFullScreen
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -66,6 +66,14 @@ extension DefaultMateCoordinator: CoordinatorFinishDelegate {
 }
 
 extension DefaultMateCoordinator: InvitationRecievable {
+    func invitationDidAccept(with settingData: RunningSetting) {
+        //
+    }
+    
+    func invitationDidReject() {
+        self.navigationController.dismiss(animated: true)
+    }
+    
     @objc func notiDidRecieve(_ notification: Notification) {
         guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
         self.invitationDidRecieve(invitation: invitation)

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -84,11 +84,7 @@ extension DefaultMateCoordinator: InvitationRecievable {
     func invitationDidRecieve(invitation: Invitation) {
         let useCase = DefaultInvitationUseCase(invitation: invitation)
         let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController(
-            mate: invitation.host,
-            mode: invitation.mode,
-            distance: invitation.targetDistance
-        )
+        let invitationViewController = InvitationViewController()
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
         invitationViewController.modalPresentationStyle = .overFullScreen

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class DefaultMateCoordinator: MateCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
+    weak var invitationDidAcceptDelegate: InvitationDidAcceptDelegate?
     var navigationController: UINavigationController
     var mateViewController: MateViewController
     var childCoordinators: [Coordinator] = []
@@ -67,7 +68,8 @@ extension DefaultMateCoordinator: CoordinatorFinishDelegate {
 
 extension DefaultMateCoordinator: InvitationRecievable {
     func invitationDidAccept(with settingData: RunningSetting) {
-        //
+        self.invitationDidAcceptDelegate?.invitationDidAccept(with: settingData)
+        self.navigationController.dismiss(animated: true)
     }
     
     func invitationDidReject() {

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class DefaultMateCoordinator: MateCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
-    weak var invitationDidAcceptDelegate: InvitationDidAcceptDelegate?
     var navigationController: UINavigationController
     var mateViewController: MateViewController
     var childCoordinators: [Coordinator] = []
@@ -18,12 +17,6 @@ final class DefaultMateCoordinator: MateCoordinator {
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.mateViewController = MateViewController()
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(notiDidRecieve(_:)),
-            name: NotificationCenterKey.invitationDidRecieve,
-            object: nil
-        )
     }
     
     func start() {
@@ -63,35 +56,5 @@ extension DefaultMateCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators
             .filter { $0.type != childCoordinator.type }
-    }
-}
-
-extension DefaultMateCoordinator: InvitationRecievable {
-    func invitationDidAccept(with settingData: RunningSetting) {
-        self.invitationDidAcceptDelegate?.invitationDidAccept(with: settingData)
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    func invitationDidReject() {
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
-        self.invitationDidRecieve(invitation: invitation)
-    }
-    
-    func invitationDidRecieve(invitation: Invitation) {
-        let useCase = DefaultInvitationUseCase(invitation: invitation)
-        let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController()
-        invitationViewController.viewModel = viewModel
-        invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overFullScreen
-        invitationViewController.hidesBottomBarWhenPushed = true
-        invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
-        invitationViewController.view.isOpaque = false
-        
-        self.navigationController.viewControllers.last?.present(invitationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -17,6 +17,12 @@ final class DefaultMateCoordinator: MateCoordinator {
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.mateViewController = MateViewController()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notiDidRecieve(_:)),
+            name: Notification.Name("noti"),
+            object: nil
+        )
     }
     
     func start() {
@@ -56,5 +62,29 @@ extension DefaultMateCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators
             .filter { $0.type != childCoordinator.type }
+    }
+}
+
+extension DefaultMateCoordinator: InvitationRecievable {
+    @objc func notiDidRecieve(_ notification: Notification) {
+        guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
+        self.invitationDidRecieve(invitation: invitation)
+    }
+    
+    func invitationDidRecieve(invitation: Invitation) {
+        let useCase = DefaultInvitationUseCase(invitation: invitation)
+        let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
+        let invitationViewController = InvitationViewController(
+            mate: invitation.host,
+            mode: invitation.mode,
+            distance: invitation.targetDistance
+        )
+        invitationViewController.viewModel = viewModel
+        invitationViewController.modalPresentationStyle = .fullScreen
+        invitationViewController.modalPresentationStyle = .overCurrentContext
+        invitationViewController.hidesBottomBarWhenPushed = true
+        invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
+        invitationViewController.view.isOpaque = false
+        self.navigationController.viewControllers.last?.present(invitationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -21,7 +21,7 @@ final class DefaultMateCoordinator: MateCoordinator {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(notiDidRecieve(_:)),
-            name: Notification.Name("noti"),
+            name: NotificationCenterKey.invitationDidRecieve,
             object: nil
         )
     }
@@ -77,7 +77,7 @@ extension DefaultMateCoordinator: InvitationRecievable {
     }
     
     @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
+        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
         self.invitationDidRecieve(invitation: invitation)
     }
     
@@ -91,6 +91,7 @@ extension DefaultMateCoordinator: InvitationRecievable {
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false
+        
         self.navigationController.viewControllers.last?.present(invitationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class DefaultMyPageCoordinator: MyPageCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
-    weak var invitationDidAcceptDelegate: InvitationDidAcceptDelegate?
     var navigationController: UINavigationController
     var myPageViewController: MyPageViewController
     var childCoordinators: [Coordinator] = []
@@ -18,12 +17,6 @@ final class DefaultMyPageCoordinator: MyPageCoordinator {
     init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.myPageViewController = MyPageViewController()
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(notiDidRecieve(_:)),
-            name: NotificationCenterKey.invitationDidRecieve,
-            object: nil
-        )
     }
     
     func start() {
@@ -68,34 +61,5 @@ extension DefaultMyPageCoordinator: CoordinatorFinishDelegate {
         self.childCoordinators = self.childCoordinators
             .filter({ $0.type != childCoordinator.type })
         childCoordinator.navigationController.popToRootViewController(animated: true)
-    }
-}
-
-extension DefaultMyPageCoordinator: InvitationRecievable {
-    func invitationDidAccept(with settingData: RunningSetting) {
-        self.invitationDidAcceptDelegate?.invitationDidAccept(with: settingData)
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    func invitationDidReject() {
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
-        self.invitationDidRecieve(invitation: invitation)
-    }
-    
-    func invitationDidRecieve(invitation: Invitation) {
-        let useCase = DefaultInvitationUseCase(invitation: invitation)
-        let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController()
-        invitationViewController.viewModel = viewModel
-        invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overFullScreen
-        invitationViewController.hidesBottomBarWhenPushed = true
-        invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
-        invitationViewController.view.isOpaque = false
-        self.navigationController.viewControllers.last?.present(invitationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class DefaultMyPageCoordinator: MyPageCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
+    weak var invitationDidAcceptDelegate: InvitationDidAcceptDelegate?
     var navigationController: UINavigationController
     var myPageViewController: MyPageViewController
     var childCoordinators: [Coordinator] = []
@@ -72,7 +73,8 @@ extension DefaultMyPageCoordinator: CoordinatorFinishDelegate {
 
 extension DefaultMyPageCoordinator: InvitationRecievable {
     func invitationDidAccept(with settingData: RunningSetting) {
-        //
+        self.invitationDidAcceptDelegate?.invitationDidAccept(with: settingData)
+        self.navigationController.dismiss(animated: true)
     }
     
     func invitationDidReject() {

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -71,6 +71,14 @@ extension DefaultMyPageCoordinator: CoordinatorFinishDelegate {
 }
 
 extension DefaultMyPageCoordinator: InvitationRecievable {
+    func invitationDidAccept(with settingData: RunningSetting) {
+        //
+    }
+    
+    func invitationDidReject() {
+        self.navigationController.dismiss(animated: true)
+    }
+    
     @objc func notiDidRecieve(_ notification: Notification) {
         guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
         self.invitationDidRecieve(invitation: invitation)

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -21,7 +21,7 @@ final class DefaultMyPageCoordinator: MyPageCoordinator {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(notiDidRecieve(_:)),
-            name: Notification.Name("noti"),
+            name: NotificationCenterKey.invitationDidRecieve,
             object: nil
         )
     }
@@ -82,7 +82,7 @@ extension DefaultMyPageCoordinator: InvitationRecievable {
     }
     
     @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
+        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
         self.invitationDidRecieve(invitation: invitation)
     }
     

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -89,11 +89,7 @@ extension DefaultMyPageCoordinator: InvitationRecievable {
     func invitationDidRecieve(invitation: Invitation) {
         let useCase = DefaultInvitationUseCase(invitation: invitation)
         let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController(
-            mate: invitation.host,
-            mode: invitation.mode,
-            distance: invitation.targetDistance
-        )
+        let invitationViewController = InvitationViewController()
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
         invitationViewController.modalPresentationStyle = .overFullScreen

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -96,7 +96,7 @@ extension DefaultMyPageCoordinator: InvitationRecievable {
         )
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overCurrentContext
+        invitationViewController.modalPresentationStyle = .overFullScreen
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -58,6 +58,14 @@ extension DefaultRecordCoordinator: CoordinatorFinishDelegate {
 }
 
 extension DefaultRecordCoordinator: InvitationRecievable {
+    func invitationDidAccept(with settingData: RunningSetting) {
+        //
+    }
+    
+    func invitationDidReject() {
+        self.navigationController.dismiss(animated: true)
+    }
+    
     @objc func notiDidRecieve(_ notification: Notification) {
         guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
         self.invitationDidRecieve(invitation: invitation)
@@ -77,6 +85,7 @@ extension DefaultRecordCoordinator: InvitationRecievable {
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false
-        self.navigationController.viewControllers.last?.present(invitationViewController, animated: true)
+
+        self.navigationController.present(invitationViewController, animated: true)
     }
 }

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -21,7 +21,7 @@ final class DefaultRecordCoordinator: RecordCoordinator {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(notiDidRecieve(_:)),
-            name: Notification.Name("noti"),
+            name: NotificationCenterKey.invitationDidRecieve,
             object: nil
         )
     }
@@ -69,7 +69,7 @@ extension DefaultRecordCoordinator: InvitationRecievable {
     }
     
     @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?["invitation"] as? Invitation else {return}
+        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
         self.invitationDidRecieve(invitation: invitation)
     }
     

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class DefaultRecordCoordinator: RecordCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
+    weak var invitationDidAcceptDelegate: InvitationDidAcceptDelegate?
     var navigationController: UINavigationController
     var recordViewController: RecordViewController
     var childCoordinators: [Coordinator] = []
@@ -59,7 +60,8 @@ extension DefaultRecordCoordinator: CoordinatorFinishDelegate {
 
 extension DefaultRecordCoordinator: InvitationRecievable {
     func invitationDidAccept(with settingData: RunningSetting) {
-        //
+        self.invitationDidAcceptDelegate?.invitationDidAccept(with: settingData)
+        self.navigationController.dismiss(animated: true)
     }
     
     func invitationDidReject() {

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -83,7 +83,7 @@ extension DefaultRecordCoordinator: InvitationRecievable {
         )
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overCurrentContext
+        invitationViewController.modalPresentationStyle = .overFullScreen
         invitationViewController.hidesBottomBarWhenPushed = true
         invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
         invitationViewController.view.isOpaque = false

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -76,11 +76,7 @@ extension DefaultRecordCoordinator: InvitationRecievable {
     func invitationDidRecieve(invitation: Invitation) {
         let useCase = DefaultInvitationUseCase(invitation: invitation)
         let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController(
-            mate: invitation.host,
-            mode: invitation.mode,
-            distance: invitation.targetDistance
-        )
+        let invitationViewController = InvitationViewController()
         invitationViewController.viewModel = viewModel
         invitationViewController.modalPresentationStyle = .fullScreen
         invitationViewController.modalPresentationStyle = .overFullScreen

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class DefaultRecordCoordinator: RecordCoordinator {
     weak var finishDelegate: CoordinatorFinishDelegate?
-    weak var invitationDidAcceptDelegate: InvitationDidAcceptDelegate?
     var navigationController: UINavigationController
     var recordViewController: RecordViewController
     var childCoordinators: [Coordinator] = []
@@ -18,12 +17,6 @@ final class DefaultRecordCoordinator: RecordCoordinator {
     required init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.recordViewController = RecordViewController()
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(notiDidRecieve(_:)),
-            name: NotificationCenterKey.invitationDidRecieve,
-            object: nil
-        )
     }
     
     func start() {
@@ -54,36 +47,8 @@ final class DefaultRecordCoordinator: RecordCoordinator {
 
 extension DefaultRecordCoordinator: CoordinatorFinishDelegate {
     func coordinatorDidFinish(childCoordinator: Coordinator) {
-
-    }
-}
-
-extension DefaultRecordCoordinator: InvitationRecievable {
-    func invitationDidAccept(with settingData: RunningSetting) {
-        self.invitationDidAcceptDelegate?.invitationDidAccept(with: settingData)
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    func invitationDidReject() {
-        self.navigationController.dismiss(animated: true)
-    }
-    
-    @objc func notiDidRecieve(_ notification: Notification) {
-        guard let invitation = notification.userInfo?[NotificationCenterKey.invitation] as? Invitation else { return }
-        self.invitationDidRecieve(invitation: invitation)
-    }
-    
-    func invitationDidRecieve(invitation: Invitation) {
-        let useCase = DefaultInvitationUseCase(invitation: invitation)
-        let viewModel = InvitationViewModel(coordinator: self, invitationUseCase: useCase)
-        let invitationViewController = InvitationViewController()
-        invitationViewController.viewModel = viewModel
-        invitationViewController.modalPresentationStyle = .fullScreen
-        invitationViewController.modalPresentationStyle = .overFullScreen
-        invitationViewController.hidesBottomBarWhenPushed = true
-        invitationViewController.view.backgroundColor = UIColor(white: 0.4, alpha: 0.8)
-        invitationViewController.view.isOpaque = false
-
-        self.navigationController.present(invitationViewController, animated: true)
+        self.childCoordinators = self.childCoordinators
+            .filter({ $0.type != childCoordinator.type })
+        childCoordinator.navigationController.popToRootViewController(animated: true)
     }
 }

--- a/MateRunner/MateRunner/Resource/Info.plist
+++ b/MateRunner/MateRunner/Resource/Info.plist
@@ -5,7 +5,10 @@
 	<key>FCM_SERVER_KEY</key>
 	<string>$(FCM_SERVER_KEY)</string>
 	<key>NSAppTransportSecurity</key>
-	<dict/>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>RacingSansOne.ttf</string>

--- a/MateRunner/MateRunner/Util/Constant/NoticeMode.swift
+++ b/MateRunner/MateRunner/Util/Constant/NoticeMode.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum NoticeMode: String {
-    case invite = "invite"
+    case invite = "invititation"
     case requestMate = "requestMate"
     
     func text() -> String {

--- a/MateRunner/MateRunner/Util/Constant/NotificationCenterKey.swift
+++ b/MateRunner/MateRunner/Util/Constant/NotificationCenterKey.swift
@@ -1,0 +1,20 @@
+//
+//  NotificationCenterKey.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/28.
+//
+
+import Foundation
+
+enum NotificationCenterKey {
+    static let invitationDidReceive = Notification.Name("invitationDidReceive")
+    static let invitation = "invitation"
+    static let sessionID = "sessionId"
+    static let host = "host"
+    static let mate = "mate"
+    static let inviteTime = "inviteTime"
+    static let mode = "mode"
+    static let targetDistance = "targetDistance"
+    static let sender = "sender"
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #241 
Close #238 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 모든 화면에서 달리기 초대 팝업을 볼 수 있도록 구현  
- [x] 달리기 요청 팝업을 모달로 지정하고 반투명으로 설정해서 배경이 보이도록 구현
- [x] 친구요청 알림 탭 이후에 앱 내 알림센터로 이동하도록 구현

- 앱이 완전히 종료된 상태에서 푸시 알림 탭하기

https://user-images.githubusercontent.com/46087477/143691659-3da9a069-4890-4dcf-a628-583720d607d8.MP4

- 홈 이외 화면에서 푸시 알림 탭 이후 초대 거절

https://user-images.githubusercontent.com/46087477/143691629-a33b632b-eab3-4c75-85ec-baa1eaceea30.MP4

- 홈 이외 화면에서 푸시 알림 탭 이후 초대 수락 

https://user-images.githubusercontent.com/46087477/143691626-971999f5-0d02-4523-b9b9-6d12b22e1ca4.MP4

- 앱 내에서 메이트 요청 알림 탭

https://user-images.githubusercontent.com/46087477/143691622-ea634dab-d614-46d6-baf9-4ef9a3033700.MP4

- 앱이 종료된 상황에서 메이트 요청 알림 탭 

https://user-images.githubusercontent.com/46087477/143691618-05a5e88c-0331-4074-b5db-5cdbe1e27881.MP4


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 모든 화면에 초대장을 띄우고 수락 시 이동 구현 내용

<img width="900" alt="스크린샷 2021-11-28 오전 3 02 46" src="https://user-images.githubusercontent.com/46087477/143691933-d5fb2c6e-dbef-4e04-8915-cbab82b58a08.png">

그림과 같이 구현했습니다..! AppDelegate에서 알림이 수신되면 호출되는 delegate 메서드에 NotificationPost를 넣어두었고 이를 수신하는 객체는 TabBarCoordinator 입니다. 탭바 코디네이터는 초대장이 들어오면 자기자신에 초대장 뷰 컨트롤러를 present 합니다.

```swift
self.tabBarController.present(invitationViewController, animated: true)
```

이때 사용자가 초대장의 거절을 탭하면 그냥 dismiss시키고, 수락을 탭하면 dismiss하면서 탭바 코디네이터가 가지고 있는 탭바컨트롤러의 현재 탭을 home 탭으로 변경해주고 home 코디네이터에 정의된 RunningPreparation부터 세팅을 시작하는 메서드를 호출합니다. 이 이후부터는 SettingFlow를 그대로 따르기 때문에 기존 달리기와 동일하게 진행됩니다.

```swift
    func invitationDidAccept(with settingData: RunningSetting) {
        self.navigationController.dismiss(animated: true)
        self.selectPage(.home)
        let homeCooridnator = self.findCoordinator(type: .home) as? HomeCoordinator
        homeCooridnator?.startRunningFromInvitation(with: settingData)
    }
```

- 앱이 종료되었을 때 푸시알림 탭
앱이 종료되었다가 실행되었을 때는 SceneDelegate를 통해 구분하고 항상 홈 탭에 초대장을 띄울 수 있도록 했습니다. 푸시알림을 통해 앱이 실행되면 `connectionOptions.notificationResponse`에 푸시 알림의 정보가 들어오기 때문에 이를 Invitation으로 변환해서 화면에 띄워주었습니다. 수락/거절은 기존에 실행되고 있을 때와 같습니다.
```swift
func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        guard let windowScene = (scene as? UIWindowScene) else { return }
        let navigationController = UINavigationController()

        self.window = UIWindow(windowScene: windowScene)
        self.window?.tintColor = .mrPurple
        self.window?.rootViewController = navigationController
        self.window?.makeKeyAndVisible()

        self.appCoordinator = DefaultAppCoordinator(navigationController)
        self.appCoordinator?.start()

        guard let notificationResponse = connectionOptions.notificationResponse else { return }
        let userInfo = notificationResponse.notification.request.content.userInfo
        self.configureInvitation(with: userInfo)

        return
```

- 메이트 요청 알림
메이트 요청은 달리기와 비슷하게 구현했습니다. 화면을 많이 전환하거나 초대장 뷰를 띄울 필요가 없어서 훨씬 더 간단했어요! 지금은 마이페이지가 아직 작업중인 것 같아서 코디네이터 통합을 하지 않았는데, 마이페이지 작업이 끝나면 한번에 작업할 예정입니다.

- findCoordinator 수정 
기존에 DFS로 구현된 자식 코디네이터를 찾는 로직에 사소한 오류가 있었습니다. 리뷰때 제대로 확인못해서 죄송합니다ㅠ
```swift
func findCoordinator(type: CoordinatorType) -> Coordinator? {
        for child in self.childCoordinators {
            if child.type == type {
                return child
            }
            return child.findCoordinator(type: type) // 항상 첫번째 자식 코디네이터만 확인하고 반환됨
        }
        return nil
    }
```
자식 재귀적으로 들어가긴 하지만 같은 레벨의 모든 sibling들을 다 확인하지 않고 하나만 확인한 뒤 반환하는 문제가 있어 bfs로 로직을 변경했습니다. 스위프트에 큐가 없는데 순서가 그렇게 중요하지는 않은 것 같아서 그냥 스택으로 구현했어요.
```swift
    func findCoordinator(type: CoordinatorType) -> Coordinator? {
        var stack: [Coordinator] = [self]

        while !stack.isEmpty {
            let currentCoordinator = stack.removeLast()
            if currentCoordinator.type == type {
                return currentCoordinator
            }
            currentCoordinator.childCoordinators.forEach({ child in
                stack.append(child)
            })   
        }
        return nil
    }
```
알린이라 저도 틀릴 수 있으니 틀렸으면 알려주세요..

- childcoordinators 에 대해서..
이전에 빈 배열을 계속 가지는 것에 대해서 피드백이 있었는데, 프로토콜에 포함을 안시키면 findCoordinator를 사용할 수 없을 것 같아요..



<br/><br/>
