### PR TITLE
결과 쿼리 적용시 오프셋이 주어졌을 때도 디코딩이 되도록 수정

### DIFF
--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -72,7 +72,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
                 guard let dto = self.decode(data: data, to: [QueryResultValue<RunningResultFirestoreDTO>].self) else {
                     throw FirestoreRepositoryError.decodingError
                 }
-                return dto.compactMap({try? $0.document.toDomain()})
+                return dto.compactMap({try? $0.document?.toDomain()})
             case .failure(let error):
                 throw error
             }
@@ -94,7 +94,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
                 guard let dto = self.decode(data: data, to: [QueryResultValue<RunningResultFirestoreDTO>].self) else {
                     throw FirestoreRepositoryError.decodingError
                 }
-                return dto.compactMap({ try? $0.document.toDomain() })
+                return dto.compactMap({ try? $0.document?.toDomain() })
             case .failure(let error):
                 throw error
             }
@@ -390,7 +390,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
                 guard let dto = self.decode(data: data, to: [QueryResultValue<UserDataFirestoreDTO>].self) else {
                     throw FirestoreRepositoryError.decodingError
                 }
-                return dto.compactMap({ try? $0.document.toDomain().nickname })
+                return dto.compactMap({ try? $0.document?.toDomain().nickname })
             case .failure(let error):
                 throw error
             }

--- a/MateRunner/MateRunner/Domain/Model/FirestoreValues.swift
+++ b/MateRunner/MateRunner/Domain/Model/FirestoreValues.swift
@@ -128,8 +128,8 @@ struct Documents<T: Codable>: Codable {
 }
 
 struct QueryResultValue<T: Codable>: Codable {
-    let readTime: String
-    let document: T
+    let readTime: String?
+    let document: T?
     
     private enum FieldKeys: String, CodingKey {
         case readTime, document


### PR DESCRIPTION
### 📕 Issue Number

Close #261 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 오프셋 적용쿼리 생성


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 새로 DTO를 만들 필요가 없었습니다..!
```json
[
    {
        "readTime": "2021-11-28T11:36:49.691075Z",
        "skippedResults": 2
    },
    {
        "document": {
            "name": "projects/mate-runner-e232c/databases/(default)/documents/RunningResult/hunihun956/records/session-RestAPI-20211127004329",
            "fields": {
                "targetDistance"
.
.
.
```

오프셋을 적용하면 저 앞에 붙은 readtime과 skippedResults 때문에 문제가 있었는데, 이게 배열안에 필드가 아예다른 데이터들이 들어가있다보니까 디코딩 포맷을 정의하기가 어려웠습니다.. 그래서 readTime, skippedResult, document가 모두 같은 레벨에 있는 키값들이라서 document를 옵셔널로 주어서 document로 반드시 디코딩이 되지 않아도 되도록 수정했습니다..! 

사소한 수정이라 피알로 넣기 좀 그렇긴한데 일단 보냅니다!

<br/><br/>
