### PR TITLE
CoreLocation 관련 공통메서드 Protocol로 분리

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -244,7 +244,6 @@
 		AEA013F8275890B1007F1BD2 /* ProfileEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D622582274E0A9B00E4A327 /* ProfileEditViewModel.swift */; };
 		AEA013FA275890E6007F1BD2 /* MockProfileEditUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA013F9275890E6007F1BD2 /* MockProfileEditUseCase.swift */; };
 		AEA013FB27589132007F1BD2 /* ProfileEditUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D622588274E0B4700E4A327 /* ProfileEditUseCase.swift */; };
-		AEA013FC275892AD007F1BD2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		AEA013FD275892D3007F1BD2 /* Height.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6595432754910500B07869 /* Height.swift */; };
 		AEA013FE275892D7007F1BD2 /* Weight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E659545275492F000B07869 /* Weight.swift */; };
 		AEA0140A27590A62007F1BD2 /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D622564274CDCC500E4A327 /* MyPageCoordinator.swift */; };
@@ -399,6 +398,8 @@
 		B06E6DC427326C1C00D1EDAC /* Emoji.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC327326C1C00D1EDAC /* Emoji.swift */; };
 		B06E6DC727326E3F00D1EDAC /* RaceRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */; };
 		B06E6DC927326E4E00D1EDAC /* TeamRunningResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */; };
+		B08CEBE9275919C500436976 /* CoreLocationConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08CEBE8275919C500436976 /* CoreLocationConvertable.swift */; };
+		B08CEBEA27591ACC00436976 /* CoreLocationConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08CEBE8275919C500436976 /* CoreLocationConvertable.swift */; };
 		B08D15C42739566A0095AC00 /* SingleRunningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */; };
 		B095EABA2752AFED001A70F4 /* InvitationReceivable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */; };
 		B0A0DA1E27441A0B004DDC71 /* HomeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */; };
@@ -784,6 +785,7 @@
 		B06E6DC327326C1C00D1EDAC /* Emoji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emoji.swift; sourceTree = "<group>"; };
 		B06E6DC627326E3F00D1EDAC /* RaceRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceRunningResult.swift; sourceTree = "<group>"; };
 		B06E6DC827326E4E00D1EDAC /* TeamRunningResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamRunningResult.swift; sourceTree = "<group>"; };
+		B08CEBE8275919C500436976 /* CoreLocationConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreLocationConvertable.swift; sourceTree = "<group>"; };
 		B08D15C32739566A0095AC00 /* SingleRunningViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleRunningViewController.swift; sourceTree = "<group>"; };
 		B095EAB92752AFED001A70F4 /* InvitationReceivable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationReceivable.swift; sourceTree = "<group>"; };
 		B0A0DA1D27441A0B004DDC71 /* HomeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeUseCase.swift; sourceTree = "<group>"; };
@@ -1684,6 +1686,7 @@
 		AEA8C55A273D537E0066E0E1 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				B08CEBE7275919B600436976 /* Protocol */,
 				3DAF2D822743A05700AC5FEA /* InvitationViewModel.swift */,
 				AEA8C55B273D538A0066E0E1 /* EmojiViewModel.swift */,
 			);
@@ -1905,6 +1908,14 @@
 				3D92760F2755BC4600D2B9DC /* RealtimeDatabaseKey.swift */,
 			);
 			path = Constant;
