### PR TITLE
초대장, 달리기 화면 다크모드 대응 & 알림 목록에서 닉네임이 길어졌을 때 표시 수정

### DIFF
--- a/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/InvitationView.swift
@@ -13,6 +13,7 @@ final class InvitationView: UIView {
         label.textAlignment = .center
         label.numberOfLines = 3
         label.font = .notoSans(size: 18, family: .bold)
+        label.textColor = .black
         return label
     }()
     
@@ -25,6 +26,7 @@ final class InvitationView: UIView {
     private lazy var runningModeLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSans(size: 23, family: .bold)
+        label.textColor = .black
         return label
     }()
     
@@ -32,6 +34,7 @@ final class InvitationView: UIView {
         let label = UILabel()
         label.font = .notoSansBoldItalic(size: 50)
         label.addShadow(offset: CGSize(width: 2.0, height: 2.0))
+        label.textColor = .black
         return label
     }()
     
@@ -159,6 +162,7 @@ private extension InvitationView {
         label.font = .notoSans(size: 16, family: .bold)
         label.text = text
         label.textAlignment = .center
+        label.textColor = .black
         return label
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningCardView.swift
@@ -35,7 +35,7 @@ final class RunningCardView: UIView {
         
         labelStackView.arrangedSubviews.forEach { subView in
             guard let label = subView as? UILabel else { return }
-            label.textColor = isWinning ? .white: .black
+            label.textColor = isWinning ? .mrYellow: .label
         }
         
         progressView.progressTintColor = isWinning ? .mrYellow : .mrPurple

--- a/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/View/RunningInfoView.swift
@@ -16,6 +16,7 @@ final class RunningInfoView: UIStackView {
     func updateValue(newValue: String) {
         guard let valueLabel = self.arrangedSubviews.first as? UILabel else { return }
         valueLabel.text = newValue
+        valueLabel.textColor = .black
     }
 }
 

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/RunningViewController.swift
@@ -83,6 +83,7 @@ class RunningViewController: UIViewController {
     func createDistanceLabel() -> UILabel {
         let label = UILabel()
         label.font = .notoSansBoldItalic(size: 100)
+        label.textColor = .black
         return label
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/TeamRunningViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/RunningViewController/TeamRunningViewController.swift
@@ -18,6 +18,7 @@ final class TeamRunningViewController: RunningViewController {
     private lazy var totalDistanceLabel: UILabel = {
         let label = UILabel()
         label.font = .notoSansBoldItalic(size: 100)
+        label.textColor = .black
         return label
     }()
     
@@ -29,6 +30,7 @@ final class TeamRunningViewController: RunningViewController {
     override func createDistanceLabel() -> UILabel {
         let label = UILabel()
         label.font = .notoSansBoldItalic(size: 30)
+        label.textColor = .black
         return label
     }
     

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SettingViewController/RunningPreparationViewController.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewController/SettingViewController/RunningPreparationViewController.swift
@@ -18,6 +18,7 @@ final class RunningPreparationViewController: UIViewController {
 	private lazy var timeLeftLabel: UILabel = {
 		let label = UILabel()
 		label.font = .notoSansBoldItalic(size: 130)
+        label.textColor = .black
 		return label
 	}()
 	

--- a/MateRunner/MateRunner/Presentation/MyPageScene/View/NotificationTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MyPageScene/View/NotificationTableViewCell.swift
@@ -35,6 +35,8 @@ class NotificationTableViewCell: UITableViewCell {
         let label = UILabel()
         label.font = UIFont.notoSans(size: 13, family: .regular)
         label.textColor = .systemGray
+        label.numberOfLines = 2
+        label.lineBreakMode = .byCharWrapping
         return label
     }()
     
@@ -60,7 +62,7 @@ class NotificationTableViewCell: UITableViewCell {
             self.iconLabel.text = "🤝"
         case .receiveEmoji:
             self.notificationTypeLabel.text = "칭찬 이모지"
-            self.contentLabel.text = "메이트 \(sender)님으로부터 칭찬 이모지를 받았습니다!"
+            self.contentLabel.text = "\(sender)님으로부터 칭찬 이모지를 받았습니다!"
             self.iconLabel.text = "💝"
         }
     }
@@ -86,6 +88,7 @@ private extension NotificationTableViewCell {
         self.contentLabel.snp.makeConstraints { make in
             make.top.equalTo(self.notificationTypeLabel.snp.bottom).offset(5)
             make.left.equalTo(self.iconLabel.snp.right).offset(10)
+            make.right.equalToSuperview().offset(-20)
         }
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #349 
Close #351 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 초대장, 달리기 화면 다크모드 대응
- [x] 알림 목록에서 닉네임이 길어졌을 때 표시 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 다크모드에서 경쟁모드 실행 시 가독성이 좋지 않아 아래 사진과 같이 변경했습니다. 혹시 이상하면 말씀해주세요..!

- 수정 전 다크모드

<img width="300px" src="https://user-images.githubusercontent.com/48787170/144053528-fe8302a1-9867-4c85-a4e4-c40825c3fd6c.PNG" />

- 수정 후 다크모드

<img width="300px" src="https://user-images.githubusercontent.com/48787170/144053590-4da9ed7c-2dbd-4d6a-9ce3-1a63f5467526.PNG" />

- 수정 후 라이트모드

<img width="300px" src="https://user-images.githubusercontent.com/48787170/144053640-98dcc36e-aa37-481c-9b0f-9da1e1f490dc.PNG" />

- 알림 목록

<img width="300px" src="https://user-images.githubusercontent.com/48787170/144054005-1a9b71ea-b5c1-4c27-8282-bedd34c368c3.PNG" />



<br/><br/>
