### PR TITLE
[마이페이지 화면] 회원탈퇴 기능 구현

### DIFF
--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
@@ -20,6 +20,10 @@ final class DefaultUserRepository: UserRepository {
         return UserDefaults.standard.string(forKey: UserDefaultKey.fcmToken.rawValue)
     }
     
+    func fetchFCMTokenFromServer(of nickname: String) -> Observable<String> {
+        return self.realtimeDatabaseNetworkService.fetchFCMToken(of: nickname)
+    }
+    
     func deleteFCMToken() {
         UserDefaults.standard.removeObject(forKey: UserDefaultKey.fcmToken.rawValue)
     }

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultUserRepository.swift
@@ -40,4 +40,9 @@ final class DefaultUserRepository: UserRepository {
     func saveLogoutInfo() {
         UserDefaults.standard.set(false, forKey: UserDefaultKey.isLoggedIn.rawValue)
     }
+    
+    func deleteUserInfo() {
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.isLoggedIn.rawValue)
+        UserDefaults.standard.removeObject(forKey: UserDefaultKey.nickname.rawValue)
+    }
 }

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/FirestoreRepository.swift
@@ -126,4 +126,12 @@ protocol FirestoreRepository {
     func fetchUserNickname(
         of uid: String
     ) -> Observable<String>
+    
+    func fetchUID(
+        of nickname: String
+    ) -> Observable<String?>
+    
+    func removeUID(
+        uid: String
+    ) -> Observable<Void>
 }

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/UserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/UserRepository.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 protocol UserRepository {
     func fetchFCMToken() -> String?
+    func fetchFCMTokenFromServer(of nickname: String) -> Observable<String>
     func deleteFCMToken()
     func saveFCMToken(_ fcmToken: String, of nickname: String) -> Observable<Void>
     func fetchUserNickname() -> String?

--- a/MateRunner/MateRunner/Data/Repository/Common/Protocol/UserRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/Protocol/UserRepository.swift
@@ -16,4 +16,5 @@ protocol UserRepository {
     func fetchUserNickname() -> String?
     func saveLoginInfo(nickname: String)
     func saveLogoutInfo()
+    func deleteUserInfo()
 }

--- a/MateRunner/MateRunner/Domain/Model/FirestoreValues.swift
+++ b/MateRunner/MateRunner/Domain/Model/FirestoreValues.swift
@@ -139,3 +139,11 @@ struct QueryResultValue<T: Codable>: Codable {
         case readTime, document
     }
 }
+
+struct Document: Codable {
+    let name: String?
+    
+    private enum CodingKeys: String, CodingKey {
+        case name
+    }
+}

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 final class DefaultSignUpUseCase: SignUpUseCase {
-    private let repository: UserRepository
+    private let userRepository: UserRepository
     private let firestoreRepository: FirestoreRepository
     private let uid: String
     var validText = PublishSubject<String?>()
@@ -25,7 +25,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
         firestoreRepository: FirestoreRepository,
         uid: String
     ) {
-        self.repository = repository
+        self.userRepository = repository
         self.firestoreRepository = firestoreRepository
         self.uid = uid
     }