+			sourceTree = "<group>";
+		};
+		B08CEBE7275919B600436976 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				B08CEBE8275919C500436976 /* CoreLocationConvertable.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		B0C66AB0274A5F8A00F33C76 /* Delegate */ = {
@@ -2537,6 +2548,7 @@
 				AE77C2172746AEE0005EDEE0 /* MateProfileCoordinator.swift in Sources */,
 				5E3B82E22738D22C00EBF39C /* BackButtonDelegate.swift in Sources */,
 				5E5E5562274581D3002FE126 /* CalendarView.swift in Sources */,
+				B08CEBE9275919C500436976 /* CoreLocationConvertable.swift in Sources */,
 				3D622587274E0AFC00E4A327 /* DefaultNotificationUseCase.swift in Sources */,
 				5E6F382A273A3DEF009686DC /* RaceRunningViewController.swift in Sources */,
 				AEB3DFC0274957E40083BA9B /* ProfileUseCase.swift in Sources */,
@@ -2629,7 +2641,6 @@
 				AEA013F72758900C007F1BD2 /* ProfileEditViewModelTests.swift in Sources */,
 				B04C185127568A5900A60863 /* MateRunningModeSettingViewModel.swift in Sources */,
 				B02A204D27563F8D00E86D8A /* DefaultMateRepository.swift in Sources */,
-				AEA013FC275892AD007F1BD2 /* (null) in Sources */,
 				B02A203D27563E4100E86D8A /* Emoji.swift in Sources */,
 				B02A206D275641D300E86D8A /* UserProfile.swift in Sources */,
 				AEA013F02757EE68007F1BD2 /* InvitationViewModel.swift in Sources */,
@@ -2664,6 +2675,7 @@
 				B02A2070275641FF00E86D8A /* RunningResultFactory.swift in Sources */,
 				B02A20582756402700E86D8A /* ComplimentEmoji.swift in Sources */,
 				AEA013FD275892D3007F1BD2 /* Height.swift in Sources */,
+				B08CEBEA27591ACC00436976 /* CoreLocationConvertable.swift in Sources */,
 				AEA013F42757EEC9007F1BD2 /* MockInvitationUseCase.swift in Sources */,
 				B0D15692275674C20054E7FA /* RealtimeDatabaseKey.swift in Sources */,
 				B02A207A2756430500E86D8A /* Point+CLLocationCoordinate2D.swift in Sources */,

--- a/MateRunner/MateRunner/Presentation/Common/ViewModel/Protocol/CoreLocationConvertable.swift
+++ b/MateRunner/MateRunner/Presentation/Common/ViewModel/Protocol/CoreLocationConvertable.swift
@@ -1,0 +1,42 @@
+//
+//  CoreLocationCalculatable.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2021/12/03.
+//
+
+import CoreLocation
+import Foundation
+
+protocol CoreLocationConvertable {
+    func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D]
+    func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region
+}
+
+extension CoreLocationConvertable {
+    func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {
+        return points.map { location in location.convertToCLLocationCoordinate2D() }
+    }
+    
+    func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region {
+        guard !points.isEmpty else { return Region() }
+        
+        let latitudes = points.map { $0.latitude }
+        let longitudes = points.map { $0.longitude }
+        
+        guard let maxLatitude = latitudes.max(),
+              let minLatitude = latitudes.min(),
+              let maxLongitude = longitudes.max(),
+              let minLongitude = longitudes.min() else { return Region() }
+        
+        let meanLatitude = (maxLatitude + minLatitude) / 2
+        let meanLongitude = (maxLongitude + minLongitude) / 2
+        let coordinate = CLLocationCoordinate2DMake(meanLatitude, meanLongitude)
+        
+        let latitudeSpan = (maxLatitude - minLatitude) * 1.5
+        let longitudeSpan = (maxLongitude - minLongitude) * 1.5
+        let span = (latitudeSpan, longitudeSpan)
+        
+        return Region(center: coordinate, span: span)
+    }
+}

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/RaceRunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/RaceRunningResultViewModel.swift
@@ -10,7 +10,7 @@ import CoreLocation
 import RxRelay
 import RxSwift
 
-final class RaceRunningResultViewModel {
+final class RaceRunningResultViewModel: CoreLocationConvertable {
     private let runningResultUseCase: RunningResultUseCase
     private let errorAlternativeText = "---"
     weak var coordinator: RunningCoordinator?
@@ -146,31 +146,5 @@ final class RaceRunningResultViewModel {
                 viewModelOutput.saveFailAlertShouldShow.accept(true)
             })
             .disposed(by: disposeBag)
-    }
-    
-    private func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {
-        return points.map { location in location.convertToCLLocationCoordinate2D() }
-    }
-    
-    private func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region {
-        guard !points.isEmpty else { return Region() }
-        
-        let latitudes = points.map { $0.latitude }
-        let longitudes = points.map { $0.longitude }
-        
-        guard let maxLatitude = latitudes.max(),
-              let minLatitude = latitudes.min(),
-              let maxLongitude = longitudes.max(),
-              let minLongitude = longitudes.min() else { return Region() }
-        
-        let meanLatitude = (maxLatitude + minLatitude) / 2
-        let meanLongitude = (maxLongitude + minLongitude) / 2
-        let coordinate = CLLocationCoordinate2DMake(meanLatitude, meanLongitude)
-        
-        let latitudeSpan = (maxLatitude - minLatitude) * 1.5
-        let longitudeSpan = (maxLongitude - minLongitude) * 1.5
-        let span = (latitudeSpan, longitudeSpan)
-        
-        return Region(center: coordinate, span: span)
     }
 }

