### PR TITLE
회원가입 및 로그인 시 fcm token 서버에 업로드 구현

### DIFF
--- a/MateRunner/MateRunner/Application/AppDelegate.swift
+++ b/MateRunner/MateRunner/Application/AppDelegate.swift
@@ -76,8 +76,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate : MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        if let nickName = UserDefaults.standard.string(forKey: UserDefaultKey.nickname.rawValue) {
-            Database.database().reference().child("fcmToken/\(nickName)").setValue(fcmToken)
+        if let nickname = UserDefaults.standard.string(forKey: UserDefaultKey.nickname.rawValue) {
+            Database.database().reference().child("fcmToken/\(nickname)").setValue(fcmToken)
+        } else {
+            UserDefaults.standard.set(fcmToken, forKey: UserDefaultKey.fcmToken.rawValue)
         }
     }
 }

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
@@ -11,9 +11,14 @@ import RxSwift
 
 final class DefaultUserRepository: UserRepository {
     private let networkService: FireStoreNetworkService
+    private let realtimeDatabaseNetworkService: RealtimeDatabaseNetworkService
     
-    init(networkService: FireStoreNetworkService) {
+    init(
+        networkService: FireStoreNetworkService,
+        realtimeDatabaseNetworkService: RealtimeDatabaseNetworkService
+    ) {
         self.networkService = networkService
+        self.realtimeDatabaseNetworkService = realtimeDatabaseNetworkService
     }
     
     func fetchUserNickname() -> String? {
@@ -26,6 +31,18 @@ final class DefaultUserRepository: UserRepository {
             collection: FirebaseCollection.uid,
             document: uid, field: "nickname"
         )
+    }
+    
+    func fetchFCMToken() -> String? {
+        return UserDefaults.standard.string(forKey: UserDefaultKey.fcmToken.rawValue)
+    }
+    
+    func deleteFCMToken() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.fcmToken.rawValue)
+    }
+    
+    func saveFCMToken(_ fcmToken: String, of nickname: String) -> Observable<Void> {
+        return self.realtimeDatabaseNetworkService.update(with: fcmToken, path: ["fcmToken/\(nickname)"])
     }
     
     func checkRegistration(uid: String) -> Observable<Bool> {

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/UserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/UserRepository.swift
@@ -12,6 +12,9 @@ import RxSwift
 protocol UserRepository {
     func fetchUserNickname() -> String?
     func fetchUserNicknameFromServer(uid: String) -> Observable<String>
+    func fetchFCMToken() -> String?
+    func deleteFCMToken()
+    func saveFCMToken(_ fcmToken: String, of nickname: String) -> Observable<Void>
     func checkRegistration(uid: String) -> Observable<Bool>
     func checkDuplicate(of nickname: String) -> Observable<Bool>
     func saveUserInfo(uid: String, nickname: String, height: Int, weight: Int) -> Observable<Bool>

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultLoginUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultLoginUseCase.swift
@@ -29,7 +29,18 @@ final class DefaultLoginUseCase: LoginUseCase {
         self.repository.fetchUserNicknameFromServer(uid: uid)
             .subscribe(onNext: { [weak self] nickname in
                 self?.repository.saveLoginInfo(nickname: nickname)
+                self?.saveFCMToken(of: nickname)
                 self?.isSaved.onNext(true)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    func saveFCMToken(of nickname: String) {
+        guard let fcmToken = self.repository.fetchFCMToken() else { return }
+
+        self.repository.saveFCMToken(fcmToken, of: nickname)
+            .subscribe(onNext: { [weak self] in
+                self?.repository.deleteFCMToken()
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -62,6 +62,17 @@ final class DefaultSignUpUseCase: SignUpUseCase {
             .disposed(by: self.disposeBag)
     }
     
+    func saveFCMToken(of nickname: String?) {
+        guard let fcmToken = self.repository.fetchFCMToken(),
+              let nickname = nickname else { return }
+
+        self.repository.saveFCMToken(fcmToken, of: nickname)
+            .subscribe(onNext: { [weak self] in
+                self?.repository.deleteFCMToken()
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
     func saveLoginInfo(nickname: String?) {
         guard let nickname = nickname else { return }
         self.repository.saveLoginInfo(nickname: nickname)

--- a/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/LoginUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/LoginUseCase.swift
@@ -14,4 +14,5 @@ protocol LoginUseCase {
     var isSaved: PublishSubject<Bool> { get set }
     func checkRegistration(uid: String)
     func saveLoginInfo(uid: String)
+    func saveFCMToken(of nickname: String)
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/SignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/SignUpUseCase.swift
@@ -20,5 +20,6 @@ protocol SignUpUseCase {
     func getCurrentWeight()
     func checkDuplicate(of nickname: String?)
     func signUp(nickname: String?)
+    func saveFCMToken(of nickname: String?)
     func saveLoginInfo(nickname: String?)
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -85,7 +85,8 @@ final class DefaultRunningCoordinator: RunningCoordinator {
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
                 ), userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ), delegate: usecase
             )
         )
@@ -142,7 +143,8 @@ final class DefaultRunningCoordinator: RunningCoordinator {
                 realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
             ),
             userRepository: DefaultUserRepository(
-                networkService: DefaultFireStoreNetworkService()
+                networkService: DefaultFireStoreNetworkService(),
+                realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
             )
         )
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningSettingCoordinator.swift
@@ -29,7 +29,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             runningSettingUseCase: DefaultRunningSettingUseCase(
                 runningSetting: RunningSetting(),
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )
@@ -44,7 +45,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             runningSettingUseCase: DefaultRunningSettingUseCase(
                 runningSetting: settingData,
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )
@@ -60,7 +62,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             runningSettingUseCase: DefaultRunningSettingUseCase(
                 runningSetting: settingData,
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )
@@ -91,7 +94,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
                 ),
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )
@@ -106,7 +110,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             runningSettingUseCase: DefaultRunningSettingUseCase(
                 runningSetting: settingData,
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             ),
             runningPreparationUseCase: DefaultRunningPreparationUseCase()
@@ -128,7 +133,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
                     urlSessionService: DefaultURLSessionNetworkService()
                 ),
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )
@@ -137,7 +143,8 @@ final class DefaultRunningSettingCoordinator: RunningSettingCoordinator {
             runningSettingUseCase: DefaultRunningSettingUseCase(
                 runningSetting: settingData,
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultLoginCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultLoginCoordinator.swift
@@ -24,7 +24,8 @@ final class DefaultLoginCoordinator: LoginCoordinator {
             coordinator: self,
             loginUseCase: DefaultLoginUseCase(
                 repository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultSignUpCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/Coordinator/DefaultSignUpCoordinator.swift
@@ -26,7 +26,8 @@ final class DefaultSignUpCoordinator: SignUpCoordinator {
             coordinator: self,
             signUpUseCase: DefaultSignUpUseCase(
                 repository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ),
                 uid: uid
             )

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -128,7 +128,9 @@ final class SignUpViewModel {
         self.signUpUseCase.canSignUp
             .filter { $0 }
             .subscribe(onNext: { [weak self] _ in
-                self?.signUpUseCase.signUp(nickname: output.nicknameFieldText.value)
+                let nickname = output.nicknameFieldText.value
+                self?.signUpUseCase.signUp(nickname: nickname)
+                self?.signUpUseCase.saveFCMToken(of: nickname)
             })
             .disposed(by: disposeBag)
         

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultAddMateCoordinator.swift
@@ -33,7 +33,8 @@ final class DefaultAddMateCoordinator: AddMateCoordinator {
                 ), firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 ), userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateCoordinator.swift
@@ -29,7 +29,8 @@ final class DefaultMateCoordinator: MateCoordinator {
                 ), firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
                 ), userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ Cooditnator/DefaultMateProfileCoordinator.swift
@@ -34,7 +34,8 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
             coordinator: self,
             profileUseCase: DefaultProfileUseCase(
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ),
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
@@ -49,7 +50,8 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
         recordDetailViewController.viewModel = RecordDetailViewModel(
             recordDetailUseCase: DefaultRecordDetailUseCase(
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ),
                 with: runningResult
             )
@@ -71,7 +73,8 @@ final class DefaultMateProfileCoordinator: MateProfileCoordinator {
                     realtimeNetworkService: DefaultRealtimeDatabaseNetworkService(),
                     urlSessionNetworkService: DefaultURLSessionNetworkService()
                 ), userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ), delegate: usecase
             )
         )

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultMyPageCoordinator.swift
@@ -24,7 +24,8 @@ final class DefaultMyPageCoordinator: MyPageCoordinator {
             myPageCoordinator: self,
             myPageUseCase: DefaultMyPageUseCase(
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ),
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()

--- a/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultNotificationCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/Coordinator/DefaultNotificationCoordinator.swift
@@ -27,7 +27,8 @@ final class DefaultNotificationCoordinator: NotificationCoordinator {
             notificationCoordinator: self,
             notificationUseCase: DefaultNotificationUseCase(
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 )
             )
         )

--- a/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/Coordinator/DefaultRecordCoordinator.swift
@@ -24,7 +24,8 @@ final class DefaultRecordCoordinator: RecordCoordinator {
             coordinator: self,
             recordUsecase: DefaultRecordUseCase(
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ),
                 firestoreRepository: DefaultFirestoreRepository(
                     urlSessionService: DefaultURLSessionNetworkService()
@@ -40,7 +41,8 @@ final class DefaultRecordCoordinator: RecordCoordinator {
         recordDetailViewController.viewModel = RecordDetailViewModel(
             recordDetailUseCase: DefaultRecordDetailUseCase(
                 userRepository: DefaultUserRepository(
-                    networkService: DefaultFireStoreNetworkService()
+                    networkService: DefaultFireStoreNetworkService(),
+                    realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
                 ),
                 with: runningResult
             )

--- a/MateRunner/MateRunner/Util/Constant/UserDefaultKey.swift
+++ b/MateRunner/MateRunner/Util/Constant/UserDefaultKey.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum UserDefaultKey: String {
-    case nickname, isLoggedIn
+    case nickname, isLoggedIn, fcmToken
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #237 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 회원가입 및 로그인 시 fcm token 서버에 업로드 구현


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 app delegate에서 닉네임 정보가 없으면 UserDefault에 fcm token을 저장하고, 회원가입이나 로그인 후 닉네임이 생성되면 그 닉네임에 대한 fcm token을 UserDefault로부터 가져와서 서버에 업로드한 후, UserDefault의 fcmToken을 저장하도록 구현했습니다.

- 특이 사항 2

<br/><br/>
