### PR TITLE
메이트 프로필 기록 리스트 인피니티 스크롤 페이징 적용 

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		AE263BE9274E1E18004A61E5 /* ImageCacheError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BE8274E1E18004A61E5 /* ImageCacheError.swift */; };
 		AE263BEB274E5D99004A61E5 /* UIImageView+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BEA274E5D99004A61E5 /* UIImageView+ImageCache.swift */; };
 		AE263BED2751438E004A61E5 /* ComplimentEmoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BEC2751438E004A61E5 /* ComplimentEmoji.swift */; };
+		AE263BEF2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE263BEE2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift */; };
 		AE3D14852737C5E600D4A186 /* Mets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D14842737C5E600D4A186 /* Mets.swift */; };
 		AE3D148B273A5D8D00D4A186 /* MateHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */; };
 		AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3D148C273A5DB400D4A186 /* MateViewModel.swift */; };
@@ -452,6 +453,7 @@
 		AE263BE8274E1E18004A61E5 /* ImageCacheError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheError.swift; sourceTree = "<group>"; };
 		AE263BEA274E5D99004A61E5 /* UIImageView+ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+ImageCache.swift"; sourceTree = "<group>"; };
 		AE263BEC2751438E004A61E5 /* ComplimentEmoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplimentEmoji.swift; sourceTree = "<group>"; };
+		AE263BEE2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+ObserveScroll.swift"; sourceTree = "<group>"; };
 		AE3D14842737C5E600D4A186 /* Mets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mets.swift; sourceTree = "<group>"; };
 		AE3D148A273A5D8D00D4A186 /* MateHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MateHeaderView.swift; sourceTree = "<group>"; };
 		AE3D148C273A5DB400D4A186 /* MateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MateViewModel.swift; path = MateRunner/Presentation/MateScene/ViewModel/MateViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -1229,6 +1231,7 @@
 				B0A0DA232744A20B004DDC71 /* Point+CLLocationCoordinate2D.swift */,
 				5ED367DC27462BAD00901765 /* Int+Formatter.swift */,
 				AE263BEA274E5D99004A61E5 /* UIImageView+ImageCache.swift */,
+				AE263BEE2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2108,6 +2111,7 @@
 				B06182B1274E0B6000EE7929 /* PersonalTotalRecordDTO.swift in Sources */,
 				5E5E5557274514F6002FE126 /* RecordCoordinator.swift in Sources */,
 				5E7B862827495A88003F9FA2 /* CalendarModel.swift in Sources */,
+				AE263BEF2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift in Sources */,
 				5E7DEE7E273FAA0B002E1374 /* LoginViewController.swift in Sources */,
 				3D622573274E036C00E4A327 /* LicenseCoordinator.swift in Sources */,
 				B0A0DA2027441AD5004DDC71 /* LocationAuthorizationStatus.swift in Sources */,

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -35,8 +35,8 @@ final class DefaultProfileUseCase: ProfileUseCase {
             .disposed(by: self.disposeBag)
     }
     
