### PR TITLE
FirebaseRepository 파일 복잡도, 라인 수 줄이기

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC327326C1C00D1EDAC /* Emoji.swift */; };
 		B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */; };
 		B06E6DC927326E4E00D1EDAC /* TeamRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */; };
+		B072F1A02759018400EE4BCA /* FireStoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B072F19F2759018400EE4BCA /* FireStoreConstants.swift */; };
 		B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */; };
 		B095EABA2752AFED001A70F4 /* InvitationReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */; };
 		B0A0DA1E27441A0B004DDC71 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */; };
@@ -784,6 +785,7 @@
 		B06E6DC327326C1C00D1EDAC /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResult.swift; sourceTree = "<group>"; };
 		B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRunningResult.swift; sourceTree = "<group>"; };
+		B072F19F2759018400EE4BCA /* FireStoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireStoreConstants.swift; sourceTree = "<group>"; };
 		B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleRunningViewController.swift; sourceTree = "<group>"; };
 		B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationReceivable.swift; sourceTree = "<group>"; };
 		B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
@@ -1903,6 +1905,7 @@
 				5E659545275492F000B07869 /* Weight.swift */,
 				B02A209127565BA500E86D8A /* SignUpValidationState.swift */,
 				3D92760F2755BC4600D2B9DC /* RealtimeDatabaseKey.swift */,
+				B072F19F2759018400EE4BCA /* FireStoreConstants.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -2390,6 +2393,7 @@
 				3D62257B274E07AB00E4A327 /* NotificationViewController.swift in Sources */,
 				B0F53294273A58AF005A3F11 /* DefaultRunningSettingCoordinator.swift in Sources */,
 				5E5E5564274586CD002FE126 /* CalendarCell.swift in Sources */,
+				B072F1A02759018400EE4BCA /* FireStoreConstants.swift in Sources */,
 				5E53FF08274F5B75002EE49C /* ImageEditButton.swift in Sources */,
 				AE77C2002744DAD8005EDEE0 /* AddMateViewController.swift in Sources */,
 				5EFABAEE272FB5EB00686D08 /* UIColor+CustomColor.swift in Sources */,

--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -244,7 +244,6 @@
 		AEA013F8275890B1007F1BD2 /* ProfileEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D622582274E0A9B00E4A327 /* ProfileEditViewModel.swift */; };
 		AEA013FA275890E6007F1BD2 /* MockProfileEditUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA013F9275890E6007F1BD2 /* MockProfileEditUseCase.swift */; };
 		AEA013FB27589132007F1BD2 /* ProfileEditUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D622588274E0B4700E4A327 /* ProfileEditUseCase.swift */; };
-		AEA013FC275892AD007F1BD2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		AEA013FD275892D3007F1BD2 /* Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6595432754910500B07869 /* Height.swift */; };
 		AEA013FE275892D7007F1BD2 /* Weight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E659545275492F000B07869 /* Weight.swift */; };
 		AEA0140A27590A62007F1BD2 /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D622564274CDCC500E4A327 /* MyPageCoordinator.swift */; };
@@ -400,6 +399,8 @@
 		B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */; };
 		B06E6DC927326E4E00D1EDAC /* TeamRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */; };
 		B072F1A02759018400EE4BCA /* FireStoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B072F19F2759018400EE4BCA /* FireStoreConstants.swift */; };
+		B08CEBE52759166A00436976 /* FireStoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B072F19F2759018400EE4BCA /* FireStoreConstants.swift */; };
+		B08CEBE62759166B00436976 /* FireStoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B072F19F2759018400EE4BCA /* FireStoreConstants.swift */; };
 		B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */; };
 		B095EABA2752AFED001A70F4 /* InvitationReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */; };
 		B0A0DA1E27441A0B004DDC71 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */; };
@@ -2633,7 +2634,6 @@
 				AEA013F72758900C007F1BD2 /* ProfileEditViewModelTests.swift in Sources */,
 				B04C185127568A5900A60863 /* MateRunningModeSettingViewModel.swift in Sources */,
 				B02A204D27563F8D00E86D8A /* DefaultMateRepository.swift in Sources */,
