### PR TITLE
메이트 프로필 기록 최신순으로 정렬 및 리프레쉬 버그 수정

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/Home/SettingUseCase/DefaultRunningSettingUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Home/SettingUseCase/DefaultRunningSettingUseCase.swift
@@ -41,7 +41,7 @@ final class DefaultRunningSettingUseCase: RunningSettingUseCase {
     }
     
     private func createSessionId(with userNickname: String) -> String {
-        return "session-\(userNickname)-\(Date().fullDateTimeNumberString())"
+        return "session-\(Date().fullDateTimeNumberString())-\(userNickname)"
     }
     
     func updateMode(mode: RunningMode) {

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -76,6 +76,6 @@ final class DefaultProfileUseCase: ProfileUseCase {
     }
     
     private func sortByDate(results: [RunningResult]) -> [RunningResult] {
-        return results.sorted { $0.dateTime ?? Date() < $1.dateTime ?? Date() }
+        return results.sorted { $0.dateTime ?? Date() > $1.dateTime ?? Date() }
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Mate/DefaultProfileUseCase.swift
@@ -43,7 +43,7 @@ final class DefaultProfileUseCase: ProfileUseCase {
                     self?.fetchRecordEmoji(record, from: nickname) ?? Observable.of(record)
                 })
                     .subscribe { [weak self] list in
-                        self?.recordInfo.onNext(list)
+                        self?.recordInfo.onNext(self?.sortByDate(results: list) ?? [])
                     }
                     .disposed(by: self?.disposeBag ?? DisposeBag())
             })
@@ -73,5 +73,9 @@ final class DefaultProfileUseCase: ProfileUseCase {
         self.firestoreRepository.removeEmoji(from: runningID, of: mate, with: selfNickname)
             .subscribe()
             .disposed(by: self.disposeBag)
+    }
+    
+    private func sortByDate(results: [RunningResult]) -> [RunningResult] {
+        return results.sorted { $0.dateTime ?? Date() < $1.dateTime ?? Date() }
     }
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -66,6 +66,7 @@ final class MateProfileViewModel: NSObject {
             .subscribe(onNext: { [weak self] in
                 guard let nickname = self?.mateInfo?.nickname,
                       let totalCount = self?.recordInfo.count else { return }
+                print("???????", totalCount)
                 self?.profileUseCase.fetchRecordList(nickname: nickname, from: 0, by: totalCount)
             })
             .disposed(by: disposeBag)
@@ -91,14 +92,17 @@ final class MateProfileViewModel: NSObject {
         
         self.profileUseCase.recordInfo
             .subscribe(onNext: { [weak self] recordList in
+                guard let fetchCount = self?.fetchRecordCount else { return }
                 switch recordList.count {
-                case 0...4:
+                case 0...fetchCount-1:
                     self?.recordInfo.append(contentsOf: recordList)
                     self?.hasNextPage = false
-                case 6..<Int.max:
+                case fetchCount..<Int.max:
                     self?.recordInfo = recordList
                 default:
-                    self?.recordInfo.append(contentsOf: recordList)
+                    (self?.recordInfo.count == fetchCount)
+                    ? self?.recordInfo = recordList
+                    : self?.recordInfo.append(contentsOf: recordList)
                 }
                 output.loadRecord.accept(true)
             })

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -66,7 +66,6 @@ final class MateProfileViewModel: NSObject {
             .subscribe(onNext: { [weak self] in
                 guard let nickname = self?.mateInfo?.nickname,
                       let totalCount = self?.recordInfo.count else { return }
-                print("???????", totalCount)
                 self?.profileUseCase.fetchRecordList(nickname: nickname, from: 0, by: totalCount)
             })
             .disposed(by: disposeBag)

--- a/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/ViewModel/MateProfileViewModel.swift
@@ -53,12 +53,20 @@ final class MateProfileViewModel: NSObject {
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        Observable.of(input.viewDidLoadEvent, input.refreshEvent).merge()
+        input.viewDidLoadEvent
             .subscribe(onNext: { [weak self] in
                 guard let nickname = self?.mateInfo?.nickname,
                       let fetchCount = self?.fetchRecordCount else { return }
                 self?.profileUseCase.fetchUserInfo(nickname)
                 self?.profileUseCase.fetchRecordList(nickname: nickname, from: 0, by: fetchCount)
+            })
+            .disposed(by: disposeBag)
+        
+        input.refreshEvent
+            .subscribe(onNext: { [weak self] in
+                guard let nickname = self?.mateInfo?.nickname,
+                      let totalCount = self?.recordInfo.count else { return }
+                self?.profileUseCase.fetchRecordList(nickname: nickname, from: 0, by: totalCount)
             })
             .disposed(by: disposeBag)
         
@@ -83,9 +91,14 @@ final class MateProfileViewModel: NSObject {
         
         self.profileUseCase.recordInfo
             .subscribe(onNext: { [weak self] recordList in
-                self?.recordInfo.append(contentsOf: recordList)
-                if recordList.count < 5 {
+                switch recordList.count {
+                case 0...4:
+                    self?.recordInfo.append(contentsOf: recordList)
                     self?.hasNextPage = false
+                case 6..<Int.max:
+                    self?.recordInfo = recordList
+                default:
+                    self?.recordInfo.append(contentsOf: recordList)
                 }
                 output.loadRecord.accept(true)
             })

--- a/MateRunner/MateRunner/Util/Constant/FirestoreQuery.swift
+++ b/MateRunner/MateRunner/Util/Constant/FirestoreQuery.swift
@@ -48,6 +48,12 @@ enum FirestoreQuery {
                         "value": { "stringValue": "\(userNickname)" }
                     }
                 },
+                "orderBy": {
+                    "field": {
+                        "fieldPath" : "runningID"
+                    },
+                    "direction" : "DESCENDING"
+                },
                 "offset": \(offset),
                 "limit": \(limit)
             }


### PR DESCRIPTION
### 📕 Issue Number

Close #343 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 메이트 프로필 기록 최신순으로 정렬
- [x] 메이트 프로필 기록 리프레쉬 버그 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현재 디비에 올라가있는 기록들은 `세션-닉네임-날짜`로 기록되어있기 때문에 지금 아마 제 기록(yujin)을 보시면 정렬이 안맞아보일 수 있습니다! -> 닉네임으로 정렬해서 가져오기 때문에
이제부터 올라가는 기록들은 `세션-날짜-닉네임`으로 올라가기 때문에 이제부터는 최신순으로 잘 보일거에요!

<br/><br/>
