### PR TITLE
프로필 기본 이미지 기능

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -197,6 +197,8 @@
 		B001A1A82733C0A000A0C3E0 /* CursorDisabledTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B001A1A72733C0A000A0C3E0 /* CursorDisabledTextField.swift */; };
 		B012E860274966710096899E /* RunningResultFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B012E85F274966710096899E /* RunningResultFactory.swift */; };
 		B02953A72732B5DA00725814 /* RunningPreparationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */; };
+		B02A209027565B8900E86D8A /* SignUpValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02A208F27565B8900E86D8A /* SignUpValidationError.swift */; };
+		B02A209227565BA500E86D8A /* SignUpValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02A209127565BA500E86D8A /* SignUpValidationState.swift */; };
 		B02D49802752AE6800B22249 /* NotificationCenterKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02D497F2752AE6800B22249 /* NotificationCenterKey.swift */; };
 		B02FCAD8273BA987001657FE /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD7273BA987001657FE /* HomeCoordinator.swift */; };
 		B02FCADA273BAACE001657FE /* DefaultHomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */; };
@@ -495,6 +497,8 @@
 		B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleRunningViewModelTests.swift; sourceTree = "<group>"; };
 		B015E86D2735864F0000AA47 /* MockSingleRunningUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSingleRunningUseCase.swift; sourceTree = "<group>"; };
 		B02953A62732B5DA00725814 /* RunningPreparationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningPreparationViewController.swift; sourceTree = "<group>"; };
+		B02A208F27565B8900E86D8A /* SignUpValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpValidationError.swift; sourceTree = "<group>"; };
+		B02A209127565BA500E86D8A /* SignUpValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpValidationState.swift; sourceTree = "<group>"; };
 		B02D497F2752AE6800B22249 /* NotificationCenterKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterKey.swift; sourceTree = "<group>"; };
 		B02FCAD7273BA987001657FE /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		B02FCAD9273BAACE001657FE /* DefaultHomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultHomeCoordinator.swift; sourceTree = "<group>"; };
@@ -1394,6 +1398,7 @@
 			children = (
 				B03A563B2745E6FA00C5C2F2 /* FirebaseServiceError.swift */,
 				AE263BE8274E1E18004A61E5 /* ImageCacheError.swift */,
+				B02A208F27565B8900E86D8A /* SignUpValidationError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -1545,6 +1550,7 @@
 				B02D497F2752AE6800B22249 /* NotificationCenterKey.swift */,
 				5E6595432754910500B07869 /* Height.swift */,
 				5E659545275492F000B07869 /* Weight.swift */,
+				B02A209127565BA500E86D8A /* SignUpValidationState.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -2194,6 +2200,7 @@
 				B06182A7274BFA2700EE7929 /* DefaultFirestoreRepository.swift in Sources */,
 				B0C66AAF274A3BBC00F33C76 /* TeamRunningResultViewModel.swift in Sources */,
 				5E171E67273258A4001C003B /* RunningMode.swift in Sources */,
+				B02A209027565B8900E86D8A /* SignUpValidationError.swift in Sources */,
 				B00133BA273D0A90004E0D1F /* MateSettingViewModel.swift in Sources */,
 				B02FCAE4273BDB91001657FE /* DefaultRunningCoordinator.swift in Sources */,
 				3DAF2D7F27439FDC00AC5FEA /* InvitationUseCase.swift in Sources */,
@@ -2225,6 +2232,7 @@
 				3D622581274E0A5B00E4A327 /* NotificationViewModel.swift in Sources */,
 				B0CB4D232742C85B005E4CD1 /* DefaultRxTimerService.swift in Sources */,
 				AEDAFD122733DC0B009BAEAA /* RunningSettingUseCase.swift in Sources */,
+				B02A209227565BA500E86D8A /* SignUpValidationState.swift in Sources */,
 				B06182AF274DFF1E00EE7929 /* UserDataFirestoreDTO.swift in Sources */,
 				AEF02183273CB1600086CBF1 /* EmojiViewController.swift in Sources */,
 				3D62257F274E07E800E4A327 /* LicenseViewController.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		B0EC2F872754BE3E00F30F89 /* DistanceSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0628B83273970A6004FAB0F /* DistanceSettingViewModelTests.swift */; };
 		B0EC2F882754BE4000F30F89 /* RunningPreparationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04A86BD2732D4D800F46069 /* RunningPreparationViewModelTests.swift */; };
 		B0EC2F892754BE4300F30F89 /* SingleRunningViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015E865273585EB0000AA47 /* SingleRunningViewModelTests.swift */; };
+		B0EC2F9B2755CF5800F30F89 /* String+UIImageConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EC2F9A2755CF5800F30F89 /* String+UIImageConverter.swift */; };
 		B0F53285273A29EA005A3F11 /* TabBarPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53284273A29EA005A3F11 /* TabBarPage.swift */; };
 		B0F53289273A32E0005A3F11 /* CoordinatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F53288273A32E0005A3F11 /* CoordinatorType.swift */; };
 		B0F5328B273A3397005A3F11 /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F5328A273A3397005A3F11 /* TabBarCoordinator.swift */; };
@@ -554,6 +555,7 @@
 		B0EB7AD12753FC0F00DC8AD6 /* CacheableImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheableImage.swift; sourceTree = "<group>"; };
 		B0EC2F5C2754BBEA00F30F89 /* MateRunnerViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MateRunnerViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B0EC2F692754BC1600F30F89 /* MateRunnerUseCaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MateRunnerUseCaseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B0EC2F9A2755CF5800F30F89 /* String+UIImageConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+UIImageConverter.swift"; sourceTree = "<group>"; };
 		B0F53284273A29EA005A3F11 /* TabBarPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPage.swift; sourceTree = "<group>"; };
 		B0F53288273A32E0005A3F11 /* CoordinatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorType.swift; sourceTree = "<group>"; };
 		B0F5328A273A3397005A3F11 /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
@@ -1203,6 +1205,7 @@
 				5ED367DC27462BAD00901765 /* Int+Formatter.swift */,
 				AE263BEA274E5D99004A61E5 /* UIImageView+ImageCache.swift */,
 				AE263BEE2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift */,
