### PR TITLE
경쟁 모드에서 프로필 이미지 표시 & 몸무게로 칼로리 계산 & 알림 정렬 & 처리된 초대장이 계속 팝업되는 버그 수정

### DIFF
--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -444,10 +444,11 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         + FirestoreCollectionPath.notificationPath
         + "/\(userNickname)"
         + FirestoreCollectionPath.recordsPath
+        + "/\(Date().fullDateTimeNumberString())-\(notice.mode)-\(notice.sender)"
         
         let dto = NoticeDTO(from: notice)
         
-        return self.urlSession.post(
+        return self.urlSession.patch(
             [FirestoreField.fields: dto],
             url: endPoint,
             headers: FirestoreConfiguration.defaultHeaders

--- a/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/Protocol/RunningUseCase.swift
@@ -21,6 +21,11 @@ protocol RunningUseCase {
     var totalProgress: BehaviorSubject<Double> { get set }
     var cancelTimeLeft: PublishSubject<Int> { get set }
     var popUpTimeLeft: PublishSubject<Int> { get set }
+    var selfImageURL: PublishSubject<String> { get set }
+    var selfWeight: BehaviorSubject<Double> { get set }
+    var mateImageURL: PublishSubject<String> { get set }
+    func loadUserInfo()
+    func loadMateInfo()
     func updateRunningStatus()
     func cancelRunningStatus()
     func executePedometer()

--- a/MateRunner/MateRunner/Domain/UseCase/Home/RunningUseCase/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/RunningUseCase/DefaultRunningUseCase.swift
@@ -134,7 +134,6 @@ final class DefaultRunningUseCase: RunningUseCase {
             .subscribe(onNext: { [weak self] time in
                 guard let self = self,
                         let selfWeight = try? self.selfWeight.value() else { return }
-                print(selfWeight)
                 self.updateTime(with: time)
                 self.updateCalorie(weight: selfWeight)
                 if self.runningSetting.mode != .single {

--- a/MateRunner/MateRunner/Domain/UseCase/Home/RunningUseCase/DefaultRunningUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/RunningUseCase/DefaultRunningUseCase.swift
@@ -35,7 +35,7 @@ final class DefaultRunningUseCase: RunningUseCase {
     var cancelTimeLeft: PublishSubject<Int>
     var popUpTimeLeft: PublishSubject<Int>
     var selfImageURL = PublishSubject<String>()
-    var selfWeight = BehaviorSubject<Double>(value: 70)
+    var selfWeight = BehaviorSubject<Double>(value: 65)
     var mateImageURL = PublishSubject<String>()
     
     init(

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultMyPageUseCase.swift
@@ -15,7 +15,6 @@ final class DefaultMyPageUseCase: MyPageUseCase {
     private let disposeBag = DisposeBag()
 
     var nickname: String?
-    var isNotificationOn = PublishSubject<Bool>()
     var imageURL = PublishSubject<String>()
     
     init(userRepository: UserRepository, firestoreRepository: FirestoreRepository) {

--- a/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/Coordinator/DefaultRunningCoordinator.swift
@@ -145,6 +145,9 @@ final class DefaultRunningCoordinator: RunningCoordinator {
             userRepository: DefaultUserRepository(
                 networkService: DefaultFireStoreNetworkService(),
                 realtimeDatabaseNetworkService: DefaultRealtimeDatabaseNetworkService()
+            ),
+            firestoreRepository: DefaultFirestoreRepository(
+                urlSessionService: DefaultURLSessionNetworkService()
             )
         )
     }

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
@@ -8,6 +8,17 @@
 import UIKit
 
 final class RunningCardView: UIView {
+    private lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .lightGray
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 40
+        imageView.snp.makeConstraints { make in
+            make.width.height.equalTo(80)
+        }
+        return imageView
+    }()
+    
     convenience init(distanceLabel: UILabel, progressView: UIProgressView) {
         self.init(frame: .zero)
         self.configureUI(distanceLabel: distanceLabel, progressView: progressView)
@@ -25,6 +36,10 @@ final class RunningCardView: UIView {
         
         progressView.progressTintColor = isWinning ? .mrYellow : .mrPurple
         self.backgroundColor = isWinning ? .mrPurple : .systemGray5
+    }
+    
+    func updateProfileImage(with imageURL: String) {
+        self.profileImageView.setImage(with: imageURL)
     }
 }
 
@@ -56,26 +71,14 @@ private extension RunningCardView {
         verticalStackView.addArrangedSubview(labelStackView)
         verticalStackView.addArrangedSubview(progressView)
         
-        let profileImageView = self.createProfileImageView()
-        
         let horizontalStackView = UIStackView()
         horizontalStackView.axis = .horizontal
         horizontalStackView.alignment = .center
         horizontalStackView.spacing = 25
         
-        horizontalStackView.addArrangedSubview(profileImageView)
+        horizontalStackView.addArrangedSubview(self.profileImageView)
         horizontalStackView.addArrangedSubview(verticalStackView)
         return horizontalStackView
-    }
-    
-    func createProfileImageView() -> UIImageView {
-        let imageView = UIImageView()
-        imageView.backgroundColor = .lightGray
-        imageView.layer.cornerRadius = 40
-        imageView.snp.makeConstraints { make in
-            make.width.height.equalTo(80)
-        }
-        return imageView
     }
     
     func createLabelStackView(distanceLabel: UILabel) -> UIStackView {

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -73,6 +73,7 @@ final class HomeViewController: UIViewController {
         if let invitationViewController = invitationViewController {
             self.navigationController?.present(invitationViewController, animated: true)
         }
+        self.invitationViewController = nil
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RaceRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RaceRunningViewController.swift
@@ -113,6 +113,20 @@ private extension RaceRunningViewController {
             })
             .disposed(by: self.disposeBag)
         
+        output?.selfImageURL
+            .asDriver(onErrorJustReturn: "")
+            .drive(onNext: { [weak self] imageURL in
+                self?.myCardView.updateProfileImage(with: imageURL)
+            })
+            .disposed(by: self.disposeBag)
+        
+        output?.mateImageURL
+            .asDriver(onErrorJustReturn: "")
+            .drive(onNext: { [weak self] imageURL in
+                self?.mateCardView.updateProfileImage(with: imageURL)
+            })
+            .disposed(by: self.disposeBag)
+        
         Driver.zip(
             output?.myDistance.asDriver(onErrorJustReturn: "0.0") ?? Driver.just("0.0"),
             output?.mateDistance.asDriver(onErrorJustReturn: "0.0") ?? Driver.just("0.0")

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/RaceRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/RaceRunningViewModel.swift
@@ -30,6 +30,8 @@ final class RaceRunningViewModel {
         var cancelTimeLeft = PublishRelay<String>()
         var popUpShouldShow = PublishRelay<Bool>()
         var cancelledAlertShouldShow = PublishRelay<Bool>()
+        var selfImageURL = PublishRelay<String>()
+        var mateImageURL = PublishRelay<String>()
     }
     
     init(coordinator: RunningCoordinator, runningUseCase: RunningUseCase) {
@@ -45,6 +47,8 @@ final class RaceRunningViewModel {
     private func configureInput(_ input: Input, disposeBag: DisposeBag) {
         input.viewDidLoadEvent
             .subscribe(onNext: { [weak self] in
+                self?.runningUseCase.loadUserInfo()
+                self?.runningUseCase.loadMateInfo()
                 self?.runningUseCase.executePedometer()
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()
@@ -115,6 +119,14 @@ final class RaceRunningViewModel {
         
         self.runningUseCase.isCancelledByMate
             .bind(to: output.cancelledAlertShouldShow)
+            .disposed(by: disposeBag)
+        
+        self.runningUseCase.selfImageURL
+            .bind(to: output.selfImageURL)
+            .disposed(by: disposeBag)
+        
+        self.runningUseCase.mateImageURL
+            .bind(to: output.mateImageURL)
             .disposed(by: disposeBag)
         
         Observable.combineLatest(

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/SingleRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/SingleRunningViewModel.swift
@@ -42,6 +42,7 @@ final class SingleRunningViewModel {
     private func configureInput(_ input: Input, disposeBag: DisposeBag) {
         input.viewDidLoadEvent
             .subscribe(onNext: { [weak self] in
+                self?.runningUseCase.loadUserInfo()
                 self?.runningUseCase.executePedometer()
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/TeamRunningViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/RunningViewModel/TeamRunningViewModel.swift
@@ -45,6 +45,7 @@ final class TeamRunningViewModel {
     private func configureInput(_ input: Input, disposeBag: DisposeBag) {
         input.viewDidLoadEvent
             .subscribe(onNext: { [weak self] in
+                self?.runningUseCase.loadUserInfo()
                 self?.runningUseCase.executePedometer()
                 self?.runningUseCase.executeActivity()
                 self?.runningUseCase.executeTimer()

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/NotificationViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/NotificationViewModel.swift
@@ -42,7 +42,7 @@ final class NotificationViewModel {
         
         self.notificationUseCase.notices
             .subscribe(onNext: { [weak self] notices in
-                self?.notices = notices
+                self?.notices = notices.reversed()
                 output.didLoadData.accept(true)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
### 📕 Issue Number

Close #159 
Close #232 
Close #240 
Close #270 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 경쟁 모드에서 프로필 이미지 표시
- 이미지 url이 잘못되어 불러올 수 없는 경우 회색 표시
<img width="300px" src="https://user-images.githubusercontent.com/48787170/143768810-bffafb4c-c7c5-494c-bcde-3715a456a041.PNG" />

- 내 시점 & 메이트 시점
<img width="300px" src="https://user-images.githubusercontent.com/48787170/143769553-39a1c84f-3f44-466c-88b1-6c1b9561120a.PNG" />
<img width="300px" src="https://user-images.githubusercontent.com/48787170/143769556-5ec0dd9d-2b66-44b2-9fce-b8f47209f87b.PNG" />


- [x] 몸무게를 서버에서 받아와서 칼로리 계산
- [x] 최신 알림이 위에 오도록 알림 정렬
- [x] 처리된 초대장이 계속 팝업되는 버그 수정 (이건 여훈님이 해주셨습니다 ㅎ)


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 알림은 파이어스토어의 문서 아이디로 정렬되기 때문에 생성 날짜를 아이디에 넣어주고, 보여줄 때는 reverse하여 보여주도록 했습니다. 이렇게 하면 최신 알림이 위에 표시됩니다.
- 특이 사항 2 setImage로 이미지 설정하니 정말 편하네요 ㅎㅎ 유진님 여훈님 감사합니다!
- 특이 사항 3 지난번 PR을 보냈던 브랜치에서 checkout하고 이 브랜치를 생성했더니 지난번 작업 내용도 포함되어있네요ㅠㅠ 흑흑 죄송합니다

<br/><br/>
