### PR TITLE
캐싱 정책 변경 및 etag를 사용한 조건부 get 구현 

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		B0E72E10272FCDEE009E5635 /* NotoSansKR-medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F46272FCDA2005A3A5C /* NotoSansKR-medium.otf */; };
 		B0E72E11272FCDEE009E5635 /* NotoSansKR-black.otf in Resources */ = {isa = PBXBuildFile; fileRef = AE6A6F48272FCDA2005A3A5C /* NotoSansKR-black.otf */; };
 		B0E72E15272FD2CC009E5635 /* DistanceSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E72E14272FD2CC009E5635 /* DistanceSettingViewModel.swift */; };
+		B0EB7AD22753FC0F00DC8AD6 /* CacheableImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EB7AD12753FC0F00DC8AD6 /* CacheableImage.swift */; };
 		B0F53285273A29EA005A3F11 /* TabBarPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53284273A29EA005A3F11 /* TabBarPage.swift */; };
 		B0F53289273A32E0005A3F11 /* CoordinatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53288273A32E0005A3F11 /* CoordinatorType.swift */; };
 		B0F5328B273A3397005A3F11 /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5328A273A3397005A3F11 /* TabBarCoordinator.swift */; };
@@ -576,6 +577,7 @@
 		B0CF5C8227480CD1002217F6 /* RunningResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningResultViewController.swift; sourceTree = "<group>"; };
 		B0CF5C842748276F002217F6 /* RaceRunningResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResultViewModel.swift; sourceTree = "<group>"; };
 		B0E72E14272FD2CC009E5635 /* DistanceSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceSettingViewModel.swift; sourceTree = "<group>"; };
+		B0EB7AD12753FC0F00DC8AD6 /* CacheableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheableImage.swift; sourceTree = "<group>"; };
 		B0F53284273A29EA005A3F11 /* TabBarPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPage.swift; sourceTree = "<group>"; };
 		B0F53288273A32E0005A3F11 /* CoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorType.swift; sourceTree = "<group>"; };
 		B0F5328A273A3397005A3F11 /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
@@ -866,6 +868,7 @@
 				B0C85185274E68FF0070BB66 /* PersonalTotalRecord.swift */,
 				AE263BE3274DDD7F004A61E5 /* Notice.swift */,
 				AE263BEC2751438E004A61E5 /* ComplimentEmoji.swift */,
+				B0EB7AD12753FC0F00DC8AD6 /* CacheableImage.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -2158,6 +2161,7 @@
 				AE6A6F2D272CCB2A005A3A5C /* RecordViewController.swift in Sources */,
 				3D622565274CDCC500E4A327 /* MyPageCoordinator.swift in Sources */,
 				AEDAFD18273526FC009BAEAA /* DefaultRunningUseCase.swift in Sources */,
+				B0EB7AD22753FC0F00DC8AD6 /* CacheableImage.swift in Sources */,
 				AE3D148D273A5DB400D4A186 /* MateViewModel.swift in Sources */,
 				AE263BE6274E1755004A61E5 /* DefaultImageCacheService.swift in Sources */,
 				5E32DC652731004D000E525B /* BehaviorRelayProperty.swift in Sources */,

--- a/MateRunner/MateRunner/Domain/Model/CacheableImage.swift
+++ b/MateRunner/MateRunner/Domain/Model/CacheableImage.swift
@@ -1,0 +1,18 @@
+//
+//  CachableImage.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/29.
+//
+
+import Foundation
+
+final class CacheableImage {
+    let imageData: Data
+    let etag: String
+    
+    init(imageData: Data, etag: String) {
+        self.imageData = imageData
+        self.etag = etag
+    }
+}

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/DefaultProfileEditUseCase.swift
@@ -55,12 +55,7 @@ final class DefaultProfileEditUseCase: ProfileEditUseCase {
         )
             .subscribe(onNext: { [weak self] _ in
                 self?.saveResult.onNext(true)
-                self?.cacheNewImage(data: imageData, with: imageURL)
             })
             .disposed(by: self.disposeBag)
