### PR TITLE
기록없는 달 기록 개수, 이모지 개수 표시 안되는 버그 해결

### DIFF
--- a/MateRunner/MateRunner/Domain/UseCase/Record/DefaultRecordUseCase.swift
+++ b/MateRunner/MateRunner/Domain/UseCase/Record/DefaultRecordUseCase.swift
@@ -49,22 +49,23 @@ final class DefaultRecordUseCase: RecordUseCase {
         
         self.firestoreRepository.fetchResult(of: nickname, from: currentMonth, to: nextMonth)
             .subscribe(onNext: { [weak self] records in
-                Observable<RunningResult>.zip(records.map { [weak self] record in
-                    self?.fetchRecordEmoji(record, from: nickname) ?? Observable.of(record)
-                })
-                    .subscribe(onNext: { [weak self] records in
-                        guard let self = self else { return }
-                        self.monthlyRecords.onNext(records)
-                        self.selectedDay.onNext(try? self.selectedDay.value())
-                        self.runningCount.onNext(records.count)
-                        self.likeCount.onNext(self.getLikeCount(from: records))
+                if records.isEmpty {
+                    self?.monthlyRecords.onNext([])
+                    self?.runningCount.onNext(0)
+                    self?.likeCount.onNext(0)
+                } else {
+                    Observable<RunningResult>.zip(records.map { [weak self] record in
+                        self?.fetchRecordEmoji(record, from: nickname) ?? Observable.of(record)
                     })
-                    .disposed(by: self?.disposeBag ?? DisposeBag())
-                
-            }, onError: { [weak self] _ in
-                self?.monthlyRecords.onNext([])
-                self?.runningCount.onNext(0)
-                self?.likeCount.onNext(0)
+                        .subscribe(onNext: { [weak self] records in
+                            guard let self = self else { return }
+                            self.monthlyRecords.onNext(records)
+                            self.selectedDay.onNext(try? self.selectedDay.value())
+                            self.runningCount.onNext(records.count)
+                            self.likeCount.onNext(self.getLikeCount(from: records))
+                        })
+                        .disposed(by: self?.disposeBag ?? DisposeBag())
+                }
             })
             .disposed(by: self.disposeBag)
     }

--- a/MateRunner/MateRunner/Presentation/Common/View/RecordCell.swift
+++ b/MateRunner/MateRunner/Presentation/Common/View/RecordCell.swift
@@ -38,7 +38,7 @@ class RecordCell: UITableViewCell {
     }
     
     func updateUI(record: RunningResult) {
-        self.dateLabel.text = record.dateTime?.toDateString(format: "yyyy.MM.dd")
+        self.dateLabel.text = record.dateTime?.toDateString(format: "yyyy.MM.dd  a hh:mm")
         self.distanceLabel.text = record.userElapsedDistance.kilometerString + " km"
         self.timeLabel.text = record.userElapsedTime.timeString
         self.calorieLabel.text = record.calorie.calorieString + " kcal"


### PR DESCRIPTION
### 📕 Issue Number

Close #352 

https://user-images.githubusercontent.com/77449223/144038779-9c3bf97f-aed9-4f66-8169-739db122fabd.MP4

![IMG_7F8CD0D7A430-1](https://user-images.githubusercontent.com/77449223/144051442-05a936f5-a665-4ce8-b474-d855b6ab4c17.jpeg)



### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 기록 없는 달 기록, 이모지 개수 0개로 표시


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 기록이 없으면 빈 배열을 onNext로 방출하는 것을 발견해서 비어있는 배열일 때 개수를 0으로 초기화하였습니다.
- 기록 리스트 날짜에 시간을 추가하였습니다.

<br/><br/>