@@ -43,7 +43,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     func checkDuplicate(of nickname: String?) {
         guard let nickname = nickname else { return }
 
-        self.repository.fetchFCMTokenFromServer(of: nickname)
+        self.userRepository.fetchFCMTokenFromServer(of: nickname)
             .subscribe(onNext: { [weak self] _ in
                 self?.canSignUp.onNext(false)
             }, onError: { [weak self] _ in
@@ -79,18 +79,18 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     }
     
     func saveFCMToken(of nickname: String?) {
-        guard let fcmToken = self.repository.fetchFCMToken(),
+        guard let fcmToken = self.userRepository.fetchFCMToken(),
               let nickname = nickname else { return }
 
-        self.repository.saveFCMToken(fcmToken, of: nickname)
+        self.userRepository.saveFCMToken(fcmToken, of: nickname)
             .subscribe(onNext: { [weak self] in
-                self?.repository.deleteFCMToken()
+                self?.userRepository.deleteFCMToken()
             })
             .disposed(by: self.disposeBag)
     }
     
     func saveLoginInfo(nickname: String?) {
         guard let nickname = nickname else { return }
-        self.repository.saveLoginInfo(nickname: nickname)
+        self.userRepository.saveLoginInfo(nickname: nickname)
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -43,7 +43,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     func checkDuplicate(of nickname: String?) {
         guard let nickname = nickname else { return }
 
-        self.firestoreRepository.fetchUserData(of: nickname)
+        self.repository.fetchFCMTokenFromServer(of: nickname)
             .subscribe(onNext: { [weak self] _ in
                 self?.canSignUp.onNext(false)
             }, onError: { [weak self] _ in

--- a/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/MyPageUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/MyPage/Protocol/MyPageUseCase.swift
@@ -14,4 +14,5 @@ protocol MyPageUseCase {
     var imageURL: PublishSubject<String> { get set }
     func loadUserInfo()
     func logout()
+    func deleteUserData() -> Observable<Bool>
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -27,7 +27,7 @@ final class SignUpViewModel {
         var heightFieldText = BehaviorRelay<String>(value: "")
         var heightRange = BehaviorRelay<[String]>(value: Height.range.map { "\($0) cm" })
         var heightPickerRow = BehaviorRelay<Int?>(value: nil)
-        var weightFieldText = BehaviorRelay<String>(value: "60 kg")
+        var weightFieldText = BehaviorRelay<String>(value: "")
         var weightRange = BehaviorRelay<[String]>(value: Weight.range.map { "\($0) kg" })
         var weightPickerRow = BehaviorRelay<Int?>(value: nil)
         var nicknameFieldText = BehaviorRelay<String?>(value: "")

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -263,18 +263,18 @@ private extension MyPageViewController {
         
         let cancel = UIAlertAction(
             title: cancelTitle,
-            style: .destructive,
+            style: .cancel,
             handler: nil
         )
         
         let confirm = UIAlertAction(
             title: confirmTitle,
-            style: .default,
+            style: isLogout ? .default : .destructive,
             handler: { [weak self] _ in
                 if isLogout {
                     self?.viewModel?.logout()
                 } else {
-                    print("withdrawal")
+                    self?.viewModel?.withdraw()
                 }
             }
         )

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewModel/MyPageViewModel.swift
@@ -13,6 +13,7 @@ import RxSwift
 final class MyPageViewModel {
     private weak var myPageCoordinator: MyPageCoordinator?
     private let myPageUseCase: MyPageUseCase
+    private let disposeBag = DisposeBag()
     
     init(
         myPageCoordinator: MyPageCoordinator,
@@ -78,6 +79,12 @@ final class MyPageViewModel {
     }
     
     func withdraw() {
-        
+        self.myPageUseCase.deleteUserData()
+            .asDriver(onErrorJustReturn: false)
+            .filter { $0 }
+            .drive(onNext: { [weak self] _ in
+                self?.myPageCoordinator?.finish()
+            })
+            .disposed(by: self.disposeBag)
     }
 }

--- a/MateRunner/MateRunner/Util/Constant/FirestoreQuery.swift
+++ b/MateRunner/MateRunner/Util/Constant/FirestoreQuery.swift
@@ -163,4 +163,23 @@ enum FirestoreQuery {
         }
         """.data(using: .utf8)
     }
+    
+    static func uidFilter(by nickname: String) -> Data? {
+        return """
+        {
+            "structuredQuery": {
+                "from": {
+                    "collectionId": "UID",
+                },
+                "where": {
+                    "fieldFilter": {
+                        "field": { "fieldPath": "nickname" },
+                        "op": "EQUAL",
+                        "value": { "stringValue": "\(nickname)" }
+                    }
+                }
+            }
+        }
+        """.data(using: .utf8)
+    }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #341 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

https://user-images.githubusercontent.com/77449223/143897996-e54b4aab-5dee-49ce-bc6f-5dabc3a57844.MP4

- [x] 회원탈퇴시 UID, User 정보 삭제
- [x] 로그인 화면으로 이동 


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Slack에서 말씀드린 것처럼 회원가입시 FCM 토큰으로 아이디 중복을 체크하여 이전에 사용했던 아이디를 사용할 수 없도록 하였습니다.
- 회원 탈퇴를 하고 다시 가입을 하기 위해 Apple 로그인을 하려 했을 때 다음 화면처럼 나오게 하고 싶었는데요, 이건 사용자가 직접 설정에서 Apple ID 사용 중단을 하지 않는 이상 어쩔 수 없는 것 같습니다. 제가 마이리얼트립 계정을 Apple 로그인으로 가입하고 탈퇴해서 실험해봤는데 거기도 마찬가지였어요! 
<img src="https://user-images.githubusercontent.com/77449223/143899754-778eb669-f1fc-4932-9077-def57c43939c.jpeg" width="200" />
<img src="https://user-images.githubusercontent.com/77449223/143900372-4e76b16e-ed98-4dc7-b36a-cda8f247b34e.jpeg" width="200" />



<br/><br/>