--- a/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/SingleRunningResultViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/HomeScene/ViewModel/ResultViewModel/SingleRunningResultViewModel.swift
@@ -10,7 +10,7 @@ import CoreLocation
 import RxRelay
 import RxSwift
 
-final class SingleRunningResultViewModel {
+final class SingleRunningResultViewModel: CoreLocationConvertable {
     private let runningResultUseCase: RunningResultUseCase
     weak var coordinator: RunningCoordinator?
     
@@ -83,31 +83,5 @@ final class SingleRunningResultViewModel {
                 viewModelOutput.saveFailAlertShouldShow.accept(true)
             })
             .disposed(by: disposeBag)
-    }
-  
-    private func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {
-        return points.map { location in location.convertToCLLocationCoordinate2D() }
-    }
-    
-    private func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region {
-        guard !points.isEmpty else { return Region() }
-        
-        let latitudes = points.map { $0.latitude }
-        let longitudes = points.map { $0.longitude }
-        
-        guard let maxLatitude = latitudes.max(),
-              let minLatitude = latitudes.min(),
-              let maxLongitude = longitudes.max(),
-              let minLongitude = longitudes.min() else { return Region() }
-        
-        let meanLatitude = (maxLatitude + minLatitude) / 2
-        let meanLongitude = (maxLongitude + minLongitude) / 2
-        let coordinate = CLLocationCoordinate2DMake(meanLatitude, meanLongitude)
-        
-        let latitudeSpan = (maxLatitude - minLatitude) * 1.5
-        let longitudeSpan = (maxLongitude - minLongitude) * 1.5
-        let span = (latitudeSpan, longitudeSpan)
-        
-        return Region(center: coordinate, span: span)
     }
 }

--- a/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordDetailViewModel.swift
+++ b/MateRunner/MateRunner/Presentation/RecordScene/ViewModel/RecordDetailViewModel.swift
@@ -9,7 +9,7 @@ import CoreLocation
 
 import RxSwift
 
-final class RecordDetailViewModel {
+final class RecordDetailViewModel: CoreLocationConvertable {
     private let recordDetailUseCase: RecordDetailUseCase
 
     struct Output {
@@ -89,32 +89,6 @@ final class RecordDetailViewModel {
 }
 
 private extension RecordDetailViewModel {
-    func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D] {
-        return points.map { location in location.convertToCLLocationCoordinate2D() }
-    }
-    
-    func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region {
-        guard !points.isEmpty else { return Region() }
-        
-        let latitudes = points.map { $0.latitude }
-        let longitudes = points.map { $0.longitude }
-        
-        guard let maxLatitude = latitudes.max(),
-              let minLatitude = latitudes.min(),
-              let maxLongitude = longitudes.max(),
-              let minLongitude = longitudes.min() else { return Region() }
-        
-        let meanLatitude = (maxLatitude + minLatitude) / 2
-        let meanLongitude = (maxLongitude + minLongitude) / 2
-        let coordinate = CLLocationCoordinate2DMake(meanLatitude, meanLongitude)
-        
-        let latitudeSpan = (maxLatitude - minLatitude) * 1.5
-        let longitudeSpan = (maxLongitude - minLongitude) * 1.5
-        let span = (latitudeSpan, longitudeSpan)
-        
-        return Region(center: coordinate, span: span)
-    }
-    
     func createHeaderMessage(
         mateNickname: String,
         isUserWinner: Bool,


### PR DESCRIPTION
### 📕 Issue Number

Close #274 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 작성


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- CoreLocationConvertable 프로토콜과 extension 추가

```swift
protocol CoreLocationConvertable {
    func pointsToCoordinate2D(from points: [Point]) -> [CLLocationCoordinate2D]
    func calculateRegion(from points: [CLLocationCoordinate2D]) -> Region
}
```
결과와 관련된 뷰모델에서 공통적으로 가지고 있는 메서드들이 이 두 메서드인데요, 지도에 보여질 region을 계산하는 메서드와 Point 타입을 CLLocationCoordinate2D로 변경하는 메서드입니다. 그래서 프로토콜로 따로 분리하고, 모든 파일에서 동일한 구현체를 사용하기 때문에 extension으로 기본 바디를 구현해두었습니다.
<br/><br/>