-    func fetchRecordList(nickname: String) {
-        self.firestoreRepository.fetchResult(of: nickname, from: 0, by: 20)
+    func fetchRecordList(nickname: String, from index: Int, by count: Int) {
+        self.firestoreRepository.fetchResult(of: nickname, from: index, by: count)
             .subscribe(onNext: { [weak self] records in
                 Observable<RunningResult>.zip( records.map { [weak self] record in
                     self?.fetchRecordEmoji(record, from: nickname) ?? Observable.of(record)

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/Protocol/ProfileUseCase.swift
@@ -14,7 +14,7 @@ protocol ProfileUseCase: EmojiDidSelectDelegate {
     var recordInfo: PublishSubject<[RunningResult]> { get set }
     var selectEmoji: PublishSubject<Emoji> { get set }
     func fetchUserInfo(_ nickname: String)
-    func fetchRecordList(nickname: String)
+    func fetchRecordList(nickname: String, from index: Int, by count: Int)
     func fetchUserNickname() -> String?
     func emojiDidSelect(selectedEmoji: Emoji)
     func deleteEmoji(from runningID: String, of mate: String)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -90,7 +90,7 @@ private extension MateProfileViewController {
         let input = MateProfileViewModel.Input(
             viewDidLoadEvent: Observable.just(()),
             refreshEvent: self.refreshControl.rx.controlEvent(.valueChanged).asObservable(),
-            scrollEvent: self.tableView.rx.endToScroll().asObservable()
+            scrollEvent: self.tableView.rx.scrollToBottom().asObservable()
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -89,7 +89,8 @@ private extension MateProfileViewController {
     func bindViewModel() {
         let input = MateProfileViewModel.Input(
             viewDidLoadEvent: Observable.just(()),
-            refreshEvent: self.refreshControl.rx.controlEvent(.valueChanged).asObservable()
+            refreshEvent: self.refreshControl.rx.controlEvent(.valueChanged).asObservable(),
+            scrollEvent: self.tableView.rx.endToScroll().asObservable()
         )
         
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
@@ -105,10 +106,11 @@ private extension MateProfileViewController {
         output?.loadRecord
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: { [weak self] _ in
-                self?.tableView.reloadSections(
-                    IndexSet(1...1),
-                    with: .none
-                )
+//                self?.tableView.reloadSections(
+//                    IndexSet(1...1),
+//                    with: .top
+//                )
+                self?.tableView.reloadData()
                 self?.checkEmptyLabel()
             })
             .disposed(by: self.disposeBag)
@@ -124,7 +126,7 @@ private extension MateProfileViewController {
             .drive(onNext: { [weak self] emoji in
                 guard let index = self?.viewModel?.selectedIndex else { return }
                 guard let selfNickname = self?.viewModel?.fetchUserNickname() else { return }
-                self?.viewModel?.recordInfo?[index].addEmoji(emoji, from: selfNickname)
+                self?.viewModel?.recordInfo[index].addEmoji(emoji, from: selfNickname)
                 self?.tableView.reloadSections(
                     IndexSet(1...1),
                     with: .none
@@ -225,7 +227,7 @@ extension MateProfileViewController: UITableViewDataSource {
         case MateProfileTableViewSection.profileSection.number():
             return 1
         case MateProfileTableViewSection.recordSection.number():
-            return self.viewModel?.recordInfo?.count ?? 0
+            return self.viewModel?.recordInfo.count ?? 0
         default:
             return 0
         }
@@ -234,7 +236,7 @@ extension MateProfileViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if indexPath.section == 1 {
-            let record = self.viewModel?.recordInfo?[indexPath.row]
+            let record = self.viewModel?.recordInfo[indexPath.row]
             guard let record = record else { return }
             self.viewModel?.moveToDetail(record: record)
         }
@@ -246,7 +248,7 @@ extension MateProfileViewController: UITableViewDataSource {
 extension MateProfileViewController: HeartButtonDidTapDelegate {
     func heartButtonDidTap(_ sender: MateRecordTableViewCell, isCanceled: Bool) {
         guard let selectedIndex = self.tableView.indexPath(for: sender)?.row,
-              let result = self.viewModel?.recordInfo?[selectedIndex] else { return }
+              let result = self.viewModel?.recordInfo[selectedIndex] else { return }
         self.viewModel?.selectedIndex = selectedIndex
         isCanceled
         ? self.viewModel?.removeEmoji(runningID: result.runningID, mate: result.resultOwner)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewController/MateProfileViewController.swift
@@ -106,10 +106,6 @@ private extension MateProfileViewController {
         output?.loadRecord
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: { [weak self] _ in
-//                self?.tableView.reloadSections(
-//                    IndexSet(1...1),
-//                    with: .top
-//                )
                 self?.tableView.reloadData()
                 self?.checkEmptyLabel()
             })

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -80,7 +80,7 @@ final class MateProfileViewModel: NSObject {
         
         self.profileUseCase.recordInfo
             .subscribe(onNext: { [weak self] record in
-                record.forEach { self?.recordInfo.append($0) }
+                self?.recordInfo.append(contentsOf: record)
                 if record.count < 5 {
                     self?.hasNextPage = false
                 }
@@ -129,14 +129,5 @@ final class MateProfileViewModel: NSObject {
               let nickname = self.fetchUserNickname() else { return }
         self.recordInfo[index].removeEmoji(from: nickname)
         self.profileUseCase.deleteEmoji(from: runningID, of: mate)
-    }
-    
-    // paging
-    func paging() {
-        let index = self.recordInfo.count
-        guard let nickname = self.mateInfo?.nickname else { return }
-        
-        self.profileUseCase.fetchRecordList(nickname: nickname, from: index, by: 5)
-        
     }
 }

--- a/MateRunner/MateRunner/Util/Extension/UIScrollView+ObserveScroll.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIScrollView+ObserveScroll.swift
@@ -17,8 +17,9 @@ public extension Reactive where Base: UIScrollView {
             let contentHeight = self.base.contentSize.height
             let height = self.base.frame.height
             
-            return offsetY > (contentHeight - height)
+            return offsetY > (contentHeight - height + 150)
         }
+        .distinctUntilChanged()
         .filter { $0 }
         .map { _ in () }
         )

--- a/MateRunner/MateRunner/Util/Extension/UIScrollView+ObserveScroll.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIScrollView+ObserveScroll.swift
@@ -1,0 +1,26 @@
+//
+//  UIScrollView+ObserveScroll.swift
+//  MateRunner
+//
+//  Created by 이유진 on 2021/11/29.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+public extension Reactive where Base: UIScrollView {
+    func endToScroll() -> ControlEvent<Void> {
+        return ControlEvent( events: contentOffset.map { offset in
+            let offsetY = offset.y
+            let contentHeight = self.base.contentSize.height
+            let height = self.base.frame.height
+            
+            return offsetY > (contentHeight - height)
+        }
+        .filter { $0 }
+        .map { _ in () }
+        )
+    }
+}

--- a/MateRunner/MateRunner/Util/Extension/UIScrollView+ObserveScroll.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIScrollView+ObserveScroll.swift
@@ -11,7 +11,7 @@ import RxCocoa
 import RxSwift
 
 public extension Reactive where Base: UIScrollView {
-    func endToScroll() -> ControlEvent<Void> {
+    func scrollToBottom() -> ControlEvent<Void> {
         return ControlEvent( events: contentOffset.map { offset in
             let offsetY = offset.y
             let contentHeight = self.base.contentSize.height


### PR DESCRIPTION
### 📕 Issue Number

Close #280 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 메이트 프로필 기록 리스트 인피니티 스크롤 적용 
- [x] 페이징 fetch 로 변경
![Simulator Screen Recording - iPhone 13 - 2021-11-29 at 02 46 14](https://user-images.githubusercontent.com/41044154/143779619-c191d8c4-9a92-4826-852a-a02b21138e4e.gif)

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
total 페이지를 서버로부터 받을 수 없기 때문에 limit을 건 부분과 페이지로 디코딩 되어진 list의 카운트를 비교해 디코딩 count가 더 작다면 다음 페이지가 없다는 flag값을 두었습니다

- 특이 사항 2
인티니티 스크롤로 바꾸고 나서 섹션1(메이트 기록 리스트)만 리로드 하는 부분을 아예 tableView.reloadData()로 변경하게 되었는데 이유는 section만 리로드를 시킬경우에 none을 적용시켜도 섹션 한개만 다시 그리기 때문에 애니메이션이 적용되는데 이게 너무 제눈엔 좀 이상합니다.. 그래서 고민하다가 일단 전체 리로드 방식으로 변경하게 되었습니다.. 
![Simulator Screen Recording - iPhone 13 - 2021-11-29 at 02 49 21](https://user-images.githubusercontent.com/41044154/143779725-572b83e4-ff6f-4887-825f-3f388699de31.gif)


<br/><br/>
