### PR TITLE
상대방 기록에서도 나의 이름이 표시되는 문제 해결

### DIFF
--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordDetailViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordDetailViewModel.swift
@@ -122,7 +122,8 @@ private extension RecordDetailViewModel {
         isCanceled: Bool
     ) -> String {
         if isRaceMode {
-            if isCanceled { return "\(mateNickname) 메이트와의 대결" } else { return "\(mateNickname) 메이트와의 대결 \(isUserWinner ? "👑" : "😂")" }
+            return isCanceled ? "\(mateNickname) 메이트와의 대결"
+            : "\(mateNickname) 메이트와의 대결 \(isUserWinner ? "👑" : "😂")"
         } else {
             return "\(mateNickname) 메이트와 함께한 달리기"
         }

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordDetailViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordDetailViewModel.swift
@@ -39,8 +39,6 @@ final class RecordDetailViewModel {
     
     func createViewModelOutput() -> Output {
         let runningResult = self.recordDetailUseCase.runningResult
-        
-        let userNickname = self.recordDetailUseCase.nickname ?? ""
         let coordinates = self.pointsToCoordinate2D(from: runningResult.points)
         
         var output = Output(
@@ -54,7 +52,7 @@ final class RecordDetailViewModel {
             points: coordinates,
             region: self.calculateRegion(from: coordinates),
             isCanceled: runningResult.isCanceled,
-            userNickname: userNickname,
+            userNickname: runningResult.resultOwner,
             emojiList: self.countedEmojiList(from: runningResult.emojis)
         )
         
@@ -62,11 +60,12 @@ final class RecordDetailViewModel {
             output.headerText = self.createHeaderMessage(
                 mateNickname: raceRunningResult.runningSetting.mateNickname ?? "",
                 isUserWinner: raceRunningResult.isUserWinner,
-                shouldShowEmoji: !raceRunningResult.isCanceled
+                isRaceMode: true,
+                isCanceled: raceRunningResult.isCanceled
             )
             output.winnerText = self.createResultMessage(
                 isUserWinner: raceRunningResult.isUserWinner,
-                userNickname: userNickname
+                userNickname: runningResult.resultOwner
             )
             output.mateResultValue = self.createMateResult(
                 isUserWinner: raceRunningResult.isUserWinner,
@@ -78,7 +77,8 @@ final class RecordDetailViewModel {
             output.headerText = self.createHeaderMessage(
                 mateNickname: teamRunningResult.runningSetting.mateNickname ?? "",
                 isUserWinner: false,
-                shouldShowEmoji: false
+                isRaceMode: false,
+                isCanceled: teamRunningResult.isCanceled
             )
             output.totalDistance = teamRunningResult.totalDistance.kilometerString
             output.contributionRate = teamRunningResult.contribution.percentageString
@@ -115,9 +115,14 @@ private extension RecordDetailViewModel {
         return Region(center: coordinate, span: span)
     }
     
-    func createHeaderMessage(mateNickname: String, isUserWinner: Bool, shouldShowEmoji: Bool) -> String {
-        if shouldShowEmoji {
-            return "\(mateNickname) 메이트와의 대결 \(isUserWinner ? "👑" : "😂")"
+    func createHeaderMessage(
+        mateNickname: String,
+        isUserWinner: Bool,
+        isRaceMode: Bool,
+        isCanceled: Bool
+    ) -> String {
+        if isRaceMode {
+            if isCanceled { return "\(mateNickname) 메이트와의 대결" } else { return "\(mateNickname) 메이트와의 대결 \(isUserWinner ? "👑" : "😂")" }
         } else {
             return "\(mateNickname) 메이트와 함께한 달리기"
         }


### PR DESCRIPTION
### 📕 Issue Number

Close #350 

<img src="https://user-images.githubusercontent.com/77449223/144057753-2a814549-5752-4f03-a84f-75c8070643bf.jpeg" width="200"/>
<img src="https://user-images.githubusercontent.com/77449223/144057796-270d04f8-1971-4864-b279-79968609af2f.jpeg" width="200"/>
<img src="https://user-images.githubusercontent.com/77449223/144057822-6bfab9a1-7cab-448e-8c90-ad67fdb0f7d0.jpeg" width="200"/>



### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 승자 표시할 때 기록 owner의 닉네임을 표시하도록 함
- [x] 취소된 달리기어도 달리기 모드에 따라 다른 문구 표시 


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- runningResult의 resultOwner가 userNickname이 될 수 있도록 수정하였습니다!
- 기존에는 취소된 달리기이면 무조건 OOO 메이트와 함께한 달리기로 표시되는 버그가 있었는데 이를 달리기 모드에 맞게 표시하도록 수정하였습니다.

<br/><br/>