-				AEA013FC275892AD007F1BD2 /* (null) in Sources */,
 				B02A203D27563E4100E86D8A /* Emoji.swift in Sources */,
 				B02A206D275641D300E86D8A /* UserProfile.swift in Sources */,
 				AEA013F02757EE68007F1BD2 /* InvitationViewModel.swift in Sources */,
@@ -2680,6 +2680,7 @@
 				B02A20622756411300E86D8A /* TeamResultView.swift in Sources */,
 				B02A20722756422500E86D8A /* EmojiView.swift in Sources */,
 				B0EC2FAB27561C2200F30F89 /* SingleRunningViewModel.swift in Sources */,
+				B08CEBE52759166A00436976 /* FireStoreConstants.swift in Sources */,
 				B02A20562756400600E86D8A /* MateRequest.swift in Sources */,
 				AEA0141427590F68007F1BD2 /* MyPageViewModelTests.swift in Sources */,
 				AEA013F12757EE7E007F1BD2 /* InvitationReceivable.swift in Sources */,
@@ -2836,6 +2837,7 @@
 				5EE77D36275677F300D05B6F /* DefaultRecordUseCase.swift in Sources */,
 				B0E7639D2757FAAC00F3810C /* RxTimerService.swift in Sources */,
 				5E867AFD2757E5680064901E /* LoginUseCase.swift in Sources */,
+				B08CEBE62759166B00436976 /* FireStoreConstants.swift in Sources */,
 				AEA013D227567065007F1BD2 /* UserRepository.swift in Sources */,
 				B0EC2F772754BC7700F30F89 /* DistanceSettingUseCaseTests.swift in Sources */,
 				B0D1569E27567AEC0054E7FA /* RunningPreparationUseCaseTests.swift in Sources */,

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -373,7 +373,6 @@ final class DefaultFirestoreRepository: FirestoreRepository {
         let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreCollectionPath.notificationPath + "/\(userNickname)"
         + FirestoreCollectionPath.recordsPath + "/\(Date().fullDateTimeNumberString())-\(notice.mode)-\(notice.sender)"
-        
         let dto = NoticeDTO(from: notice)
         let bodyData = [FirestoreField.fields: dto]
         

--- a/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
+++ b/MateRunner/MateRunner/Data/Repository/Common/DefaultFirestoreRepository.swift
@@ -14,6 +14,7 @@ enum FirestoreRepositoryError: Error {
 }
 
 final class DefaultFirestoreRepository: FirestoreRepository {
+    typealias Error = FirestoreRepositoryError
     private let urlSession: URLSessionNetworkService
     
     init(urlSessionService: URLSessionNetworkService) {
@@ -22,27 +23,22 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     
     // MARK: - Running Result Update/Read
     func save(runningResult: RunningResult, to userNickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.runningResultPath
-        + "/\(userNickname)"
-        + FirestoreCollectionPath.recordsPath
-        + "/\(runningResult.runningID)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.runningResultPath + "/\(userNickname)"
+        + FirestoreCollectionPath.recordsPath + "/\(runningResult.runningID)"
         
         guard let dto = try? RunningResultFirestoreDTO(runningResult: runningResult) else {
-            return Observable.error(FirestoreRepositoryError.encodingError)
+            return Observable.error(Error.encodingError)
         }
+        let bodyData = [FirestoreField.fields: dto]
         
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result -> Void in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result -> Void in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func saveAll(
@@ -58,92 +54,68 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     }
     
     func fetchResult(of nickname: String, from startDate: Date, to endDate: Date) -> Observable<[RunningResult]> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreConfiguration.queryKey
+        let bodyData = FirestoreQuery.recordsBetweenDate(from: startDate, to: endDate, of: nickname)
+        let decodeTarget = [QueryResultValue<RunningResultFirestoreDTO>].self
         
-        return self.urlSession.post(
-            FirestoreQuery.recordsBetweenDate(from: startDate, to: endDate, of: nickname),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ queryResult -> [RunningResult] in
-            switch queryResult {
-            case .success(let data):
-                guard let dto = self.decode(data: data, to: [QueryResultValue<RunningResultFirestoreDTO>].self) else {
-                    throw FirestoreRepositoryError.decodingError
+        return self.urlSession.post(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ queryResult -> [RunningResult] in
+                switch queryResult {
+                case .success(let data):
+                    guard let dto = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
+                    return dto.compactMap({try? $0.document?.toDomain()})
+                case .failure(let error):
+                    throw error
                 }
-                return dto.compactMap({try? $0.document?.toDomain()})
-            case .failure(let error):
-                throw error
-            }
-        })
+            })
     }
     
     func fetchResult(of nickname: String, from startOffset: Int, by limit: Int) -> Observable<[RunningResult]> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreConfiguration.queryKey
+        let bodyData = FirestoreQuery.allRecords(of: nickname, from: startOffset, by: limit)
+        let decodeTarget = [QueryResultValue<RunningResultFirestoreDTO>].self
         
-        return self.urlSession.post(
-            FirestoreQuery.allRecords(of: nickname, from: startOffset, by: limit),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ queryResult -> [RunningResult] in
-            switch queryResult {
-            case .success(let data):
-                guard let dto = self.decode(data: data, to: [QueryResultValue<RunningResultFirestoreDTO>].self) else {
-                    throw FirestoreRepositoryError.decodingError
+        return self.urlSession.post(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ queryResult -> [RunningResult] in
+                switch queryResult {
+                case .success(let data):
+                    guard let dto = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
+                    return dto.compactMap({ try? $0.document?.toDomain() })
+                case .failure(let error):
+                    throw error
                 }
-                return dto.compactMap({ try? $0.document?.toDomain() })
-            case .failure(let error):
-                throw error
-            }
-        })
+            })
     }
     
     // MARK: - Emoji Update/Read/Delete
