### PR TITLE
메이트 화면 관련 버그 수정 및 emptyLabel 추가

### DIFF
--- a/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
@@ -42,6 +42,11 @@ final class AddMateTableViewCell: MateTableViewCell {
         self.configureUI()
         self.bindUI()
     }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.addButton.isEnabled = true
+    }
 }
 
 // MARK: - Private Functions

--- a/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
@@ -45,6 +45,7 @@ final class AddMateTableViewCell: MateTableViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        self.addButton.backgroundColor = .mrPurple
         self.addButton.isEnabled = true
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -56,6 +56,13 @@ class MateProfileViewController: UIViewController {
         return tableView
     }()
     
+    private lazy var emptyLabel: UILabel = {
+        let label = UILabel()
+        label.font = .notoSans(size: 16, family: .medium)
+        label.text = "메이트의 달리기 기록이 없네요 👀"
+        return label
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
@@ -71,6 +78,12 @@ private extension MateProfileViewController {
         self.tableView.snp.makeConstraints { make in
             make.top.bottom.left.right.equalToSuperview()
         }
+        
+        self.tableView.addSubview(self.emptyLabel)
+        self.emptyLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview().offset(50)
+        }
     }
     
     func bindViewModel() {
@@ -85,6 +98,7 @@ private extension MateProfileViewController {
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: { [weak self] _ in
                 self?.tableView.reloadData()
+                self?.checkEmptyLabel()
             })
             .disposed(by: self.disposeBag)
         
@@ -95,6 +109,7 @@ private extension MateProfileViewController {
                     IndexSet(1...1),
                     with: .none
                 )
+                self?.checkEmptyLabel()
             })
             .disposed(by: self.disposeBag)
         
@@ -116,6 +131,13 @@ private extension MateProfileViewController {
                 )
             })
             .disposed(by: self.disposeBag)
+    }
+    
+    func checkEmptyLabel() {
+        self.emptyLabel.isHidden = true
+        if self.viewModel?.recordInfo == nil {
+            self.emptyLabel.isHidden = false
+        }
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -30,8 +30,8 @@ final class MateProfileViewModel: NSObject {
     }
     
     init(nickname: String,
-        coordinator: MateProfileCoordinator,
-        profileUseCase: ProfileUseCase
+         coordinator: MateProfileCoordinator,
+         profileUseCase: ProfileUseCase
     ) {
         self.mateInfo = UserData(
             nickname: nickname,
@@ -109,6 +109,9 @@ final class MateProfileViewModel: NSObject {
     }
     
     func removeEmoji(runningID: String, mate: String) {
+        guard let index = self.selectedIndex,
+              let nickname = self.fetchUserNickname() else { return }
+        self.recordInfo?[index].removeEmoji(from: nickname)
         self.profileUseCase.deleteEmoji(from: runningID, of: mate)
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #271 #263 #247 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 메이트 프로픽 기록 EmptyLabel 추가
- [x] 이모지 전송 취소 후 디테일 뷰로 이동했을 때 반영이 안되는 버그 픽스
- [x] 메이트 관련 테이블 뷰 셀 prepareReuse 확인 및 수정
![Simulator Screen Recording - iPhone 13 - 2021-11-29 at 00 06 42](https://user-images.githubusercontent.com/41044154/143773678-354e5288-802a-4824-9b6d-d5b79d15441d.gif)


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br/><br/>