-    }
-    
-    func cacheNewImage(data imageData: Data, with imageURL: String) {
-        DefaultImageCacheService.shared.replace(imageData: imageData, of: imageURL)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
@@ -7,7 +7,11 @@
 
 import UIKit
 
+import RxSwift
+
 final class RunningCardView: UIView {
+    private let disposeBag = DisposeBag()
+    
     private lazy var profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .lightGray
@@ -39,7 +43,7 @@ final class RunningCardView: UIView {
     }
     
     func updateProfileImage(with imageURL: String) {
-        self.profileImageView.setImage(with: imageURL)
+        self.profileImageView.setImage(with: imageURL, disposeBag: self.disposeBag)
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
@@ -19,7 +19,6 @@ final class AddMateTableViewCell: MateTableViewCell {
         return String(describing: Self.self)
     }
     weak var delegate: AddMateDelegate?
-    private let disposeBag = DisposeBag()
     
     private lazy var addButton: UIButton = {
         let button = UIButton()

--- a/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/AddMateTableViewCell.swift
@@ -18,6 +18,7 @@ final class AddMateTableViewCell: MateTableViewCell {
     static var addIdentifier: String {
         return String(describing: Self.self)
     }
+    private let disposeBag = DisposeBag()
     weak var delegate: AddMateDelegate?
     
     private lazy var addButton: UIButton = {

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateProfileTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateProfileTableViewCell.swift
@@ -7,9 +7,11 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 
 final class MateProfilTableViewCell: UITableViewCell {
+    private let disposeBag = DisposeBag()
     static var identifier: String {
         return String(describing: Self.self)
     }
@@ -47,7 +49,7 @@ final class MateProfilTableViewCell: UITableViewCell {
     }
     
     func updateUI(imageURL: String, nickname: String, time: String, distance: String, calorie: String) {
-        self.mateProfileImageView.setImage(with: imageURL)
+        self.mateProfileImageView.setImage(with: imageURL, disposeBag: self.disposeBag)
         self.mateNickname.text = nickname
         self.cumulativeRecordView.timeLabel.text = time
         self.cumulativeRecordView.distanceLabel.text = distance

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateTableViewCell.swift
@@ -7,9 +7,12 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 
 class MateTableViewCell: UITableViewCell {
+    private let disposeBag = DisposeBag()
+    
     static var identifier: String {
         return String(describing: Self.self)
     }
@@ -45,7 +48,7 @@ class MateTableViewCell: UITableViewCell {
     }
     
     func updateUI(name: String, image: String) {
-        self.mateProfileImageView.setImage(with: image)
+        self.mateProfileImageView.setImage(with: image, disposeBag: self.disposeBag)
         self.mateNameLabel.text = name
     }
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -118,7 +118,8 @@ private extension MyPageViewController {
         output.imageURL
             .asDriver(onErrorJustReturn: "")
             .drive(onNext: { [weak self] imageURL in
-                self?.profileImageView.setImage(with: imageURL)
+                guard let self = self else { return }
+                self.profileImageView.setImage(with: imageURL, disposeBag: self.disposeBag)
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/ProfileEditViewController.swift
@@ -117,7 +117,8 @@ private extension ProfileEditViewController {
         output?.imageURL
             .asDriver()
             .drive(onNext: { [weak self] imageURL in
-                self?.imageEditButton.profileImageView.setImage(with: imageURL)
+                guard let self = self else { return }
+                self.imageEditButton.profileImageView.setImage(with: imageURL, disposeBag: self.disposeBag)
             })
             .disposed(by: self.disposeBag)
         

--- a/MateRunner/MateRunner/Util/Error/ImageCacheError.swift
+++ b/MateRunner/MateRunner/Util/Error/ImageCacheError.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum ImageCacheError: Error {
-    case nilPathError, nilImageError, invalidURLError
+    case nilPathError, nilImageError, invalidURLError, imageNotModifiedError
 }

--- a/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
+++ b/MateRunner/MateRunner/Util/Extension/UIImageView+ImageCache.swift
@@ -10,12 +10,12 @@ import UIKit
 import RxSwift
 
 extension UIImageView {
-    func setImage(with url: String) {
+    func setImage(with url: String, disposeBag: DisposeBag) {
         DefaultImageCacheService.shared.setImage(url)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] image in
-                self?.image = image
+                self?.image = UIImage(data: image)
             })
-            .dispose()
+            .disposed(by: disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -10,7 +10,17 @@ import UIKit
 import RxSwift
 
 enum ImageCache {
-    static var cache = NSCache<NSString, UIImage>()
+    static var cache = NSCache<NSString, CachableImage>()
+}
+
+final class CachableImage: Codable {
+    let imageData: Data
+    let etag: String
+    
+    init(imageData: Data, etag: String) {
+        self.imageData = imageData
+        self.etag = etag
+    }
 }
 
 final class DefaultImageCacheService {
@@ -18,75 +28,87 @@ final class DefaultImageCacheService {
     static let shared = DefaultImageCacheService()
     private init () {}
     
-    func setImage(_ url: String) -> Observable<UIImage> {
+    func setImage(_ url: String) -> Observable<Data> {
         guard let imageURL = URL(string: url) else {
             return Observable.error(ImageCacheError.invalidURLError)
         }
         
         // 1. Lookup NSCache
         if let image = self.checkMemory(url) {
-            return Observable.just(image)
+            print("cache hit")
+            print(image)
+            return self.conditionalGet(imageURL: imageURL, etag: image.etag, conditional: true)
+                .map({ $0.imageData })
+                .catchAndReturn(image.imageData)
         }
         
         // 2. Lookup Disk
         if let image = self.checkDisk(imageURL) {
-            self.saveIntoCache(imageURL: imageURL, image: image)
-            return Observable.just(image)
+            print("disk hit")
+            return self.conditionalGet(imageURL: imageURL, etag: image.etag, conditional: true)
+                .map({ $0.imageData })
+                .catchAndReturn(image.imageData)
         }
         
         // 3. Network Request
-        return Observable<UIImage>.create { emitter in
-            let request = URLRequest(url: imageURL)
+        return self.conditionalGet(imageURL: imageURL, etag: "", conditional: false)
+            .map({ $0.imageData })
+    }
+    
+    private func conditionalGet(imageURL: URL, etag: String, conditional: Bool) -> Observable<CachableImage> {
+        return Observable<CachableImage>.create { emitter in
+            var request = URLRequest(url: imageURL)
+            if conditional {
+                request.addValue(etag, forHTTPHeaderField: "If-None-Match")
+            }
             URLSession.shared.rx.response(request: request).subscribe(
-                onNext: { [weak self] response in
-                    guard let image = UIImage(data: response.data) else { return }
-                    self?.saveIntoCache(imageURL: imageURL, image: image)
-                    self?.saveIntoDisk(imageURL: imageURL, image: image)
-                    emitter.onNext(image)
+                onNext: { [weak self] (response, data) in
+                    if (200...299) ~= response.statusCode {
+                        let etag = response.allHeaderFields["Etag"] as? String ?? ""
+                        let image = CachableImage(imageData: data, etag: etag)
+                        self?.saveIntoCache(imageURL: imageURL, image: image)
+                        self?.saveIntoDisk(imageURL: imageURL, image: image)
+                        emitter.onNext(image)
+                    } else if response.statusCode == 304 {
+                        emitter.onError(ImageCacheError.nilImageError)
+                    }
                 },
                 onError: { error in
                     emitter.onError(error)
                 }
             ).disposed(by: self.disposeBag)
-
+            
             return Disposables.create()
         }
     }
     
-    func replace(imageData: Data, of imageURL: String) {
-        guard let image = UIImage(data: imageData),
-              let imageURL = URL(string: imageURL) else { return }
-        self.saveIntoCache(imageURL: imageURL, image: image)
-        self.saveIntoDisk(imageURL: imageURL, image: image)
-    }
-    
-    private func checkMemory(_ url: String) -> UIImage? {
+    private func checkMemory(_ url: String) -> CachableImage? {
         let cacheKey = NSString(string: url)
-        if let cachedImage = ImageCache.cache.object(forKey: cacheKey) {
-            return cachedImage
-        }
-        return nil
+        return ImageCache.cache.object(forKey: cacheKey)
     }
     
-    private func checkDisk(_ imageURL: URL) -> UIImage? {
+    private func checkDisk(_ imageURL: URL) -> CachableImage? {
         guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else {
             return nil
         }
         let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
+        
         if FileManager.default.fileExists(atPath: filePath.path) {
-            guard let imageData = try? Data(contentsOf: filePath) else { return nil }
-            return UIImage(data: imageData)
+            guard let imageData = try? Data(contentsOf: filePath),
+                  let etag = UserDefaults.standard.string(forKey: imageURL.absoluteString)else { return nil }
+            return CachableImage(imageData: imageData, etag: etag)
         }
         return nil
     }
     
-    private func saveIntoCache(imageURL: URL, image: UIImage) {
+    private func saveIntoCache(imageURL: URL, image: CachableImage) {
         ImageCache.cache.setObject(image, forKey: NSString(string: imageURL.absoluteString))
     }
     
-    private func saveIntoDisk(imageURL: URL, image: UIImage) {
+    private func saveIntoDisk(imageURL: URL, image: CachableImage) {
         guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else { return }
         let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
-        FileManager.default.createFile(atPath: filePath.path, contents: image.pngData(), attributes: nil)
+        UserDefaults.standard.set(image.etag, forKey: imageURL.absoluteString)
+        FileManager.default.createFile(atPath: filePath.path, contents: image.imageData, attributes: nil)
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #277

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 캐싱 개선 
- [x] etag를 사용한 조건부 get 구현 


https://user-images.githubusercontent.com/46087477/143781148-33acb6d5-7f92-43a5-a58d-582ae080aff3.MP4


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 캐시 저장 데이터 타입 변경
캐시에 저장하는 데이터 타입을 UIImage에서 `CacheableData(imageData: Data, etag: String)` 으로 변경하였습니다. 데이터에 대한 etag정보를 함께 보관하기 위해서 이렇게 했어요!

- etag 적용
etag를 사용해서 현재 디스크나 메모리에 가지고 있는 데이터가 최신데이터인지 확인할 수 있도록 변경했습니다. GET 요청을 보낼 때 헤더에 `If-None-Match : {etag}`를 보내게 되면, 서버에 있는 etag가 헤더의 etag와 동일하면 데이터 없이 `304: Not Modified`를 리턴하고, 다르면 200과 함께 새로운 데이터를 반환합니다. 따라서 메모리나 디스크 캐시에서 hit가 발생하면 해당 데이터의 etag로 요청을 보내 최신데이터인지 확인하는 과정을 추가했습니다.

```swift
 // 1. Lookup NSCache
        if let image = self.checkMemory(url) {
            return self.get(imageURL: imageURL, etag: image.etag)
                .map({ $0.imageData })
                .catchAndReturn(image.imageData) // 304 에서 error가 오면 캐싱된 데이터 사용
        }
        
        // 2. Lookup Disk
        if let image = self.checkDisk(imageURL) {
            return self.get(imageURL: imageURL, etag: image.etag)
                .map({ $0.imageData })
                .catchAndReturn(image.imageData)
        }
        
        // 3. Network Request
        return self.get(imageURL: imageURL)
            .map({ $0.imageData })
```

위 코드의 전체 과정을 간단히 요약하면 이렇습니다.

```
1. 메모리 캐시를 확인
      1-1. hit: hit된 CacheableImage 객체에서 etag를 꺼내 conditional get 요청 전송.
              1-1-1. 304(Not Modified): 캐시의 데이터가 서버의 데이터와 동일하므로 현재 데이터를 그대로 반환 
              1-1-2. 200(OK): 캐시의 데이터는 아웃데이트된 데이터이므로 서버에게 새로 받은 데이터를 캐시에 저장한 후 반환. 
                                         이때 새로 갱신된 etag도 저장 
      1-2. miss: 디스크 체킹으로 이동
2.  디스크 캐시 확인 
      1-1. hit: hit된 CacheableImage 객체에서 etag를 꺼내 conditional get 요청 전송.
              1-1-1. 304(Not Modified): 캐시의 데이터가 서버의 데이터와 동일하므로 현재 데이터를 그대로 반환 
              1-1-2. 200(OK): 캐시의 데이터는 아웃데이트된 데이터이므로 서버에게 새로 받은 데이터를 캐시에 저장한 후 반환. 
                                         이때 새로 갱신된 etag도 저장 
      1-2. miss: 네트워크 요청으로 이동
3. 네트워크 요청 
      - 전달받은 주소로 get 요청을 보내 데이터를 받고 etag와 데이터를 캐시에 저장한 뒤 데이터 반환 
```

etag와 이미지 데이터를 함께 디스크에 저장할 수 있는 방법이 없어서 디스크 캐싱에서는 Data파일만 스토리지에 넣고 UserDefaults에 이미지 주소와 etag를 맵핑해 저장합니다.

- 새로 올릴 때 캐시를 업데이트 해줄 필요도 없어졌어요!
캐시 hit가 발생해도 무조건 서버에 etag를 확인하는 작업을 거치기 때문에 직접 캐시를 교체할 필요가 없어졌습니다. 프로필을 변경하면 다시 마이페이지로 돌아갔을 때 이미 없어진 etag를 서버에 요청하므로 새로운 이미지를 받아옵니다.

- disposeBag
어제 subscribe가 시작되자마자 dispose가 되는 현상이 있었는데, disposeBag이 함수 안에서 인스턴스가 생성되어서 함수가 끝나면 곧바로 폐기되는 문제였습니다. 그래서 setImage를 할 때 외부에서 자신의 disposeBag을 전달해주는 것으로 변경했습니다. 지금 있는 함수호출들은 제가 수정해두었어요!

```swift
func setImage(with url: String, disposeBag: DisposeBag)
```

- UIKit 분리
아무래도 UIKit을 떼어내는게 좋을 것 같아서 캐시 서비스에서는 Data로 관리하고 반환된 Data를 UIImage로 변경하도록 반환타입을 변경했습니다.

프로필이 변경되었을 때 반영되는지는 제가 서버에서 이미지를 바꿔보면서 확인해보긴 했는데, 앱 대 앱으로 확인한건 아니라서 내일 테스트해보면 좋을 것 같습니다!

<br/><br/>