-    func save(
-        emoji: Emoji,
-        to mateNickname: String,
-        of runningID: String,
-        from userNickname: String
+    func save(emoji: Emoji,
+              to mateNickname: String,
+              of runningID: String,
+              from userNickname: String
     ) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.runningResultPath
-        + "/\(mateNickname)"
-        + FirestoreCollectionPath.recordsPath
-        + "/\(runningID)"
-        + FirestoreCollectionPath.emojiPath
-        + "/\(userNickname)"
-        
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.runningResultPath + "/\(mateNickname)"
+        + FirestoreCollectionPath.recordsPath + "/\(runningID)"
+        + FirestoreCollectionPath.emojiPath + "/\(userNickname)"
         let dto = EmojiFirestoreDTO(emoji: emoji.text(), userNickname: userNickname)
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error):
-                throw error
-            }
-        })
+        let bodyData = [FirestoreField.fields: dto]
+        
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
-    func removeEmoji(
-        from runningID: String,
-        of mateNickname: String,
-        with userNickname: String
-    ) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.runningResultPath
-        + "/\(mateNickname)"
-        + FirestoreCollectionPath.recordsPath
-        + "/\(runningID)"
-        + FirestoreCollectionPath.emojiPath
-        + "/\(userNickname)"
+    func removeEmoji(from runningID: String, of mateNickname: String, with userNickname: String) -> Observable<Void> {
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.runningResultPath + "/\(mateNickname)"
+        + FirestoreCollectionPath.recordsPath + "/\(runningID)"
+        + FirestoreCollectionPath.emojiPath + "/\(userNickname)"
         
         return self.urlSession.delete(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result in
@@ -155,21 +127,17 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     }
     
     func fetchEmojis(of runningID: String, from mateNickname: String) -> Observable<[String: Emoji]> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.runningResultPath
-        + "/\(mateNickname)"
-        + FirestoreCollectionPath.recordsPath
-        + "/\(runningID)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.runningResultPath + "/\(mateNickname)"
+        + FirestoreCollectionPath.recordsPath + "/\(runningID)"
         + FirestoreCollectionPath.emojiPath
+        let decodeTarget = DocumentsValue.self
         
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> [String: Emoji] in
                 switch result {
                 case .success(let data):
-                    guard let documents = self.decode(data: data, to: DocumentsValue.self) else {
-                        throw FirestoreRepositoryError.decodingError
-                    }
+                    guard let documents = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
                     return self.parseEmojiFromDocuments(documents)
                 case .failure(let error):
                     throw error
@@ -190,18 +158,15 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     
     // MARK: - UserInformation Read/Update/Delete
     func fetchUserData(of nickname: String) -> Observable<UserData> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(nickname)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(nickname)"
+        let decodeTarget = UserDataFirestoreDTO.self
         
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> UserData in
                 switch result {
                 case .success(let data):
-                    guard let dto = self.decode(data: data, to: UserDataFirestoreDTO.self) else {
-                        throw FirestoreRepositoryError.decodingError
-                    }
+                    guard let dto = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
                     return dto.toDomain()
                 case .failure(let error):
                     throw error
@@ -222,34 +187,27 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     }
     
     func save(userProfile: UserProfile, of userNickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(userNickname)?"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(userNickname)?"
         + [FirestoreFieldParameter.updateMask + FirestoreField.height,
            FirestoreFieldParameter.updateMask + FirestoreField.weight,
            FirestoreFieldParameter.updateMask + FirestoreField.image
         ].joined(separator: "&")
-        
         let dto = UserProfileFirestoreDTO(userProfile: userProfile)
+        let bodyData = [FirestoreField.fields: dto]
         
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func fetchUserProfile(of userNickname: String) -> Observable<UserProfile> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(userNickname)?"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(userNickname)?"
         + [FirestoreFieldParameter.readMask + FirestoreField.height,
            FirestoreFieldParameter.readMask + FirestoreField.weight,
            FirestoreFieldParameter.readMask + FirestoreField.image
@@ -260,7 +218,7 @@ final class DefaultFirestoreRepository: FirestoreRepository {
                 switch result {
                 case .success(let data):
                     guard let dto = self.decode(data: data, to: UserProfileFirestoreDTO.self) else {
-                        throw FirestoreRepositoryError.decodingError
+                        throw Error.decodingError
                     }
                     return dto.toDomain()
                 case .failure(let error):
@@ -271,45 +229,39 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     
     // MARK: - TotalRecord Update/Read
     func save(totalRecord: PersonalTotalRecord, of nickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(nickname)?"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(nickname)?"
         + [FirestoreFieldParameter.updateMask + FirestoreField.calorie,
            FirestoreFieldParameter.updateMask + FirestoreField.distance,
            FirestoreFieldParameter.updateMask + FirestoreField.time
         ].joined(separator: "&")
-        let dto = PersonalTotalRecordDTO(totalRecord: totalRecord)
         
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        let dto = PersonalTotalRecordDTO(totalRecord: totalRecord)
+        let bodyData = [FirestoreField.fields: dto]
+        
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func fetchTotalPeronsalRecord(of nickname: String) -> Observable<PersonalTotalRecord> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(nickname)?"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(nickname)?"
         + [FirestoreFieldParameter.readMask + FirestoreField.calorie,
            FirestoreFieldParameter.readMask + FirestoreField.distance,
            FirestoreFieldParameter.readMask + FirestoreField.time
         ].joined(separator: "&")
+        let decodeTarget = PersonalTotalRecordDTO.self
         
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> PersonalTotalRecord in
                 switch result {
                 case .success(let data):
-                    guard let dto = self.decode(data: data, to: PersonalTotalRecordDTO.self) else {
-                        throw FirestoreRepositoryError.decodingError
-                    }
+                    guard let dto = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
                     return dto.toDomain()
                 case .failure(let error):
                     throw error
@@ -319,30 +271,24 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     
     // MARK: - User Update/Delete
     func save(user: UserData) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(user.nickname)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(user.nickname)"
         
         let dto = UserDataFirestoreDTO(userData: user)
+        let bodyData = [FirestoreField.fields: dto]
         
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func remove(user nickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(nickname)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(nickname)"
         
         return self.urlSession.delete(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result in
@@ -355,19 +301,16 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     
     // MARK: - Mate Read/Update/Delete
     func fetchMate(of nickname: String) -> Observable<[String]> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.userPath
-        + "/\(nickname)?"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.userPath + "/\(nickname)?"
         + FirestoreFieldParameter.readMask + FirestoreField.mate
+        let decodeTarget = MateListFirestoreDTO.self
         
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> [String] in
                 switch result {
                 case .success(let data):
-                    guard let mates = self.decode(data: data, to: MateListFirestoreDTO.self) else {
-                        throw FirestoreRepositoryError.decodingError
-                    }
+                    guard let mates = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
                     return mates.toDomain()
                 case .failure(let error):
                     throw error
@@ -376,137 +319,113 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     }
     
     func fetchFilteredMate(from text: String, of nickname: String) -> Observable<[String]> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreConfiguration.queryKey
-
-        return self.urlSession.post(
-            FirestoreQuery.nameFilter(by: text, selfNickname: nickname),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ queryResult -> [String] in
-            switch queryResult {
-            case .success(let data):
-                guard let dto = self.decode(data: data, to: [QueryResultValue<UserDataFirestoreDTO>].self) else {
-                    throw FirestoreRepositoryError.decodingError
+        let bodyData = FirestoreQuery.nameFilter(by: text, selfNickname: nickname)
+        let decodeTarget = [QueryResultValue<UserDataFirestoreDTO>].self
+        
+        return self.urlSession.post(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ queryResult -> [String] in
+                switch queryResult {
+                case .success(let data):
+                    guard let dto = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
+                    return dto.compactMap({ $0.document?.toDomain().nickname })
+                case .failure(let error):
+                    throw error
                 }
-                return dto.compactMap({ try? $0.document?.toDomain().nickname })
-            case .failure(let error):
-                throw error
-            }
-        })
+            })
     }
     
     func save(mate nickname: String, to targetNickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreConfiguration.commitKey
+        let bodyData = FirestoreQuery.append(mate: nickname, to: targetNickname)
         
-        return self.urlSession.post(
-            FirestoreQuery.append(mate: nickname, to: targetNickname),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        return self.urlSession.post(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     // MARK: - Notice Read/Update
     func fetchNotice(of userNickname: String) -> Observable<[Notice]> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.notificationPath
-        + "/\(userNickname)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.notificationPath + "/\(userNickname)"
         + FirestoreCollectionPath.recordsPath
+        let decodeTarget = Documents<[NoticeDTO]>.self
         
-        return self.urlSession.get(
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result -> [Notice] in
-            switch result {
-            case .success(let data):
-                guard let documents = self.decode(data: data, to: Documents<[NoticeDTO]>.self) else {
-                    throw FirestoreRepositoryError.decodingError
+        return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result -> [Notice] in
+                switch result {
+                case .success(let data):
+                    guard let documents = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
+                    return documents.documents.map { $0.toDomain() }
+                case .failure(let error):
+                    throw error
                 }
-                return documents.documents.map { $0.toDomain() }
-            case .failure(let error):
-                throw error
-            }
-        })
+            })
     }
     
     func save(notice: Notice, of userNickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.notificationPath
-        + "/\(userNickname)"
-        + FirestoreCollectionPath.recordsPath
-        + "/\(Date().fullDateTimeNumberString())-\(notice.mode)-\(notice.sender)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.notificationPath + "/\(userNickname)"
+        + FirestoreCollectionPath.recordsPath + "/\(Date().fullDateTimeNumberString())-\(notice.mode)-\(notice.sender)"
         
         let dto = NoticeDTO(from: notice)
+        let bodyData = [FirestoreField.fields: dto]
         
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func updateState(notice: Notice, of userNickname: String) -> Observable<Void> {
         let endPoint = FirestoreConfiguration.firestoreBaseURL + (notice.id ?? "")
         let dto = NoticeDTO(from: notice)
         
-        return self.urlSession.patch(
-            [FirestoreField.fields: dto],
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        let bodyData = [FirestoreField.fields: dto]
+        
+        return self.urlSession.patch(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func remove(mate nickname: String, from targetNickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreConfiguration.commitKey
         
-        return self.urlSession.post(
-            FirestoreQuery.remove(mate: nickname, from: targetNickname),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        let bodyData = FirestoreQuery.remove(mate: nickname, from: targetNickname)
+        
+        return self.urlSession.post(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func fetchUserNickname(of uid: String) -> Observable<String> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.uidPath
-        + "/\(uid)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.uidPath + "/\(uid)"
         
         return self.urlSession.get(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map({ result -> String in
                 switch result {
                 case .success(let data):
                     guard let dto = self.decode(data: data, to: FieldValue.self),
-                          let nickname = dto.fields["nickname"]?.value else {
-                        throw FirestoreRepositoryError.decodingError
-                    }
+                          let nickname = dto.fields[FirestoreField.nickname]?.value else { throw Error.decodingError }
                     return nickname
                 case .failure(let error):
                     throw error
@@ -515,39 +434,30 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     }
     
     func save(uid: String, nickname: String) -> Observable<Void> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
-        + FirestoreCollectionPath.uidPath
-        + "/\(uid)"
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.uidPath + "/\(uid)"
+        let bodyyData = FieldValue(value: [FirestoreField.nickname: StringValue(value: nickname)])
         
-        return self.urlSession.patch(
-            FieldValue(value: ["nickname": StringValue(value: nickname)]),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        ).map({ result in
-            switch result {
-            case .success: break
-            case .failure(let error): throw error
-            }
-        })
+        return self.urlSession.patch(bodyyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
     }
     
     func fetchUID(of nickname: String) -> Observable<String?> {
-        let endPoint = FirestoreConfiguration.baseURL
-        + FirestoreConfiguration.documentsPath
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
         + FirestoreConfiguration.queryKey
-           
-        return self.urlSession.post(
-            FirestoreQuery.uidFilter(by: nickname),
-            url: endPoint,
-            headers: FirestoreConfiguration.defaultHeaders
-        )
+        let bodyData = FirestoreQuery.uidFilter(by: nickname)
+        let decodeTarget = [QueryResultValue<Document>].self
+        
+        return self.urlSession.post(bodyData, url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
             .map { queryResult -> String? in
                 switch queryResult {
                 case .success(let data):
-                    guard let dto = self.decode(data: data, to: [QueryResultValue<Document>].self) else {
-                        throw FirestoreRepositoryError.decodingError
-                    }
+                    guard let dto = self.decode(data: data, to: decodeTarget) else { throw Error.decodingError }
                     return dto.first?.document?.name?.components(separatedBy: "/").last
                 case .failure(let error):
                     throw error
@@ -556,104 +466,43 @@ final class DefaultFirestoreRepository: FirestoreRepository {
     }
     
     func removeUID(uid: String) -> Observable<Void> {
-            let endPoint = FirestoreConfiguration.baseURL
-            + FirestoreConfiguration.documentsPath
-            + FirestoreCollectionPath.uidPath
-            + "/\(uid)"
-            
-            return self.urlSession.delete(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
-                .map({ result in
-                    switch result {
-                    case .success: break
-                    case .failure(let error): throw error
-                    }
-                })
-        }
+        let endPoint = FirestoreConfiguration.baseURL + FirestoreConfiguration.documentsPath
+        + FirestoreCollectionPath.uidPath + "/\(uid)"
+        
+        return self.urlSession.delete(url: endPoint, headers: FirestoreConfiguration.defaultHeaders)
+            .map({ result in
+                switch result {
+                case .success: break
+                case .failure(let error): throw error
+                }
+            })
+    }
     
     private func decode<T: Decodable>(data: Data, to target: T.Type) -> T? {
-        do {
-            return try JSONDecoder().decode(target, from: data)
-        } catch {
-            return nil
-        }
-    }
-}
-
-// MARK: - firestore request constants
-extension DefaultFirestoreRepository {
-    private enum FirestoreConfiguration {
-        static let firestoreBaseURL = "https://firestore.googleapis.com/v1/"
-        static let baseURL = "https://firestore.googleapis.com/v1/projects/mate-runner-e232c"
-        static let documentsPath = "/databases/(default)/documents"
-        static let queryKey = ":runQuery"
-        static let commitKey = ":commit"
-        static let defaultHeaders = ["Content-Type": "application/json", "Accept": "application/json"]
-    }
-    
-    private enum FirestoreFieldParameter {
-        static let updateMask = "updateMask.fieldPaths="
-        static let readMask = "mask.fieldPaths="
-    }
-    
-    private enum FirestoreCollectionPath {
-        static let runningResultPath = "/RunningResult"
-        static let userPath = "/User"
-        static let recordsPath = "/records"
-        static let emojiPath = "/emojis"
-        static let notificationPath = "/Notification"
-        static let uidPath = "/UID"
-    }
-    
-    private enum FirestoreField {
-        static let fields = "fields"
-        static let emoji = "emoji"
-        static let userNickname = "userNickname"
-        static let nickname = "nickname"
-        static let distance = "distance"
-        static let time = "time"
-        static let height = "height"
-        static let weight = "weight"
-        static let image = "image"
-        static let calorie = "calorie"
-        static let mate = "mate"
+        return try? JSONDecoder().decode(target, from: data)
     }
 }
 
 extension DefaultFirestoreRepository {
-    private enum FirebaseStorageConfiguration {
-        static let baseURL = "https://firebasestorage.googleapis.com/v0/b"
-        static let projectNamePath = "/mate-runner-e232c.appspot.com/o"
-        static let profileImageName = "profile.png"
-        static let downloadTokens = "downloadTokens"
-        static let altMediaParameter = "alt=media"
-        static let tokenParameter = "token="
-        static let mediaContentType = ["Content-Type": "image/png"]
-    }
-    
     func save(profileImageData: Data, of userNickname: String) -> Observable<String> {
         let endPoint = FirebaseStorageConfiguration.baseURL
-        + FirebaseStorageConfiguration.projectNamePath
-        + "/\(userNickname)%2F"
+        + FirebaseStorageConfiguration.projectNamePath + "/\(userNickname)%2F"
         + FirebaseStorageConfiguration.profileImageName
+        let header = FirebaseStorageConfiguration.mediaContentType
+        let tokenKey = FirebaseStorageConfiguration.downloadTokens
         
-        return self.urlSession.post(
-            profileImageData,
-            url: endPoint,
-            headers: FirebaseStorageConfiguration.mediaContentType
-        ).map({ result -> String in
-            switch result {
-            case .success(let data):
-                guard let json = self.decode(data: data, to: [String: String].self),
-                      let token = json[FirebaseStorageConfiguration.downloadTokens] else {
-                          throw FirestoreRepositoryError.decodingError
-                      }
-                return endPoint + "?"
-                + [FirebaseStorageConfiguration.altMediaParameter,
-                   FirebaseStorageConfiguration.tokenParameter + token
-                ].joined(separator: "&")
-            case .failure(let error):
-                throw error
-            }
-        })
+        return self.urlSession.post(profileImageData, url: endPoint, headers: header)
+            .map({ result -> String in
+                switch result {
+                case .success(let data):
+                    guard let json = self.decode(data: data, to: [String: String].self),
+                          let token = json[tokenKey] else { throw Error.decodingError }
+                    return endPoint + "?"
+                    + [FirebaseStorageConfiguration.altMediaParameter,
+                       FirebaseStorageConfiguration.tokenParameter + token].joined(separator: "&")
+                case .failure(let error):
+                    throw error
+                }
+            })
     }
 }

--- a/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
+++ b/MateRunner/MateRunner/Network/DefaultURLSessionNetworkService.swift
@@ -104,7 +104,7 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
                     return
                 }
                 
-                if let error = error {
+                if error != nil {
                     emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                     return
                 }
@@ -145,7 +145,7 @@ final class DefaultURLSessionNetworkService: URLSessionNetworkService {
                     emitter.onError(URLSessionNetworkServiceError.unknownError)
                     return
                 }
-                if let error = error {
+                if error != nil {
                     emitter.onError(self.configureHTTPError(errorCode: httpResponse.statusCode))
                     return
                 }

--- a/MateRunner/MateRunner/Util/Constant/FireStoreConstants.swift
+++ b/MateRunner/MateRunner/Util/Constant/FireStoreConstants.swift
@@ -1,0 +1,55 @@
+//
+//  FireStoreConstants.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/12/02.
+//
+
+import Foundation
+
+enum FirestoreConfiguration {
+    static let firestoreBaseURL = "https://firestore.googleapis.com/v1/"
+    static let baseURL = "https://firestore.googleapis.com/v1/projects/mate-runner-e232c"
+    static let documentsPath = "/databases/(default)/documents"
+    static let queryKey = ":runQuery"
+    static let commitKey = ":commit"
+    static let defaultHeaders = ["Content-Type": "application/json", "Accept": "application/json"]
+}
+
+enum FirestoreFieldParameter {
+    static let updateMask = "updateMask.fieldPaths="
+    static let readMask = "mask.fieldPaths="
+}
+
+enum FirestoreCollectionPath {
+    static let runningResultPath = "/RunningResult"
+    static let userPath = "/User"
+    static let recordsPath = "/records"
+    static let emojiPath = "/emojis"
+    static let notificationPath = "/Notification"
+    static let uidPath = "/UID"
+}
+
+enum FirestoreField {
+    static let fields = "fields"
+    static let emoji = "emoji"
+    static let userNickname = "userNickname"
+    static let nickname = "nickname"
+    static let distance = "distance"
+    static let time = "time"
+    static let height = "height"
+    static let weight = "weight"
+    static let image = "image"
+    static let calorie = "calorie"
+    static let mate = "mate"
+}
+
+enum FirebaseStorageConfiguration {
+    static let baseURL = "https://firebasestorage.googleapis.com/v0/b"
+    static let projectNamePath = "/mate-runner-e232c.appspot.com/o"
+    static let profileImageName = "profile.png"
+    static let downloadTokens = "downloadTokens"
+    static let altMediaParameter = "alt=media"
+    static let tokenParameter = "token="
+    static let mediaContentType = ["Content-Type": "image/png"]
+}

--- a/MateRunner/MateRunnerUseCaseTests/LoginScene/SignUpUseCaseTests.swift
+++ b/MateRunner/MateRunnerUseCaseTests/LoginScene/SignUpUseCaseTests.swift
@@ -89,7 +89,7 @@ class SignUpUseCaseTests: XCTestCase {
         self.signUpUseCase.saveLoginInfo()
         
         let nickname = self.userRepository.fetchUserNickname()
-        XCTAssertEqual(nickname, "Sfesdfcxkl2131sd")
+        XCTAssertEqual(nickname, "materunner")
     }
     
     func test_shuffle_profile_emoji() {


### PR DESCRIPTION
### 📕 Issue Number

Close #273 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 코드 라인 수 줄이기


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 린터에서 붉은 색으로 에어라고 처리하는 클래스 바디 중복제외 300줄 초과는 해결했는데 여전히 파일이 너무 큽니다.
- 프로토콜로 각 콜렉션에 대한 operation들을 묶음으로 나누면 효과적으로 나눌 수 있을 것 같지만 테스트가 진행중이라 구조 자체를 변경하는 것은 지양하는 게 좋을 것 같아서 일단 이대로 두겠습니다. 
- 목데이터를 제가 이전에 테스트하면서 바꾼게 있는데 이전 값으로 SignUpTests에 적용되고 있어서 실패하는 테스트 케이스가 있었습니다. 수정했어요!

<br/><br/>
