### PR TITLE
REST로 특정 달에 대한 기록 받기

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/Record/DefaultRecordUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Record/DefaultRecordUseCase.swift
@@ -11,29 +11,30 @@ import RxSwift
 
 final class DefaultRecordUseCase: RecordUseCase {    
     private let userRepository: UserRepository
+    private let firestoreRepository: FirestoreRepository
     private let disposeBag = DisposeBag()
     private let nickname: String?
     
-    var time = PublishSubject<Int>()
-    var distance = PublishSubject<Double>()
-    var calorie = PublishSubject<Double>()
-    var userInfo = PublishSubject<UserProfileDTO>()
+    var totalRecord = PublishSubject<PersonalTotalRecord>()
     var month = BehaviorSubject<Date?>(value: Date().startOfMonth)
     var selectedDay = BehaviorSubject<Date?>(value: Date())
     var runningCount = PublishSubject<Int>()
     var likeCount = PublishSubject<Int>()
     var monthlyRecords = BehaviorSubject<[RunningResult]>(value: [])
     
-    init(userRepository: UserRepository) {
+    init(userRepository: UserRepository, firestoreRepository: FirestoreRepository) {
         self.userRepository = userRepository
+        self.firestoreRepository = firestoreRepository
         self.nickname = self.userRepository.fetchUserNickname()
     }
     
-    func loadCumulativeRecord() {
+    func loadTotalRecord() {
         guard let nickname = self.nickname else { return }
         
-        self.userRepository.fetchUserInfo(nickname)
-            .bind(to: self.userInfo)
+        self.firestoreRepository.fetchTotalPeronsalRecord(of: nickname)
+            .subscribe(onNext: { [weak self] totalRecord in
+                self?.totalRecord.onNext(totalRecord)
+            })
             .disposed(by: self.disposeBag)
     }
     
@@ -42,7 +43,23 @@ final class DefaultRecordUseCase: RecordUseCase {
     }
     
     func loadMonthlyRecord() {
-        // 나중에 한달에 대한 기록을 가져오면 여기에 구현할 예정
+        guard let nickname = self.nickname,
+              let currentMonth = try? self.month.value()?.startOfMonth,
+              let nextMonth = currentMonth.nextMonth?.startOfMonth else { return }
+        
+        self.firestoreRepository.fetchResult(of: nickname, from: currentMonth, to: nextMonth)
+            .subscribe(onNext: { [weak self] records in
+                guard let self = self else { return }
+                self.monthlyRecords.onNext(records)
+                self.selectedDay.onNext(try? self.selectedDay.value())
+                self.runningCount.onNext(records.count)
+                self.likeCount.onNext(self.getLikeCount(from: records))
+            }, onError: { [weak self] _ in
+                self?.monthlyRecords.onNext([])
+                self?.runningCount.onNext(0)
+                self?.likeCount.onNext(0)
+            })
+            .disposed(by: self.disposeBag)
     }
     
     func updateMonth(toNext: Bool) {
@@ -51,32 +68,6 @@ final class DefaultRecordUseCase: RecordUseCase {
         let updatedDate = toNext ? month.nextMonth?.startOfMonth : month.previousMonth?.startOfMonth
         self.selectedDay.onNext(updatedDate)
         self.month.onNext(updatedDate)
-    }
-    
-    func fetchRecordList() {
-        guard let nickname = self.nickname else { return }
-
-        self.userRepository.fetchRecordList(nickname)
-            .compactMap { [weak self] in
-                self?.resultToRecordList(from: $0)
-            }
-            .subscribe(onNext: { [weak self] list in
-                guard let self = self else { return }
-                self.monthlyRecords.onNext(list)
-                self.runningCount.onNext(list.count)
-                self.likeCount.onNext(self.getLikeCount(from: list))
-                self.selectedDay.onNext(try? self.selectedDay.value())
-            })
-            .disposed(by: self.disposeBag)
-    }
-    
-    private func resultToRecordList(from result: UserResultDTO) -> [RunningResult] {
-        var recordList: [RunningResult] = []
-        result.records.values.forEach { record in
-            recordList.append(record.toDomain())
-        }
-
-        return recordList
     }
                        
     private func getLikeCount(from list: [RunningResult]) -> Int {

--- a/MateRunner/MateRunner/Domain/UseCase/Record/Protocol/RecordUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Record/Protocol/RecordUseCase.swift
@@ -10,18 +10,14 @@ import Foundation
 import RxSwift
 
 protocol RecordUseCase {
-    var time: PublishSubject<Int> { get set }
-    var distance: PublishSubject<Double> { get set }
-    var calorie: PublishSubject<Double> { get set }
-    var userInfo: PublishSubject<UserProfileDTO> {get set }
+    var totalRecord: PublishSubject<PersonalTotalRecord> {get set }
     var month: BehaviorSubject<Date?> { get set }
     var selectedDay: BehaviorSubject<Date?> { get set }
     var runningCount: PublishSubject<Int> { get set }
     var likeCount: PublishSubject<Int> { get set }
     var monthlyRecords: BehaviorSubject<[RunningResult]> { get set }
-    func loadCumulativeRecord()
+    func loadTotalRecord()
     func refreshRecords()
     func loadMonthlyRecord()
     func updateMonth(toNext: Bool)
-    func fetchRecordList()
 }

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -25,6 +25,9 @@ final class DefaultRecordCoordinator: RecordCoordinator {
             recordUsecase: DefaultRecordUseCase(
                 userRepository: DefaultUserRepository(
                     networkService: DefaultFireStoreNetworkService()
+                ),
+                firestoreRepository: DefaultFirestoreRepository(
+                    urlSessionService: DefaultURLSessionNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
@@ -30,6 +30,14 @@ final class RecordViewController: UIViewController {
         return label
     }()
     
+    private lazy var emptyLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSans(size: 16, family: .medium)
+        label.text = "이 날의 달리기 기록이 없네요 ☺️"
+        label.isHidden = true
+        return label
+    }()
+    
     private lazy var refreshControl = UIRefreshControl()
     
     private lazy var tableView: UITableView = {
@@ -68,6 +76,12 @@ private extension RecordViewController {
         self.view.addSubview(self.tableView)
         self.tableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+        
+        self.tableView.addSubview(self.emptyLabel)
+        self.emptyLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.dateLabel.snp.bottom).offset(45)
         }
     }
     
@@ -201,6 +215,13 @@ private extension RecordViewController {
             ) { _, record, cell in
                 cell.updateUI(record: record)
             }
+            .disposed(by: self.disposeBag)
+        
+        output?.hasDailyRecords
+            .asDriver()
+            .debug()
+            .compactMap { $0 }
+            .drive(self.emptyLabel.rx.isHidden)
             .disposed(by: self.disposeBag)
     }
     

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
@@ -106,7 +106,7 @@ private extension RecordViewController {
     
     func bindViewModel() {
         let input = RecordViewModel.Input(
-            viewDidLoadEvent: Observable.just(()),
+            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map { _ in },
             refreshEvent: self.refreshControl.rx.controlEvent(.valueChanged).asObservable(),
             previousButtonDidTapEvent: self.calendarHeaderView.previousButton.rx.tap.asObservable(),
             nextButtonDidTapEvent: self.calendarHeaderView.nextButton.rx.tap.asObservable(),

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
@@ -129,7 +129,7 @@ private extension RecordViewController {
         )
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         
-        self.bindCumulativeRecord(output: output)
+        self.bindTotalRecord(output: output)
         self.bindCalendarHeader(output: output)
         self.bindCalendar(output: output)
         self.bindRecord(output: output)
@@ -142,7 +142,7 @@ private extension RecordViewController {
             .disposed(by: self.disposeBag)
     }
     
-    func bindCumulativeRecord(output: RecordViewModel.Output?) {
+    func bindTotalRecord(output: RecordViewModel.Output?) {
         output?.timeText
             .asDriver()
             .drive(self.cumulativeRecordView.timeLabel.rx.text)

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewController/RecordViewController.swift
@@ -158,9 +158,9 @@ private extension RecordViewController {
             .drive(self.cumulativeRecordView.calorieLabel.rx.text)
             .disposed(by: self.disposeBag)
         
-        output?.userInfoDidUpdate
+        output?.totalRecordDidUpdate
             .map { !$0 }
-            .asDriver(onErrorJustReturn: true)
+            .asDriver(onErrorJustReturn: false)
             .drive(self.refreshControl.rx.isRefreshing)
             .disposed(by: self.disposeBag)
     }
@@ -219,7 +219,6 @@ private extension RecordViewController {
         
         output?.hasDailyRecords
             .asDriver()
-            .debug()
             .compactMap { $0 }
             .drive(self.emptyLabel.rx.isHidden)
             .disposed(by: self.disposeBag)

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordViewModel.swift
@@ -27,7 +27,7 @@ final class RecordViewModel {
         var timeText = BehaviorRelay<String>(value: "00:00")
         var distanceText = BehaviorRelay<String>(value: "0.00")
         var calorieText = BehaviorRelay<String>(value: "0")
-        var userInfoDidUpdate = BehaviorRelay<Bool>(value: false)
+        var totalRecordDidUpdate = BehaviorRelay<Bool>(value: false)
         var yearMonthDateText = BehaviorRelay<String>(value: "")
         var monthDayDateText = BehaviorRelay<String>(value: "")
         var runningCountText = BehaviorRelay<String>(value: "")
@@ -49,7 +49,7 @@ final class RecordViewModel {
         
         Observable.of(input.viewWillAppearEvent, input.refreshEvent).merge()
             .subscribe(onNext: { [weak self] in
-                self?.recordUseCase.loadCumulativeRecord()
+                self?.recordUseCase.loadTotalRecord()
                 self?.recordUseCase.refreshRecords()
             })
             .disposed(by: disposeBag)
@@ -81,7 +81,7 @@ final class RecordViewModel {
         
         self.recordUseCase.month
             .subscribe(onNext: { [weak self] _ in
-                self?.recordUseCase.fetchRecordList()
+                self?.recordUseCase.loadMonthlyRecord()
             })
             .disposed(by: disposeBag)
         
@@ -100,12 +100,12 @@ final class RecordViewModel {
     }
     
     private func bindCumulativeRecord(output: Output, disposeBag: DisposeBag) {
-        self.recordUseCase.userInfo
-            .subscribe(onNext: { userInfo in
-                     output.timeText.accept(userInfo.time.timeString)
-                     output.distanceText.accept(userInfo.distance.kilometer.totalDistanceString)
-                     output.calorieText.accept(userInfo.calorie.calorieString)
-                     output.userInfoDidUpdate.accept(true)
+        self.recordUseCase.totalRecord
+            .subscribe(onNext: { totalRecord in
+                     output.timeText.accept(totalRecord.time.timeString)
+                     output.distanceText.accept(totalRecord.distance.kilometerString)
+                     output.calorieText.accept(totalRecord.calorie.calorieString)
+                     output.totalRecordDidUpdate.accept(true)
             })
             .disposed(by: disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordViewModel.swift
@@ -15,7 +15,7 @@ final class RecordViewModel {
     private let recordUseCase: RecordUseCase
     
     struct Input {
-        let viewDidLoadEvent: Observable<Void>
+        let viewWillAppearEvent: Observable<Void>
         let refreshEvent: Observable<Void>
         let previousButtonDidTapEvent: Observable<Void>
         let nextButtonDidTapEvent: Observable<Void>
@@ -46,13 +46,7 @@ final class RecordViewModel {
         let output = Output()
         self.bindOutput(output: output, disposeBag: disposeBag)
         
-        input.viewDidLoadEvent
-            .subscribe(onNext: { [weak self] in
-                self?.recordUseCase.loadCumulativeRecord()
-            })
-            .disposed(by: disposeBag)
-        
-        input.refreshEvent
+        Observable.of(input.viewWillAppearEvent, input.refreshEvent).merge()
             .subscribe(onNext: { [weak self] in
                 self?.recordUseCase.loadCumulativeRecord()
                 self?.recordUseCase.refreshRecords()

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordViewModel.swift
@@ -35,6 +35,7 @@ final class RecordViewModel {
         var calendarArray = BehaviorRelay<[CalendarModel?]>(value: [])
         var indicesToUpdate = BehaviorRelay<(Int?, Int?)>(value: (nil, nil))
         var dailyRecords = BehaviorRelay<[RunningResult]>(value: [])
+        var hasDailyRecords = BehaviorRelay<Bool?>(value: nil)
     }
     
     init(coordinator: RecordCoordinator, recordUsecase: RecordUseCase) {
@@ -155,7 +156,10 @@ final class RecordViewModel {
             .map { [weak self] selectedDay in
                 self?.filterRecords(by: selectedDay) ?? []
             }
-            .bind(to: output.dailyRecords)
+            .bind(onNext: { dailyRecords in
+                output.dailyRecords.accept(dailyRecords)
+                output.hasDailyRecords.accept(!dailyRecords.isEmpty)
+            })
             .disposed(by: disposeBag)
     }
     


### PR DESCRIPTION
### 📕 Issue Number

Close #259 


### 📙 작업 내역

https://user-images.githubusercontent.com/77449223/143729186-fcc1e055-24a4-493f-90d8-e2a5e8a9a92c.MP4

> 구현 내용 및 작업 했던 내역

- [x] 기록화면도 viewWillAppear일 때 refresh 하도록 수정
- [x] 기록 없는 날짜에 대한 안내 문구 표시
- [x] REST로 특정 달에 대한 기록 가져오기 


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 중요하진 않은 부분이긴 한데 제가 from과 to를 한달의 시작으로 설정하거든요 (O월 1일 0시 0분 0초 000)
그래서 엄밀히 말하면 LESS_THAN이 되어야 할 것 같은데 현실적으로 1일 자정에 1000분의 1초의 오차도 없이 운동을 끝내는 일은 없을 것 같아서 그대로 넘어가도 될 것 같습니다!
![image](https://user-images.githubusercontent.com/77449223/143729218-d8a26d88-c796-47d3-ab9b-6cbaf4f4b091.png)

- 처음에 DB에 result가 아예 없거나 쿼리 조건에 만족하지 못하면 repository에서 onError를 방출하는 것 같습니다! 그래서 UseCase에서 onError를 받아 기록 배열을 빈 배열로 만들어주고 통계값도 0으로 설정해주었습니다.

- 녹화 영상을 보시면 이제 운동을 끝내고 기록탭으로 돌아왔을 때 누적 기록이 반영되고 (안움직여서 시간 쌓인거 보시면 될 것 같습니다😂) 통계값, 기록 리스트가 바뀌는 걸 확인하실 수 있을겁니다.

- 그리고 다음 달 이전 달로 넘어가면 그 달에 대한 기록을 가져오도록 구현했는데요, 테스트를 위해서 firestore에서 datetime을 수정했는데 RunningResult로 잘 받아오긴 하는데 dateTime이 nil로 들어오는 것 같습니다 ㅠㅠ 대신에 운동해서 서버에 올린 기록은 잘 받아와요! datetime을 수정하면 문제가 생깁니다..! 

- emoji도 테스트하기 위해 Firestore에서 필드 추가해서 dictionary로 생성했는데 이것도 잘 못받아오는 것 같네요 ㅠㅠ 제가 잘못 입력한 걸까요..?

<br/><br/>
