### PR TITLE
이미지 캐싱 수정, 프로필 사진 변경 적용

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -53,8 +53,19 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
             with: imageData,
             of: nickname
         )
-            .map { true }
-            .bind(to: self.saveResult)
+            .subscribe(onNext: {
+                self.saveResult.onNext(true)
+                self.cacheNewImage(data: imageData)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func cacheNewImage(data imageData: Data) {
+        guard let nickname = nickname else { return }
+        self.firestoreRepository.fetchUserProfile(of: nickname)
+            .subscribe(onNext: { profile in
+                DefaultImageCacheService.shared.replace(imageData: imageData, of: profile.image)
+            })
             .disposed(by: self.disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -53,9 +53,9 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
             with: imageData,
             of: nickname
         )
-            .subscribe(onNext: {
-                self.saveResult.onNext(true)
-                self.cacheNewImage(data: imageData, with: imageURL)
+            .subscribe(onNext: { [weak self] _ in
+                self?.saveResult.onNext(true)
+                self?.cacheNewImage(data: imageData, with: imageURL)
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -55,17 +55,12 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
         )
             .subscribe(onNext: {
                 self.saveResult.onNext(true)
-                self.cacheNewImage(data: imageData)
+                self.cacheNewImage(data: imageData, with: imageURL)
             })
             .disposed(by: self.disposeBag)
     }
     
-    func cacheNewImage(data imageData: Data) {
-        guard let nickname = nickname else { return }
-        self.firestoreRepository.fetchUserProfile(of: nickname)
-            .subscribe(onNext: { profile in
-                DefaultImageCacheService.shared.replace(imageData: imageData, of: profile.image)
-            })
-            .disposed(by: self.disposeBag)
+    func cacheNewImage(data imageData: Data, with imageURL: String) {
+        DefaultImageCacheService.shared.replace(imageData: imageData, of: imageURL)
     }
 }

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -176,6 +176,7 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
     }
     
     private func configureHTTPError(errorCode: Int) -> Error {
+        print(errorCode)
         return URLSessionNetworkServiceError(rawValue: errorCode)
         ?? URLSessionNetworkServiceError.unknownError
     }

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -176,7 +176,6 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
     }
     
     private func configureHTTPError(errorCode: Int) -> Error {
-        print(errorCode)
         return URLSessionNetworkServiceError(rawValue: errorCode)
         ?? URLSessionNetworkServiceError.unknownError
     }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -113,18 +113,13 @@ private extension MyPageViewController {
         )
         
         let output = viewModel.transform(from: input, disposeBag: self.disposeBag)
+        self.nicknameLabel.text = output.nickname
         
         output.imageURL
-            .asDriver()
-            .skip(1)
+            .asDriver(onErrorJustReturn: "")
             .drive(onNext: { [weak self] imageURL in
                 self?.profileImageView.setImage(with: imageURL)
             })
-            .disposed(by: self.disposeBag)
-        
-        output.nickname
-            .asDriver()
-            .drive(self.nicknameLabel.rx.text)
             .disposed(by: self.disposeBag)
     }
     

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -116,6 +116,7 @@ private extension MyPageViewController {
         
         output.imageURL
             .asDriver()
+            .skip(1)
             .drive(onNext: { [weak self] imageURL in
                 self?.profileImageView.setImage(with: imageURL)
             })

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -32,12 +32,14 @@ final class MyPageViewModel {
     }
     
     struct Output {
-        var nickname = BehaviorRelay<String>(value: "")
-        var imageURL = BehaviorRelay<String>(value: "")
+        var nickname: String
+        var imageURL = PublishRelay<String>()
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
-        let output = Output()
+        let output = Output(
+            nickname: self.myPageUseCase.nickname ?? "알 수 없는 사용자"
+        )
         
         input.viewWillAppearEvent
             .subscribe(onNext: { [weak self] in
@@ -63,11 +65,6 @@ final class MyPageViewModel {
             .subscribe { _ in
                 self.myPageCoordinator?.showLicenseFlow()
             }
-            .disposed(by: disposeBag)
-        
-        Observable.just(self.myPageUseCase.nickname)
-            .compactMap { $0 }
-            .bind(to: output.nickname)
             .disposed(by: disposeBag)
         
         self.myPageUseCase.imageURL

--- a/MateRunner/MateRunner/Util/Error/ImageCacheError.swift
+++ b/MateRunner/MateRunner/Util/Error/ImageCacheError.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum ImageCacheError: Error {
-    case nilPathError, nilImageError
+    case nilPathError, nilImageError, invalidURLError
 }

--- a/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
@@ -13,7 +13,6 @@ extension UIImageView {
     func setImage(with url: String) {
         DefaultImageCacheService.shared.setImage(url)
             .observe(on: MainScheduler.instance)
-            .debug()
             .subscribe(onNext: { [weak self] image in
                 self?.image = image
             })

--- a/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
@@ -12,15 +12,10 @@ import RxSwift
 extension UIImageView {
     
     func setImage(with url: String) {
-        print("========== set image =============")
-        print(url)
-        DefaultImageCacheService.shared.setImage(url)
-            .debug()
+        _ = DefaultImageCacheService.shared.setImage(url)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] image in
                 self?.image = image
-                print("========== compleete =============")
             })
-        
     }
 }

--- a/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
@@ -10,12 +10,14 @@ import UIKit
 import RxSwift
 
 extension UIImageView {
-    
     func setImage(with url: String) {
-        _ = DefaultImageCacheService.shared.setImage(url)
+        
+        DefaultImageCacheService.shared.setImage(url)
             .observe(on: MainScheduler.instance)
+            .debug()
             .subscribe(onNext: { [weak self] image in
                 self?.image = image
             })
+            
     }
 }

--- a/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
@@ -11,13 +11,12 @@ import RxSwift
 
 extension UIImageView {
     func setImage(with url: String) {
-        
         DefaultImageCacheService.shared.setImage(url)
             .observe(on: MainScheduler.instance)
             .debug()
             .subscribe(onNext: { [weak self] image in
                 self?.image = image
             })
-            
+            .dispose()
     }
 }

--- a/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
@@ -10,13 +10,17 @@ import UIKit
 import RxSwift
 
 extension UIImageView {
+    
     func setImage(with url: String) {
-        let imageCacheService = DefaultImageCacheService()
-        imageCacheService.setImage(url)
+        print("========== set image =============")
+        print(url)
+        DefaultImageCacheService.shared.setImage(url)
+            .debug()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] image in
                 self?.image = image
+                print("========== compleete =============")
             })
-            .disposed(by: DisposeBag())
+        
     }
 }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -19,46 +19,36 @@ final class DefaultImageCacheService {
     private init () {}
     
     func setImage(_ url: String) -> Observable<UIImage> {
-        // 1. 메모리 캐싱: 이미지가 memory cache(NSCache)에 있는지 확인
+        guard let imageURL = URL(string: url) else {
+            return Observable.error(ImageCacheError.invalidURLError)
+        }
+        
+        // 1. Lookup NSCache
         if let image = self.checkMemory(url) {
-            print("mem hit")
             return Observable.just(image)
         }
-        print("mem miss")
         
-        if let image = self.checkDisk(url) {
-            print("disk hit")
-            ImageCache.cache.setObject(image, forKey: NSString(string: url))
+        // 2. Lookup Disk
+        if let image = self.checkDisk(imageURL) {
+            self.saveIntoCache(imageURL: imageURL, image: image)
             return Observable.just(image)
         }
-        print("disk miss")
         
-        guard let imageURL = URL(string: url) else { return Observable.error(ImageCacheError.nilImageError) }
+        // 3. Network Request
         return Observable<UIImage>.create { emitter in
-            // 3. 서버통신: 받은 URL로 이미지를 가져오고 캐시 저장
-            URLSession.shared.dataTask(with: imageURL, completionHandler: { (data, _, error) in
-                if error != nil {
-                    emitter.onError(ImageCacheError.nilImageError)
-                    return
-                }
-                if let data = data, let image = UIImage(data: data) {
-                    guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first,
-                          let tokenString  = url.components(separatedBy: "=").last,
-                          let imageURL = URL(string: url) else {
-                              return
-                          }
-                    
-                    let filePath = URL(fileURLWithPath: path).appendingPathComponent(tokenString + imageURL.path)
-                    ImageCache.cache.setObject(image, forKey: NSString(string: url))
-                    print("save cache for \(url)")
-                    FileManager.default.createFile(atPath: filePath.path, contents: image.pngData(), attributes: nil)
-                    print("save distk for \(filePath.path)")
-                    print(ImageCache.cache)
-                    print("net cache")
+            let request = URLRequest(url: imageURL)
+            URLSession.shared.rx.response(request: request).subscribe(
+                onNext: { [weak self] response in
+                    guard let image = UIImage(data: response.data) else { return }
+                    self?.saveIntoCache(imageURL: imageURL, image: image)
+                    self?.saveIntoDisk(imageURL: imageURL, image: image)
                     emitter.onNext(image)
+                },
+                onError: { error in
+                    emitter.onError(error)
                 }
-            }).resume()
-            
+            ).disposed(by: self.disposeBag)
+
             return Disposables.create()
         }
     }
@@ -71,47 +61,30 @@ final class DefaultImageCacheService {
         return nil
     }
     
-    private func checkDisk(_ url: String) -> UIImage? {
-        // 2. 디스크 캐싱: disk cache(UserDefault 혹은 기기Directory에있는 file형태)에서 확인
-        let fileManager = FileManager.default
-        guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first,
-              let tokenString  = url.components(separatedBy: "=").last,
-              let imageURL = URL(string: url) else {
-                  return nil
-              }
+    private func checkDisk(_ imageURL: URL) -> UIImage? {
+        guard let path = NSSearchPathForDirectoriesInDomains(
+            .cachesDirectory,
+            .userDomainMask,
+            true
+        ).first else { return nil }
         
-        let filePath = URL(fileURLWithPath: path).appendingPathComponent(tokenString + imageURL.path)
-        print("filePath", filePath)
-        if fileManager.fileExists(atPath: filePath.path) {
-            guard let imageData = try? Data(contentsOf: filePath),
-                  let image = UIImage(data: imageData)
-            else { return nil }
-            return image
+        let filePath = URL(fileURLWithPath: path).appendingPathComponent(imageURL.path)
+        if FileManager.default.fileExists(atPath: filePath.path) {
+            guard let imageData = try? Data(contentsOf: filePath) else { return nil }
+            return UIImage(data: imageData)
         }
         return nil
     }
     
-//    private func createImageCachePath(with url: String) {
-//        guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first,
-//              let tokenString  = url.components(separatedBy: "=").last,
-//              let imageURL = URL(string: url) else {
-//                  return nil
-//              }
-//    }
+    private func saveIntoCache(imageURL: URL, image: UIImage) {
+        ImageCache.cache.setObject(image, forKey: NSString(string: imageURL.path))
+    }
     
-    // 2. 디스크 캐싱: disk cache(UserDefault 혹은 기기Directory에있는 file형태)에서 확인
-    //      let fileManager = FileManager.default
-    //      let path = NSSearchPathForDirectoriesInDomains(
-    //        .cachesDirectory,
-    //        .userDomainMask,
-    //        true).first ?? “”
-    //      var filePath = URL(fileURLWithPath: path)
-    //      if let imageURL = URL(string: url) {
-    //        filePath.appendPathComponent(imageURL.lastPathComponent)
-    //        if let image = self?.checkDisk(filePath: filePath, url: imageURL) {
-    //          ImageCache.cache.setObject(image, forKey: NSString(string: url))
-    //          emitter.onNext(image)
-    //          emitter.onCompleted()
-    //        }
-    //      }
+    private func saveIntoDisk(imageURL: URL, image: UIImage) {
+        guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first else {
+            return
+        }
+        let filePath = URL(fileURLWithPath: path).appendingPathComponent(imageURL.path)
+        FileManager.default.createFile(atPath: filePath.path, contents: image.pngData(), attributes: nil)
+    }
 }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -62,13 +62,10 @@ final class DefaultImageCacheService {
     }
     
     private func checkDisk(_ imageURL: URL) -> UIImage? {
-        guard let path = NSSearchPathForDirectoriesInDomains(
-            .cachesDirectory,
-            .userDomainMask,
-            true
-        ).first else { return nil }
-        
-        let filePath = URL(fileURLWithPath: path).appendingPathComponent(imageURL.path)
+        guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else {
+            return nil
+        }
+        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
         if FileManager.default.fileExists(atPath: filePath.path) {
             guard let imageData = try? Data(contentsOf: filePath) else { return nil }
             return UIImage(data: imageData)
@@ -77,14 +74,12 @@ final class DefaultImageCacheService {
     }
     
     private func saveIntoCache(imageURL: URL, image: UIImage) {
-        ImageCache.cache.setObject(image, forKey: NSString(string: imageURL.path))
+        ImageCache.cache.setObject(image, forKey: NSString(string: imageURL.absoluteString))
     }
     
     private func saveIntoDisk(imageURL: URL, image: UIImage) {
-        guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first else {
-            return
-        }
-        let filePath = URL(fileURLWithPath: path).appendingPathComponent(imageURL.path)
+        guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else { return }
+        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
         FileManager.default.createFile(atPath: filePath.path, contents: image.pngData(), attributes: nil)
     }
 }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -53,6 +53,13 @@ final class DefaultImageCacheService {
         }
     }
     
+    func replace(imageData: Data, of imageURL: String) {
+        guard let image = UIImage(data: imageData),
+              let imageURL = URL(string: imageURL) else { return }
+        self.saveIntoCache(imageURL: imageURL, image: image)
+        self.saveIntoDisk(imageURL: imageURL, image: image)
+    }
+    
     private func checkMemory(_ url: String) -> UIImage? {
         let cacheKey = NSString(string: url)
         if let cachedImage = ImageCache.cache.object(forKey: cacheKey) {

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -15,43 +15,50 @@ enum ImageCache {
 
 final class DefaultImageCacheService {
     private let disposeBag = DisposeBag()
+    static let shared = DefaultImageCacheService()
+    private init () {}
     
     func setImage(_ url: String) -> Observable<UIImage> {
-        return Observable<UIImage>.create { [weak self] emitter in
-            // 1. 메모리 캐싱: 이미지가 memory cache(NSCache)에 있는지 확인
-            if let image = self?.checkMemory(url) {
-                emitter.onNext(image)
-                emitter.onCompleted()
-            }
-            
-            // 2. 디스크 캐싱: disk cache(UserDefault 혹은 기기Directory에있는 file형태)에서 확인
-            let fileManager = FileManager.default
-            let path = NSSearchPathForDirectoriesInDomains(
-                .cachesDirectory,
-                .userDomainMask,
-                true).first ?? ""
-            var filePath = URL(fileURLWithPath: path)
-            if let imageURL = URL(string: url) {
-                filePath.appendPathComponent(imageURL.lastPathComponent)
-                if let image = self?.checkDisk(filePath: filePath, url: imageURL) {
-                    ImageCache.cache.setObject(image, forKey: NSString(string: url))
-                    emitter.onNext(image)
-                    emitter.onCompleted()
-                }
-            }
-            
+        // 1. 메모리 캐싱: 이미지가 memory cache(NSCache)에 있는지 확인
+        if let image = self.checkMemory(url) {
+            print("mem hit")
+            return Observable.just(image)
+        }
+        print("mem miss")
+        
+        if let image = self.checkDisk(url) {
+            print("disk hit")
+            ImageCache.cache.setObject(image, forKey: NSString(string: url))
+            return Observable.just(image)
+        }
+        print("disk miss")
+        
+        guard let imageURL = URL(string: url) else { return Observable.error(ImageCacheError.nilImageError) }
+        return Observable<UIImage>.create { emitter in
             // 3. 서버통신: 받은 URL로 이미지를 가져오고 캐시 저장
-            if let imageURL = URL(string: url) {
-                URLSession.shared.dataTask(with: imageURL, completionHandler: { (data, _, error) in
-                    if error != nil { return }
-
-                    if let data = data, let image = UIImage(data: data) {
-                        ImageCache.cache.setObject(image, forKey: NSString(string: url))
-                        fileManager.createFile(atPath: filePath.path, contents: image.pngData(), attributes: nil)
-                        emitter.onNext(image)
-                    }
-                }).resume()
-            }
+            URLSession.shared.dataTask(with: imageURL, completionHandler: { (data, _, error) in
+                if error != nil {
+                    emitter.onError(ImageCacheError.nilImageError)
+                    return
+                }
+                if let data = data, let image = UIImage(data: data) {
+                    guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first,
+                          let tokenString  = url.components(separatedBy: "=").last,
+                          let imageURL = URL(string: url) else {
+                              return
+                          }
+                    
+                    let filePath = URL(fileURLWithPath: path).appendingPathComponent(tokenString + imageURL.path)
+                    ImageCache.cache.setObject(image, forKey: NSString(string: url))
+                    print("save cache for \(url)")
+                    FileManager.default.createFile(atPath: filePath.path, contents: image.pngData(), attributes: nil)
+                    print("save distk for \(filePath.path)")
+                    print(ImageCache.cache)
+                    print("net cache")
+                    emitter.onNext(image)
+                }
+            }).resume()
+            
             return Disposables.create()
         }
     }
@@ -64,8 +71,17 @@ final class DefaultImageCacheService {
         return nil
     }
     
-    private func checkDisk(filePath: URL, url: URL) -> UIImage? {
+    private func checkDisk(_ url: String) -> UIImage? {
+        // 2. 디스크 캐싱: disk cache(UserDefault 혹은 기기Directory에있는 file형태)에서 확인
         let fileManager = FileManager.default
+        guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first,
+              let tokenString  = url.components(separatedBy: "=").last,
+              let imageURL = URL(string: url) else {
+                  return nil
+              }
+        
+        let filePath = URL(fileURLWithPath: path).appendingPathComponent(tokenString + imageURL.path)
+        print("filePath", filePath)
         if fileManager.fileExists(atPath: filePath.path) {
             guard let imageData = try? Data(contentsOf: filePath),
                   let image = UIImage(data: imageData)
@@ -74,4 +90,28 @@ final class DefaultImageCacheService {
         }
         return nil
     }
+    
+//    private func createImageCachePath(with url: String) {
+//        guard let path = NSSearchPathForDirectoriesInDomains( .cachesDirectory, .userDomainMask, true).first,
+//              let tokenString  = url.components(separatedBy: "=").last,
+//              let imageURL = URL(string: url) else {
+//                  return nil
+//              }
+//    }
+    
+    // 2. 디스크 캐싱: disk cache(UserDefault 혹은 기기Directory에있는 file형태)에서 확인
+    //      let fileManager = FileManager.default
+    //      let path = NSSearchPathForDirectoriesInDomains(
+    //        .cachesDirectory,
+    //        .userDomainMask,
+    //        true).first ?? “”
+    //      var filePath = URL(fileURLWithPath: path)
+    //      if let imageURL = URL(string: url) {
+    //        filePath.appendPathComponent(imageURL.lastPathComponent)
+    //        if let image = self?.checkDisk(filePath: filePath, url: imageURL) {
+    //          ImageCache.cache.setObject(image, forKey: NSString(string: url))
+    //          emitter.onNext(image)
+    //          emitter.onCompleted()
+    //        }
+    //      }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #262 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 이미지 캐싱 디버깅

https://user-images.githubusercontent.com/46087477/143764364-d5ed6f42-3d25-4dfc-84c6-2a1726aacf66.MP4

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 문제의 원인과 해결

1. 캐싱 주소 문제
먼저 사진이 디스크에 저장될 때는 사진의 토큰 정보 없이 profile.png로 저장됩니다. 그래서 memory cache miss 가 생긴 이후에 네트워크 요청까지 가지 않고 disk 단계에서 바로 hit이 발생합니다. 아직 서버에 새로 올린 사진은 캐시에 저장이 업데이트가 안되어있기 때문에 여기서 이전에 저장했던 사진이 그대로 반환됩니다.

메모리 캐시는 인자로 받은 url을 그대로 키 값으로 사용하기 때문에 문제가 없었어요. 그래서 방금 수정된 사진은 memory miss -> disk hit(변경되기 전 사진) 의 과정을 통해서 마이페이지로 나왔을 때 변경되지 전 사진이 표시됩니다.

아래 코드에서 `filePath.appendPathComponent(imageURL.lastPathComponent)` 이 부분이 url의 파라미터 부분은 처리하지 않고 주소만 처리합니다. pathComponent라서 그런가봐요.

```swift
if let imageURL = URL(string: url) {
      filePath.appendPathComponent(imageURL.lastPathComponent)
      if let image = self?.checkDisk(filePath: filePath, url: imageURL) {
      ImageCache.cache.setObject(image, forKey: NSString(string: url))
      emitter.onNext(image)
      emitter.onCompleted()
}
```

2. 캐싱할 이미지 주소를 어떻게 하지?
그래서 처음에는 `filePath.appendPathComponent(imageURL.absoluteString)` 을 디스크에 저장할 주소로 주어서 이미지를 구분하려고 했습니다. 근데 이러면 http://firestore~~?~&~=~ 이렇게 디렉토리 주소로 사용하면 문제가 생길법한 문자열들이 사용되어서 어려울 것 같다고 판단했습니다. 또, pathComponent 는 앞서 말한 것 처럼 주소 뒤 파라미터를 포함하지 않아서 디렉토리만 달라지고 똑같은 문제가 발생합니다. 

3. 그럼 토큰을 끼워넣을까?
다음으로 생각한 방법이 이미지이름 뒤에 토큰을 끼워넣는건데요, `caches/123214-123124profile.png` 이런식으로 주소를 만들어서 주면 겹칠 일도 없고 캐싱도 잘 될 것이라고 생각했습니다. 

4. 근데 뭐하러 이렇게하지..?
근데 이렇게 하면 사용자가 프로필 사진을 변경할 때마다 이전 사진을 계속 앱에 보관하는 상황이 발생합니다. 더 이상 사용할 일이 전혀 없는 사진이고 필요하더라도 주소를 찾아갈 수도 없는 국제 미아 파일이 생성되는 격이죠.. 그래서 결국 내린 결론이 새롭게 이미지를 업로드 하면 캐시에 데이터를 교체해주는 방식입니다. 

```swift
    func replace(imageData: Data, of imageURL: String) {
        guard let image = UIImage(data: imageData),
              let imageURL = URL(string: imageURL) else { return }
        self.saveIntoCache(imageURL: imageURL, image: image)
        self.saveIntoDisk(imageURL: imageURL, image: image)
    }
```

프로필 업로드가 완료되면, 새로 받은 이미지를 메모리와 디스크에 저장하는 메서드를 캐시 서비스 안에 정의하고,

```swift
//  DefaultProfileEditUseCase.swift
  self.firestoreRepository.saveAll(
            userProfile: userProfile,
            with: imageData,
            of: nickname
        )
            .subscribe(onNext: {
                self.saveResult.onNext(true)
                self.cacheNewImage(data: imageData, with: imageURL)
            })
            .disposed(by: self.disposeBag)
.
.
.
    func cacheNewImage(data imageData: Data, with imageURL: String) {
        DefaultImageCacheService.shared.replace(imageData: imageData, of: imageURL)
    }
```

saveAll이 성공적으로 완료되면 새로운 이미지를 캐싱하는 메서드를 호출했습니다.


이제 프로필 사진 변경은 다음과 같은 과정으로 진행됩니다. 

```
1. 마이페이지 진입 시 Caches/{nickname}/profile.png 를 찾는다. 
2. 있으면 그대로 표시한다. 
3. 없으면 디스크를 확인한다 -> 있으면 반환 없으면 네트워킹 
4. 네트워크로 새로운 이미지를 받아오면 메모리와 디스크 캐시에 저장하고 저장한 이미지를 반환한다. 
5. 프로필 사진 편집으로 진입 후 사진 변경, 완료버튼 탭
6. 서버에 프로필 사진이 올라간다.
7. 업로드가 완료되면 디스크 캐시에 있는 Caches/{nickname}/profile.png 를 변경한다. 
8. 마이페이지 화면으로 진입
9. url을 캐시에서 검색한다. 이때 miss 가 발생한다(토큰을 포함한 url주소가 다르므로)
10. 디스크 캐시에서 url을 검색한다. 이때는 토큰을 제외한 경로주소를 사용하므로 7번에서 변경된 파일이 hit 된다. 
11. hit되었으므로 메모리 캐시 사진을 갱신
12. 프로필 사진 표시 

여기서부터는 캐시가 비워지지 않는 이상 메모리캐시에서 계속 hit
```

- 디스크 캐싱이 안됨
디스크 캐싱이 계속 실패해서 원인을 못찾고 있었는데, url을 디렉토리로 변환해서 사용하다보니까 Caches/v0/firestore.../hunihun/profile.png 처럼 깊이가 깊은 디렉토리가 되어서 그런지 저기까지 접근을 못하는 것 같아요.. 그래서 캐싱 주소를 `/`를 모두 `-`로 변경해서 하나의 파일로 만들어버렸습니다.

```swift
let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
```

- MyPageViewModel 타입변경
Output이 BehaviorRelay로 되어있다보니 프로필 이미지 요청을 subscribe에서 빈 문자열("")로 한 번, 사용자 정보가 패칭된 이후에 한 번 총 두 번 보내는 것이 발견되어서 skip(1)을 할까하다가 그냥 PublishRelay로 변경했어요.

- 캐싱에 대해서 다른 사이드이펙트가 있을 것 같다면 알려주세요!!

<br/><br/>