+				B0EC2F9A2755CF5800F30F89 /* String+UIImageConverter.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2122,6 +2125,7 @@
 				AE3D149B273BAEDD00D4A186 /* InvitationViewController.swift in Sources */,
 				B06182B1274E0B6000EE7929 /* PersonalTotalRecordDTO.swift in Sources */,
 				5E5E5557274514F6002FE126 /* RecordCoordinator.swift in Sources */,
+				B0EC2F9B2755CF5800F30F89 /* String+UIImageConverter.swift in Sources */,
 				5E7B862827495A88003F9FA2 /* CalendarModel.swift in Sources */,
 				AE263BEF2753DFBB004A61E5 /* UIScrollView+ObserveScroll.swift in Sources */,
 				5E7DEE7E273FAA0B002E1374 /* LoginViewController.swift in Sources */,

--- a/MateRunner/MateRunner/Domain/Model/UserData.swift
+++ b/MateRunner/MateRunner/Domain/Model/UserData.swift
@@ -16,4 +16,15 @@ struct UserData {
     let height: Double
     let weight: Double
     let mate: [String]
+    
+    init (nickname: String, image: String, height: Double, weight: Double) {
+        self.nickname = nickname
+        self.image = image
+        self.time = 0
+        self.distance = 0.0
+        self.calorie = 0.0
+        self.height = height
+        self.weight = weight
+        self.mate = []
+    }
 }

--- a/MateRunner/MateRunner/Domain/Model/UserData.swift
+++ b/MateRunner/MateRunner/Domain/Model/UserData.swift
@@ -17,14 +17,23 @@ struct UserData {
     let weight: Double
     let mate: [String]
     
-    init (nickname: String, image: String, height: Double, weight: Double) {
+    init (
+        nickname: String = "",
+        image: String = "",
+        time: Int = 0,
+        distance: Double = 0.0,
+        calorie: Double = 0.0,
+        height: Double = 0.0,
+        weight: Double = 0.0,
+        mate: [String] = []
+    ) {
         self.nickname = nickname
         self.image = image
-        self.time = 0
-        self.distance = 0.0
-        self.calorie = 0.0
+        self.time = time
+        self.distance = distance
+        self.calorie = calorie
         self.height = height
         self.weight = weight
-        self.mate = []
+        self.mate = mate
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -9,41 +9,6 @@ import Foundation
 
 import RxSwift
 
-enum SignUpValidationError: Error {
-    case nicknameDuplicatedError
-    case requiredDataMissingError
-    
-    var description: String {
-        switch self {
-        case .nicknameDuplicatedError:
-            return "이미 존재하는 닉네임입니다"
-        case .requiredDataMissingError:
-            return "알 수 없는 에러"
-        }
-    }
-}
-
-enum SignUpValidationState {
-    case empty
-    case lowerboundViolated
-    case upperboundViolated
-    case invalidLetterIncluded
-    case success
-    
-    var description: String {
-        switch self {
-        case .empty, .success:
-            return ""
-        case .lowerboundViolated:
-            return "최소 5자 이상 입력해주세요"
-        case .upperboundViolated:
-            return "최대 20자까지만 가능해요"
-        case .invalidLetterIncluded:
-            return "영문과 숫자만 입력할 수 있어요"
-        }
-    }
-}
-
 final class DefaultSignUpUseCase: SignUpUseCase {
     private let userRepository: UserRepository
     private let firestoreRepository: FirestoreRepository
@@ -93,7 +58,6 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     }
     
     private func checkDuplicate(of nickname: String) -> Observable<Bool> {
-        
         return self.userRepository.fetchFCMTokenFromServer(of: nickname)
             .map { _ in true }
             .catchAndReturn(false)
@@ -105,6 +69,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
                   return Observable.error(SignUpValidationError.requiredDataMissingError)
               }
         self.saveFCMToken()
+        
         return self.saveImage().flatMap { [weak self] imageDownloadURL -> Observable<Bool> in
             guard let self = self else { throw SignUpValidationError.requiredDataMissingError  }
             let userData = UserData(nickname: self.nickname, image: imageDownloadURL, height: height, weight: weight)
@@ -134,6 +99,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
             self.nicknameValidationState.onNext(.invalidLetterIncluded)
             return
         }
+        
         self.nicknameValidationState.onNext(.success)
     }
     

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -10,13 +10,16 @@ import Foundation
 import RxSwift
 
 final class DefaultSignUpUseCase: SignUpUseCase {
+    private enum ValidtaionError: Error {
+        case nicknameRuleViolatedError, nicknameDuplicatedError, requiredDataMissingError
+    }
     private let userRepository: UserRepository
     private let firestoreRepository: FirestoreRepository
     private let uid: String
-    var validText = PublishSubject<String?>()
-    var height = BehaviorSubject<Double?>(value: 170)
-    var weight = BehaviorSubject<Double?>(value: 60)
-    var canSignUp = PublishSubject<Bool>()
+    var selectedProfileEmoji = BehaviorSubject<String>(value: "👩🏻‍🚀")
+    var nickname = BehaviorSubject<String>(value: "")
+    var height = BehaviorSubject<Double>(value: 170)
+    var weight = BehaviorSubject<Double>(value: 60)
     var signUpResult = PublishSubject<Bool>()
     var disposeBag = DisposeBag()
     
@@ -31,56 +34,45 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     }
     
     func validate(text: String) {
-        self.validText.onNext(self.checkValidty(of: text))
+        self.checkValidty(of: text)
+        ? self.nickname.onNext(text)
+        : self.nickname.onError(ValidtaionError.nicknameRuleViolatedError)
     }
     
-    private func checkValidty(of nicknameText: String) -> String? {
-        guard nicknameText.count <= 20 else { return nil }
-        guard nicknameText.range(of: "[^a-zA-Z0-9]", options: .regularExpression) == nil else { return nil }
-        return nicknameText
+    func checkDuplicate(of nickname: String) -> Observable<Bool> {
+        return self.firestoreRepository.fetchUserData(of: nickname)
+            .map { _ in true }
+            .catchAndReturn(false)
     }
     
-    func checkDuplicate(of nickname: String?) {
-        guard let nickname = nickname else { return }
-
-        self.userRepository.fetchFCMTokenFromServer(of: nickname)
-            .subscribe(onNext: { [weak self] _ in
-                self?.canSignUp.onNext(false)
-            }, onError: { [weak self] _ in
-                self?.canSignUp.onNext(true)
-            })
-            .disposed(by: self.disposeBag)
-    }
-    
-    func signUp(nickname: String?) {
-        guard let nickname = nickname,
+    func signUp() -> Observable<Bool> {
+        guard let nickname = try? self.nickname.value(),
               let height = try? self.height.value(),
-              let weight = try? self.weight.value() else { return }
+              let weight = try? self.weight.value() else {
+                  return Observable.error(ValidtaionError.requiredDataMissingError)
+              }
         
-        let userData = UserData(
-            nickname: nickname,
-            image: "",
-            time: 0,
-            distance: 0.0,
-            calorie: 0.0,
-            height: height,
-            weight: weight,
-            mate: []
-        )
-        
-        let saveUserDataResult = self.firestoreRepository.save(user: userData)
-        let saveUIDResult = self.firestoreRepository.save(uid: self.uid, nickname: nickname)
-        
-        Observable.zip(saveUserDataResult, saveUIDResult) { _, _ in }
-            .subscribe(onNext: { [weak self] in
-                self?.signUpResult.onNext(true)
-            })
-            .disposed(by: self.disposeBag)
+        self.saveFCMToken()
+        return self.saveImage().flatMap { [weak self] imageDownloadURL -> Observable<Bool> in
+            guard let self = self else { return Observable.error(ValidtaionError.requiredDataMissingError) }
+            let userData = UserData(nickname: nickname, image: imageDownloadURL, height: height, weight: weight)
+            return Observable.zip(
+                self.firestoreRepository.save(user: userData),
+                self.firestoreRepository.save(uid: self.uid, nickname: nickname)
+            ) { _, _ in }
+            .map { true }
+            .catchAndReturn(false)
+        }
     }
     
-    func saveFCMToken(of nickname: String?) {
-        guard let fcmToken = self.userRepository.fetchFCMToken(),
-              let nickname = nickname else { return }
+    private func checkValidty(of nicknameText: String) -> Bool {
+        return nicknameText.count <= 20
+        && nicknameText.range(of: "[^a-zA-Z0-9]", options: .regularExpression) == nil
+    }
+    
+    private func saveFCMToken() {
+        guard let nickname = try? self.nickname.value(),
+              let fcmToken = self.userRepository.fetchFCMToken() else { return }
 
         self.userRepository.saveFCMToken(fcmToken, of: nickname)
             .subscribe(onNext: { [weak self] in
@@ -89,8 +81,25 @@ final class DefaultSignUpUseCase: SignUpUseCase {
             .disposed(by: self.disposeBag)
     }
     
-    func saveLoginInfo(nickname: String?) {
-        guard let nickname = nickname else { return }
+    private func saveLoginInfo() {
+        guard let nickname = try? self.nickname.value() else { return }
         self.userRepository.saveLoginInfo(nickname: nickname)
+    }
+    
+    private func saveImage() -> Observable<String> {
+        guard let nickname = try? self.nickname.value(),
+              let emoji = try? self.selectedProfileEmoji.value(),
+              let emojiImageData = emoji.emojiToImage() else {
+                  return Observable.error(ValidtaionError.requiredDataMissingError)
+              }
+        
+        return self.firestoreRepository.save(profileImageData: emojiImageData, of: nickname)
+    }
+    
+    private func createRandomEmoji() -> String {
+        let range = [UInt32](0x1F601...0x1F64F)
+        let ascii = range[Int(drand48() * (Double(range.count)))]
+        let emoji = UnicodeScalar(ascii)?.description
+        return emoji ?? "👩🏻‍🚀"
     }
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -67,7 +67,8 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     }
     
     private func checkDuplicate(of nickname: String) -> Observable<Bool> {
-        return self.firestoreRepository.fetchUserData(of: nickname)
+        
+        return self.userRepository.fetchFCMTokenFromServer(of: nickname)
             .map { _ in true }
             .catchAndReturn(false)
     }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/DefaultSignUpUseCase.swift
@@ -12,10 +12,36 @@ import RxSwift
 enum SignUpValidationError: Error {
     case nicknameDuplicatedError
     case requiredDataMissingError
+    
+    var description: String {
+        switch self {
+        case .nicknameDuplicatedError:
+            return "이미 존재하는 닉네임입니다"
+        case .requiredDataMissingError:
+            return "알 수 없는 에러"
+        }
+    }
 }
 
 enum SignUpValidationState {
-    case empty, lowerboundViolated, upperboundViolated, invalidLetterIncluded, success
+    case empty
+    case lowerboundViolated
+    case upperboundViolated
+    case invalidLetterIncluded
+    case success
+    
+    var description: String {
+        switch self {
+        case .empty, .success:
+            return ""
+        case .lowerboundViolated:
+            return "최소 5자 이상 입력해주세요"
+        case .upperboundViolated:
+            return "최대 20자까지만 가능해요"
+        case .invalidLetterIncluded:
+            return "영문과 숫자만 입력할 수 있어요"
+        }
+    }
 }
 
 final class DefaultSignUpUseCase: SignUpUseCase {
@@ -45,7 +71,7 @@ final class DefaultSignUpUseCase: SignUpUseCase {
     }
     
     func signUp() -> Observable<Bool> {
-        return self.checkDuplicate(of: self.nickname).debug()
+        return self.checkDuplicate(of: self.nickname)
             .flatMap({ [weak self] isDuplicated -> Observable<Bool> in
                 guard let self = self else {
                     throw SignUpValidationError.requiredDataMissingError

--- a/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/SignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/SignUpUseCase.swift
@@ -11,11 +11,12 @@ import RxSwift
 
 protocol SignUpUseCase {
     var selectedProfileEmoji: BehaviorSubject<String> { get }
-    var nickname: BehaviorSubject<String> { get}
+    var nickname: String { get set }
     var height: BehaviorSubject<Double> { get }
     var weight: BehaviorSubject<Double> { get }
-    var signUpResult: PublishSubject<Bool> { get }
+    var nicknameValidationState: BehaviorSubject<SignUpValidationState> { get }
     func validate(text: String)
-    func checkDuplicate(of nickname: String) -> Observable<Bool>
     func signUp() -> Observable<Bool>
+    func saveLoginInfo()
+    func shuffleProfileEmoji()
 }

--- a/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/SignUpUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Account/Protocol/SignUpUseCase.swift
@@ -10,14 +10,12 @@ import Foundation
 import RxSwift
 
 protocol SignUpUseCase {
-    var validText: PublishSubject<String?> { get set }
-    var height: BehaviorSubject<Double?> { get set }
-    var weight: BehaviorSubject<Double?> { get set }
-    var canSignUp: PublishSubject<Bool> { get set }
-    var signUpResult: PublishSubject<Bool> { get set }
+    var selectedProfileEmoji: BehaviorSubject<String> { get }
+    var nickname: BehaviorSubject<String> { get}
+    var height: BehaviorSubject<Double> { get }
+    var weight: BehaviorSubject<Double> { get }
+    var signUpResult: PublishSubject<Bool> { get }
     func validate(text: String)
-    func checkDuplicate(of nickname: String?)
-    func signUp(nickname: String?)
-    func saveFCMToken(of nickname: String?)
-    func saveLoginInfo(nickname: String?)
+    func checkDuplicate(of nickname: String) -> Observable<Bool>
+    func signUp() -> Observable<Bool>
 }

--- a/MateRunner/MateRunner/Presentation/Common/View/PickerTextField.swift
+++ b/MateRunner/MateRunner/Presentation/Common/View/PickerTextField.swift
@@ -51,7 +51,7 @@ private extension PickerTextField {
         self.borderStyle = .roundedRect
         self.tintColor = .clear
         self.backgroundColor = .systemGray6
-        self.font = .notoSans(size: 16, family: .regular)
+        self.font = .notoSans(size: 13, family: .regular)
         self.inputView = self.pickerView
     }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -160,8 +160,8 @@ private extension SignUpViewController {
         let output = self.viewModel?.transform(from: input, disposeBag: self.disposeBag)
         output?.profileEmoji
             .asDriver()
-            .drive(onNext: { newEmoji in
-                self.emojiTextField.text = newEmoji
+            .drive(onNext: { [weak self] newEmoji in
+                self?.emojiTextField.text = newEmoji
             })
             .disposed(by: disposeBag)
         self.bindNicknameTextField(output: output)

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -153,7 +153,8 @@ private extension SignUpViewController {
     
     func bindViewModel() {
         let input = SignUpViewModel.Input(
-            nickname: self.nicknameTextField.rx.text.orEmpty.asObservable(),
+            nicknameTextFieldDidEditEvent: self.nicknameTextField.rx.text.orEmpty.asObservable(),
+            shuffleButtonDidTapEvent: self.shuffleButton.rx.tap.asObservable(),
             heightTextFieldDidTapEvent: self.heightTextField.rx.controlEvent(.editingDidBegin).asObservable(),
             heightPickerSelectedRow: self.heightTextField.pickerView.rx.itemSelected.map { $0.row },
             weightTextFieldDidTapEvent: self.weightTextField.rx.controlEvent(.editingDidBegin).asObservable(),
@@ -287,28 +288,5 @@ private extension SignUpViewController {
         let ord = range.lowerBound + index
         guard let scalar = UnicodeScalar(ord) else { return "❓" }
         return String(scalar)
-    }
-}
-
-extension String {
-    static func randomEmoji() -> String {
-        let range = [UInt32](0x1F601...0x1F64F)
-        let ascii = range[Int(drand48() * (Double(range.count)))]
-        let emoji = UnicodeScalar(ascii)?.description
-        return emoji!
-    }
-}
-
-extension String {
-    func emojiToImage() -> UIImage? {
-        let size = CGSize(width: 60, height: 65)
-        UIGraphicsBeginImageContextWithOptions(size, false, 0)
-        UIColor.clear.set()
-        let rect = CGRect(origin: CGPoint(), size: size)
-        UIRectFill(CGRect(origin: CGPoint(), size: size))
-        (self as NSString).draw(in: rect, withAttributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 60)])
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return image
     }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -117,7 +117,7 @@ private extension SignUpViewController {
         self.view.backgroundColor = .systemBackground
         self.titleLabel.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(20)
-            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(5)
+            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(15)
         }
         
         self.emojiTextField.snp.makeConstraints { make in

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -14,25 +14,47 @@ final class SignUpViewController: UIViewController {
     private var disposeBag = DisposeBag()
     var viewModel: SignUpViewModel?
     
+    private lazy var heightTextField = PickerTextField()
+    private lazy var weightTextField = PickerTextField()
+    private lazy var descriptionLabel = UILabel()
+    
+    private lazy var shuffleButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("프로필 이미지 변경하기", for: .normal)
+        button.titleLabel?.font = UIFont.notoSans(size: 13, family: .bold)
+        button.setTitleColor(UIColor.mrPurple, for: .normal)
+        return button
+    }()
+    
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .notoSans(size: 25, family: .bold)
-        label.text = "회원가입"
+        label.font = .notoSans(size: 17, family: .light)
+        label.numberOfLines = 2
+        label.textAlignment = .center
+        label.text = "환영해요 🙌\n메이트러너와 함께 달릴 준비를 해주세요!"
         return label
+    }()
+    
+    private lazy var emojiTextField: UITextField = {
+        let textField = UITextField()
+        textField.isUserInteractionEnabled = false
+        textField.text = String.randomEmoji()
+        textField.font = UIFont.notoSans(size: 60, family: .light)
+        textField.textAlignment = .center
+        textField.layer.cornerRadius = 40
+        textField.sizeToFit()
+        return textField
     }()
     
     private lazy var nicknameTextField: UITextField = {
         let textField = UITextField()
         textField.borderStyle = .roundedRect
+        textField.keyboardType = .asciiCapable
         textField.backgroundColor = .systemGray6
-        textField.font = .notoSans(size: 16, family: .regular)
-        textField.placeholder = "5~20자의 영문, 숫자 조합"
+        textField.font = .notoSans(size: 13, family: .regular)
+        textField.placeholder = "영문, 숫자만 5~20자 이내로 입력해주세요."
         return textField
     }()
-    
-    private lazy var heightTextField = PickerTextField()
-    private lazy var weightTextField = PickerTextField()
-    private lazy var descriptionLabel = UILabel()
     
     private lazy var nicknameSection = self.createInputSection(
         text: "닉네임",
@@ -40,8 +62,14 @@ final class SignUpViewController: UIViewController {
         isNickname: true
     )
     
-    private lazy var heightSection = self.createInputSection(text: "키", textField: self.heightTextField)
-    private lazy var weightSection = self.createInputSection(text: "몸무게", textField: self.weightTextField)
+    private lazy var heightSection = self.createInputSection(
+        text: "키",
+        textField: self.heightTextField)
+    
+    private lazy var weightSection = self.createInputSection(
+        text: "몸무게",
+        textField: self.weightTextField
+    )
     
     private lazy var inputStackView: UIStackView = {
         let stackView = UIStackView()
@@ -54,12 +82,20 @@ final class SignUpViewController: UIViewController {
         return stackView
     }()
     
-    private lazy var doneButton = RoundedButton(title: "완료")
+    private lazy var doneButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("준비완료!", for: .normal)
+        button.backgroundColor = UIColor.mrPurple
+        button.titleLabel?.font = UIFont.notoSans(size: 15, family: .regular)
+        return button
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.configureSubviews()
         self.configureUI()
         self.bindViewModel()
+        self.tabBarController?.tabBar.isHidden = true
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -70,26 +106,48 @@ final class SignUpViewController: UIViewController {
 // MARK: - Private Functions
 
 private extension SignUpViewController {
+    func configureSubviews() {
+        self.view.addSubview(self.titleLabel)
+        self.view.addSubview(self.emojiTextField)
+        self.view.addSubview(self.shuffleButton)
+        self.view.addSubview(self.inputStackView)
+        self.view.addSubview(self.doneButton)
+    }
+    
     func configureUI() {
         self.view.backgroundColor = .systemBackground
+        self.shuffleButton.rx.tap.subscribe(onNext: {
+            self.emojiTextField.text = String.randomEmoji()
+        })
         
-        self.view.addSubview(self.titleLabel)
         self.titleLabel.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(20)
-            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(20)
+            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(5)
         }
         
-        self.view.addSubview(self.inputStackView)
+        self.emojiTextField.snp.makeConstraints { make in
+            make.width.height.equalTo(80)
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(25)
+        }
+        
+        self.shuffleButton.snp.makeConstraints { make in
+            make.top.equalTo(self.emojiTextField.snp.bottom).offset(5)
+            make.centerX.equalToSuperview()
+        }
+        
         self.inputStackView.snp.makeConstraints { make in
-            make.left.right.equalToSuperview().inset(20)
-            make.centerY.equalToSuperview().offset(-40)
+            make.left.right.equalToSuperview().inset(60)
+            make.top.equalTo(self.shuffleButton.snp.bottom).offset(15)
         }
         
-        self.view.addSubview(self.doneButton)
         self.doneButton.snp.makeConstraints { make in
-            make.left.right.equalToSuperview().inset(20)
-            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-20)
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(80)
+            make.top.equalTo(self.inputStackView.snp.bottom).offset(50)
         }
+        
+        self.doneButton.layer.cornerRadius = 40
     }
     
     func bindViewModel() {
@@ -190,13 +248,13 @@ private extension SignUpViewController {
     
     func createInputSection(text: String, textField: UITextField, isNickname: Bool = false) -> UIStackView {
         let titleLabel = UILabel()
-        titleLabel.font = .notoSans(size: 20, family: .bold)
+        titleLabel.font = .notoSans(size: 15, family: .light)
         titleLabel.text = text
         
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.alignment = .fill
-        stackView.spacing = 4
+        stackView.spacing = 8
         
         if isNickname {
             stackView.addArrangedSubview(self.createNicknameLabelStack(titleLabel: titleLabel))
@@ -208,16 +266,48 @@ private extension SignUpViewController {
     }
     
     func createNicknameLabelStack(titleLabel: UILabel) -> UIStackView {
-        self.descriptionLabel.font = .notoSans(size: 14, family: .regular)
+        self.descriptionLabel.font = .notoSans(size: 14, family: .medium)
         self.descriptionLabel.textColor = .mrPurple
-
+        
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.distribution = .fill
+        stackView.alignment = .center
         stackView.alignment = .lastBaseline
         
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(self.descriptionLabel)
         return stackView
+    }
+    
+    func randomEmoji() -> String {
+        let range = 0x1F300...0x1F3F0
+        let index = Int(arc4random_uniform(UInt32(range.count)))
+        let ord = range.lowerBound + index
+        guard let scalar = UnicodeScalar(ord) else { return "❓" }
+        return String(scalar)
+    }
+}
+
+extension String {
+    static func randomEmoji() -> String {
+        let range = [UInt32](0x1F601...0x1F64F)
+        let ascii = range[Int(drand48() * (Double(range.count)))]
+        let emoji = UnicodeScalar(ascii)?.description
+        return emoji!
+    }
+}
+
+extension String {
+    func emojiToImage() -> UIImage? {
+        let size = CGSize(width: 60, height: 65)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        UIColor.clear.set()
+        let rect = CGRect(origin: CGPoint(), size: size)
+        UIRectFill(CGRect(origin: CGPoint(), size: size))
+        (self as NSString).draw(in: rect, withAttributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 60)])
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
     }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -132,13 +132,13 @@ private extension SignUpViewController {
         }
         
         self.shuffleButton.snp.makeConstraints { make in
-            make.top.equalTo(self.emojiTextField.snp.bottom).offset(5)
+            make.top.equalTo(self.emojiTextField.snp.bottom)
             make.centerX.equalToSuperview()
         }
         
         self.inputStackView.snp.makeConstraints { make in
             make.left.right.equalToSuperview().inset(60)
-            make.top.equalTo(self.shuffleButton.snp.bottom).offset(15)
+            make.top.equalTo(self.shuffleButton.snp.bottom).offset(25)
         }
         
         self.doneButton.snp.makeConstraints { make in
@@ -148,6 +148,7 @@ private extension SignUpViewController {
         }
         
         self.doneButton.layer.cornerRadius = 40
+        self.doneButton.addShadow(offset: CGSize(width: 3, height: 5))
     }
     
     func bindViewModel() {

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewController/SignUpViewController.swift
@@ -274,12 +274,4 @@ private extension SignUpViewController {
         stackView.addArrangedSubview(self.descriptionLabel)
         return stackView
     }
-    
-    func randomEmoji() -> String {
-        let range = 0x1F300...0x1F3F0
-        let index = Int(arc4random_uniform(UInt32(range.count)))
-        let ord = range.lowerBound + index
-        guard let scalar = UnicodeScalar(ord) else { return "❓" }
-        return String(scalar)
-    }
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -125,6 +125,7 @@ final class SignUpViewModel {
         input.doneButtonDidTapEvent
             .subscribe(onNext: { [weak self] in
                 self?.signUpUseCase.signUp()
+                    .observe(on: MainScheduler.instance)
                     .subscribe(onNext: { _ in
                         self?.signUpUseCase.saveLoginInfo()
                         self?.coordinator?.finish()

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -75,9 +75,9 @@ final class SignUpViewModel {
         let output = Output()
         
         self.signUpUseCase.nicknameValidationState
-            .subscribe(onNext: { state in
-                output.nicknameFieldText.accept(self.signUpUseCase.nickname)
-                output.validationErrorMessage.accept(self.createValidationErrorMessage(error: state))
+            .subscribe(onNext: { [weak self] state in
+                output.nicknameFieldText.accept(self?.signUpUseCase.nickname)
+                output.validationErrorMessage.accept(state.description)
                 output.doneButtonShouldEnable.accept(state == .success)
             })
             .disposed(by: disposeBag)
@@ -131,32 +131,9 @@ final class SignUpViewModel {
                         self?.coordinator?.finish()
                     }, onError: { error in
                         guard let error = error as? SignUpValidationError else { return }
-                        output.validationErrorMessage.accept(self?.createSignUpErrorMessage(error: error))
+                        output.validationErrorMessage.accept(error.description)
                         output.doneButtonShouldEnable.accept(false)
                     }).disposed(by: disposeBag)
             }).disposed(by: disposeBag)
     }
-    
-    private func createSignUpErrorMessage(error: SignUpValidationError) -> String {
-        switch error {
-        case .nicknameDuplicatedError:
-            return "이미 존재하는 닉네임입니다"
-        case .requiredDataMissingError:
-            return "알 수 없는 에러"
-        }
-    }
-    
-    private func createValidationErrorMessage(error: SignUpValidationState) -> String {
-        switch error {
-        case .empty, .success:
-            return ""
-        case .lowerboundViolated:
-            return "최소 5자 이상 입력해주세요"
-        case .upperboundViolated:
-            return "최대 20자까지만 가능해요"
-        case .invalidLetterIncluded:
-            return "영문과 숫자만 입력할 수 있어요"
-        }
-    }
-    
 }

--- a/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/LoginScene/ViewModel/SignUpViewModel.swift
@@ -15,7 +15,8 @@ final class SignUpViewModel {
     private let signUpUseCase: SignUpUseCase
     
     struct Input {
-        let nickname: Observable<String>
+        let nicknameTextFieldDidEditEvent: Observable<String>
+        let shuffleButtonDidTapEvent: Observable<Void>
         let heightTextFieldDidTapEvent: Observable<Void>
         let heightPickerSelectedRow: Observable<Int>
         let weightTextFieldDidTapEvent: Observable<Void>
@@ -31,8 +32,9 @@ final class SignUpViewModel {
         var weightRange = BehaviorRelay<[String]>(value: Weight.range.map { "\($0) kg" })
         var weightPickerRow = BehaviorRelay<Int?>(value: nil)
         var nicknameFieldText = BehaviorRelay<String?>(value: "")
-        var isNicknameValid = BehaviorRelay<Bool>(value: false)
-        var canSignUp = BehaviorRelay<Bool>(value: true)
+        var validationErrorMessage = BehaviorRelay<String?>(value: nil)
+        var doneButtonShouldEnable = BehaviorRelay<Bool>(value: false)
+        var profileEmoji = BehaviorRelay<String>(value: "👩🏻‍🚀")
     }
     
     init(coordinator: SignUpCoordinator, signUpUseCase: SignUpUseCase) {
@@ -46,7 +48,7 @@ final class SignUpViewModel {
     }
     
     private func configureInput(_ input: Input, disposeBag: DisposeBag) {
-        input.nickname
+        input.nicknameTextFieldDidEditEvent
             .subscribe(onNext: { [weak self] nickname in
                 self?.signUpUseCase.validate(text: nickname)
             })
@@ -61,21 +63,23 @@ final class SignUpViewModel {
             .map { Double(Weight.range[$0]) }
             .bind(to: self.signUpUseCase.weight)
             .disposed(by: disposeBag)
+        
+        input.shuffleButtonDidTapEvent
+            .subscribe(onNext: { [weak self] _ in
+                self?.signUpUseCase.shuffleProfileEmoji()
+            })
+            .disposed(by: disposeBag)
     }
     
     private func createOutput(from input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
-        let nickname = self.signUpUseCase.validText
-            .scan("") { oldValue, newValue in
-                newValue == nil ? oldValue: newValue
-            }
-        
-        nickname.bind(to: output.nicknameFieldText)
-            .disposed(by: disposeBag)
-        
-        nickname.map { ($0 ?? "").count >= 5 }
-            .bind(to: output.isNicknameValid)
+        self.signUpUseCase.nicknameValidationState
+            .subscribe(onNext: { state in
+                output.nicknameFieldText.accept(self.signUpUseCase.nickname)
+                output.validationErrorMessage.accept(self.createValidationErrorMessage(error: state))
+                output.doneButtonShouldEnable.accept(state == .success)
+            })
             .disposed(by: disposeBag)
         
         input.heightTextFieldDidTapEvent
@@ -108,38 +112,50 @@ final class SignUpViewModel {
             })
             .disposed(by: disposeBag)
         
-        self.bindSignUp(input: input, output: output, disposeBag: disposeBag)
+        self.signUpUseCase.selectedProfileEmoji
+            .bind(to: output.profileEmoji)
+            .disposed(by: disposeBag)
+        
+        self.bindSignUp(from: input, with: output, disposeBag: disposeBag)
+        
         return output
     }
     
-    private func bindSignUp(input: Input, output: Output, disposeBag: DisposeBag) {
+    private func bindSignUp(from input: Input, with output: Output, disposeBag: DisposeBag) {
         input.doneButtonDidTapEvent
             .subscribe(onNext: { [weak self] in
-                self?.signUpUseCase.checkDuplicate(of: output.nicknameFieldText.value)
-            })
-            .disposed(by: disposeBag)
-        
-        self.signUpUseCase.canSignUp
-            .bind(to: output.canSignUp)
-            .disposed(by: disposeBag)
-        
-        self.signUpUseCase.canSignUp
-            .filter { $0 }
-            .subscribe(onNext: { [weak self] _ in
-                let nickname = output.nicknameFieldText.value
-                self?.signUpUseCase.saveFCMToken(of: nickname)
-                self?.signUpUseCase.signUp(nickname: nickname)
-            })
-            .disposed(by: disposeBag)
-        
-        self.signUpUseCase.signUpResult
-            .asDriver(onErrorJustReturn: false)
-            .filter { $0 }
-            .drive(onNext: { [weak self] _ in
-                self?.signUpUseCase.saveLoginInfo(nickname: output.nicknameFieldText.value)
-                self?.coordinator?.finish()
-            })
-            .disposed(by: disposeBag)
+                self?.signUpUseCase.signUp()
+                    .subscribe(onNext: { _ in
+                        self?.signUpUseCase.saveLoginInfo()
+                        self?.coordinator?.finish()
+                    }, onError: { error in
+                        guard let error = error as? SignUpValidationError else { return }
+                        output.validationErrorMessage.accept(self?.createSignUpErrorMessage(error: error))
+                        output.doneButtonShouldEnable.accept(false)
+                    }).disposed(by: disposeBag)
+            }).disposed(by: disposeBag)
+    }
+    
+    private func createSignUpErrorMessage(error: SignUpValidationError) -> String {
+        switch error {
+        case .nicknameDuplicatedError:
+            return "이미 존재하는 닉네임입니다"
+        case .requiredDataMissingError:
+            return "알 수 없는 에러"
+        }
+    }
+    
+    private func createValidationErrorMessage(error: SignUpValidationState) -> String {
+        switch error {
+        case .empty, .success:
+            return ""
+        case .lowerboundViolated:
+            return "최소 5자 이상 입력해주세요"
+        case .upperboundViolated:
+            return "최대 20자까지만 가능해요"
+        case .invalidLetterIncluded:
+            return "영문과 숫자만 입력할 수 있어요"
+        }
     }
     
 }

--- a/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/ViewController/MyPageViewController.swift
@@ -31,7 +31,7 @@ final class MyPageViewController: UIViewController {
         let imageView = UIImageView()
         imageView.layer.masksToBounds = true
         imageView.layer.cornerRadius = 40
-        imageView.backgroundColor = .lightGray
+        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     

--- a/MateRunner/MateRunner/Util/Constant/SignUpValidationState.swift
+++ b/MateRunner/MateRunner/Util/Constant/SignUpValidationState.swift
@@ -1,0 +1,29 @@
+//
+//  SignUpValidationState.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/30.
+//
+
+import Foundation
+
+enum SignUpValidationState {
+    case empty
+    case lowerboundViolated
+    case upperboundViolated
+    case invalidLetterIncluded
+    case success
+    
+    var description: String {
+        switch self {
+        case .empty, .success:
+            return ""
+        case .lowerboundViolated:
+            return "최소 5자 이상 입력해주세요"
+        case .upperboundViolated:
+            return "최대 20자까지만 가능해요"
+        case .invalidLetterIncluded:
+            return "영문과 숫자만 입력할 수 있어요"
+        }
+    }
+}

--- a/MateRunner/MateRunner/Util/Error/SignUpValidationError.swift
+++ b/MateRunner/MateRunner/Util/Error/SignUpValidationError.swift
@@ -1,0 +1,22 @@
+//
+//  SignUpValidationError.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/30.
+//
+
+import Foundation
+
+enum SignUpValidationError: Error {
+    case nicknameDuplicatedError
+    case requiredDataMissingError
+    
+    var description: String {
+        switch self {
+        case .nicknameDuplicatedError:
+            return "이미 존재하는 닉네임입니다"
+        case .requiredDataMissingError:
+            return "알 수 없는 에러"
+        }
+    }
+}

--- a/MateRunner/MateRunner/Util/Extension/String+UIImageConverter.swift
+++ b/MateRunner/MateRunner/Util/Extension/String+UIImageConverter.swift
@@ -5,7 +5,7 @@
 //  Created by 전여훈 on 2021/11/30.
 //
 
-import Foundation
+import UIKit
 
 extension String {
     func emojiToImage() -> Data? {

--- a/MateRunner/MateRunner/Util/Extension/String+UIImageConverter.swift
+++ b/MateRunner/MateRunner/Util/Extension/String+UIImageConverter.swift
@@ -1,0 +1,22 @@
+//
+//  String+UIImageConverter.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/11/30.
+//
+
+import Foundation
+
+extension String {
+    func emojiToImage() -> Data? {
+        let size = CGSize(width: 60, height: 65)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        UIColor.clear.set()
+        let rect = CGRect(origin: CGPoint(), size: size)
+        UIRectFill(CGRect(origin: CGPoint(), size: size))
+        (self as NSString).draw(in: rect, withAttributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 60)])
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image?.pngData()
+    }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #289 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 기본이미지 기능 추가

https://user-images.githubusercontent.com/46087477/144006685-4eb5d0f9-05eb-4205-ae86-536f39706895.MP4



### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 기능 정리
가입시에 화면에 나타나는 이모지는 텍스트필드를 유저인터렉션을 막아두고 설정하도록 했습니다.

```swift
    private func createRandomEmoji() -> String {
        let range = [UInt32](0x1F601...0x1F64F)
        let ascii = range[Int(drand48() * (Double(range.count)))]
        let emoji = UnicodeScalar(ascii)?.description
        return emoji ?? "👩🏻‍🚀"
    }
```
이렇게 유니코드 범위를 지정해두고 아스키로 변환한 다음에 텍스트로 만드는 작업을 거쳤어요. 옵셔널 언래핑 실패하면 우주인으로 반환하게 했는데 그냥 개인 취향입니다..

그래서 회원가입 전까지는 이모지 텍스트로 화면에 계속 보여지구요, 회원가입하는 순간에 데이터로 변경해서 업로드 하도록 했습니다.

```swift
extension String {
    func emojiToImage() -> Data? {
        let size = CGSize(width: 60, height: 65)
        UIGraphicsBeginImageContextWithOptions(size, false, 0)
        UIColor.clear.set()
        let rect = CGRect(origin: CGPoint(), size: size)
        UIRectFill(CGRect(origin: CGPoint(), size: size))
        (self as NSString).draw(in: rect, withAttributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 60)])
        let image = UIGraphicsGetImageFromCurrentImageContext()
        UIGraphicsEndImageContext()
        return image?.pngData()
    }
}
```
스택오버플로우에 누군가 잘 공유해준게 있어서 UIImage로 한번 바꿨다가 다시 pngData로 변환하는 작업을 거칩니다.

- input/output 일부 변경
뷰모델-유즈케이스를 작업하면서 리팩토링 했습니다. 전체적인 로직은 그대로이구요, 뷰 컨트롤러에서 텍스트를 판단하는 로직이 있는 부분을 뷰모델로 옮기고 뷰모델에서 회원가입 절차를 순서대로 유즈케이스에 요청하는 부분을 유즈케이스에 한번의 요청으로 모두 처리하도록 변경했습니다. 그래서 프로토콜도 많이 달라졌어요.

- nicknameValidation 개선
하다보니까 욕심이 좀 생겨서 닉네임 validation을 세분화했습니다.

```swift
enum SignUpValidationState {
    case empty, lowerboundViolated, upperboundViolated, invalidLetterIncluded, success
}
```
이렇게 검증 상태에 대한 enum을 정의하고

```swift
// usecase
    private func updateValidationState(of nicknameText: String) {
        guard !nicknameText.isEmpty else {
            self.nicknameValidationState.onNext(.empty)
            return
        }
        guard nicknameText.count >= 5 else {
            self.nicknameValidationState.onNext(.lowerboundViolated)
            return
        }
        guard nicknameText.count <= 20 else {
            self.nicknameValidationState.onNext(.upperboundViolated)
            return
        }
        guard nicknameText.range(of: "[^a-zA-Z0-9]", options: .regularExpression) == nil else {
            self.nicknameValidationState.onNext(.invalidLetterIncluded)
            return
        }
        self.nicknameValidationState.onNext(.success)
    }


// viewmodel
    private func createValidationErrorMessage(error: SignUpValidationState) -> String {
        switch error {
        case .empty, .success:
            return ""
        case .lowerboundViolated:
            return "최소 5자 이상 입력해주세요"
        case .upperboundViolated:
            return "최대 20자까지만 가능해요"
        case .invalidLetterIncluded:
            return "영문과 숫자만 입력할 수 있어요"
        }
    }
```
각 상황에 대한 검증 결과를 반환해서 뷰모델에서 메시지를 결정할 수 있도록 했습니다. 텍스트필드에 입력을 막을 필요는 없기 때문에 닉네임 프로퍼티를 String으로 변경하고 뷰모델에는 이 검증 상태를 방출합니다. 이 상태에 따라서 뷰에 보여질 에러 텍스트와 버튼 상태를 결정하도록 구현되어 있습니다.

피커뷰에 대한 부분은 정원님이 잘 만들어주셔서 크게 손 댈게 없었어요! 

- 프로필에 가면 이미지가 이상하게 잘 안맞는다..

<img width="211" alt="스크린샷 2021-11-30 오후 5 04 24" src="https://user-images.githubusercontent.com/46087477/144008710-3a4c6f80-8d17-4693-b5aa-f6988c1fedcf.png">

이렇게 뭔가 이상하게 나오는데요.. scaleToFill로 안하고 fit으로 해도 사진 자체가 전체적으로 오른쪽으로 쏠려있어서 잘 안맞더라구요.. 해결방법을 아시면 알려주세요..!


<br/><br/>