### PR TITLE
캐싱 정책 개선

### DIFF
--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let notificationResponse = connectionOptions.notificationResponse else { return }
         let userInfo = notificationResponse.notification.request.content.userInfo
         self.configureInvitation(with: userInfo)
-        ImageCache.configureCachePolicy(with: 50)
+        ImageCache.configureCachePolicy(with: 52428800)
 
         return
     }

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -29,6 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let notificationResponse = connectionOptions.notificationResponse else { return }
         let userInfo = notificationResponse.notification.request.content.userInfo
         self.configureInvitation(with: userInfo)
+        ImageCache.configureCachePolicy(with: 50)
 
         return
     }

--- a/MateRunner/MateRunner/Domain/Model/CacheableImage.swift
+++ b/MateRunner/MateRunner/Domain/Model/CacheableImage.swift
@@ -9,10 +9,15 @@ import Foundation
 
 final class CacheableImage {
     let imageData: Data
-    let etag: String
+    let cacheInfo: CacheInfo
     
     init(imageData: Data, etag: String) {
+        self.cacheInfo = CacheInfo(etag: etag, lastRead: Date())
         self.imageData = imageData
-        self.etag = etag
     }
+}
+
+struct CacheInfo {
+    let etag: String
+    let lastRead: Date
 }

--- a/MateRunner/MateRunner/Domain/Model/CacheableImage.swift
+++ b/MateRunner/MateRunner/Domain/Model/CacheableImage.swift
@@ -17,7 +17,7 @@ final class CacheableImage {
     }
 }
 
-struct CacheInfo {
+struct CacheInfo: Codable {
     let etag: String
     let lastRead: Date
 }

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateProfileTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateProfileTableViewCell.swift
@@ -11,7 +11,7 @@ import RxSwift
 import SnapKit
 
 final class MateProfilTableViewCell: UITableViewCell {
-    private let disposeBag = DisposeBag()
+    private var disposeBag = DisposeBag()
     static var identifier: String {
         return String(describing: Self.self)
     }
@@ -46,6 +46,7 @@ final class MateProfilTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.mateProfileImageView.image = UIImage(systemName: "person.crop.circle.fill")
+        self.disposeBag = DisposeBag()
     }
     
     func updateUI(imageURL: String, nickname: String, time: String, distance: String, calorie: String) {

--- a/MateRunner/MateRunner/Presentation/MateScene/View/MateTableViewCell.swift
+++ b/MateRunner/MateRunner/Presentation/MateScene/View/MateTableViewCell.swift
@@ -11,7 +11,7 @@ import RxSwift
 import SnapKit
 
 class MateTableViewCell: UITableViewCell {
-    private let disposeBag = DisposeBag()
+    private var disposeBag = DisposeBag()
     
     static var identifier: String {
         return String(describing: Self.self)
@@ -45,6 +45,7 @@ class MateTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.mateProfileImageView.image = UIImage(systemName: "person.crop.circle.fill")
+        self.disposeBag = DisposeBag()
     }
     
     func updateUI(name: String, image: String) {

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -78,7 +78,9 @@ final class DefaultImageCacheService {
     
     private func checkMemory(_ imageURL: URL) -> CacheableImage? {
         let cacheKey = NSString(string: imageURL.path)
-        return ImageCache.cache.object(forKey: cacheKey)
+        guard let cached = ImageCache.cache.object(forKey: cacheKey) else { return nil }
+        self.updateLastRead(of: imageURL, currentEtag: cached.cacheInfo.etag)
+        return cached
     }
     
     private func checkDisk(_ imageURL: URL) -> CacheableImage? {
@@ -93,6 +95,7 @@ final class DefaultImageCacheService {
             
             let image = CacheableImage(imageData: imageData, etag: etag)
             self.saveIntoCache(imageURL: imageURL, image: image)
+            self.updateLastRead(of: imageURL, currentEtag: etag)
             
             return image
         }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -11,6 +11,9 @@ import RxSwift
 
 enum ImageCache {
     static var cache = NSCache<NSString, CacheableImage>()
+    static func configureCachePolicy(with maximumObjectCount: Int) {
+        Self.cache.countLimit = maximumObjectCount
+    }
 }
 
 final class DefaultImageCacheService {

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -88,7 +88,11 @@ final class DefaultImageCacheService {
         if FileManager.default.fileExists(atPath: filePath.path) {
             guard let imageData = try? Data(contentsOf: filePath),
                   let etag = UserDefaults.standard.string(forKey: imageURL.path) else { return nil }
-            return CacheableImage(imageData: imageData, etag: etag)
+            
+            let image = CacheableImage(imageData: imageData, etag: etag)
+            self.saveIntoCache(imageURL: imageURL, image: image)
+            
+            return image
         }
         return nil
     }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -12,7 +12,7 @@ import RxSwift
 enum ImageCache {
     static var cache = NSCache<NSString, CacheableImage>()
     static func configureCachePolicy(with maximumBytes: Int) {
-        Self.cache.totalCostLimit = 52428800
+        Self.cache.totalCostLimit = maximumBytes
     }
 }
 

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -17,7 +17,6 @@ enum ImageCache {
 }
 
 final class DefaultImageCacheService {
-    private let disposeBag = DisposeBag()
     static let shared = DefaultImageCacheService()
     private init () {}
     
@@ -51,7 +50,7 @@ final class DefaultImageCacheService {
             if let etag = etag {
                 request.addValue(etag, forHTTPHeaderField: "If-None-Match")
             }
-            URLSession.shared.rx.response(request: request).subscribe(
+            let disposable = URLSession.shared.rx.response(request: request).subscribe(
                 onNext: { [weak self] (response, data) in
                     switch response.statusCode {
                     case (200...299):
@@ -71,9 +70,9 @@ final class DefaultImageCacheService {
                 onError: { error in
                     emitter.onError(error)
                 }
-            ).disposed(by: self.disposeBag)
+            )
             
-            return Disposables.create()
+            return Disposables.create(with: disposable.dispose )
         }
     }
     


### PR DESCRIPTION
### 📕 Issue Number

Close #407

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x]  NSCache 정책 추가
- [x] 디스크 캐시 정책 추가
- [x] 디스크 캐시 히트 후 메모리 캐시 업데이트 추가
- [x] 디스크 캐시 삭제 기능 추가


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

### NSCache 정책
<img width="604" alt="스크린샷 2022-01-09 오후 5 31 04" src="https://user-images.githubusercontent.com/46087477/148675067-f849e9a1-c5ac-401c-bb70-482cd9b4ac5f.png">

먼저 메모리 캐시인 NSCache에 CostLimit 정책을 추가했습니다. [공식문서](https://developer.apple.com/documentation/foundation/nscache/1407672-totalcostlimit)에서 costLimit을 지정하면 cost가 넘어갈 때 내부적으로 캐시가 데이터를 삭제한다고 합니다. 어떤 기준으로 삭제하는지는 [여기](https://hcn1519.github.io/articles/2018-08/nscache)에 정리해주신 내용에 따르면 cost가 작은 순서대로 삭제한다고 하는데, 저 글이 작성된 시점에 공개되었던 NSCache코드가 지금은 보이지 않아서 현재도 그런지는 정확히 확인할 수 없을 것 같습니다.

정책을 사용하기 위해서 캐시에 정책을 설정하는 타입 메서드를 하나 만들어주었고 SceneDelegate에서 이 메서드를 불러서 정책을 설정할 수 있도록 했습니다.

cost의 최대치는 50메가바이트로 설정했어요. 기준이 딱 있었던 것은 아니고 우리 앱 용량이 45메가바이트 정도 되니까 100메가 바이트 안으로 사용하면 좋을 것 같아서 설정했습니다. 사용자 한 명 당 프로필 사진이 1메가바이트 내외라고 했을 때 한번에 50명의 사진을 캐싱해둘 수 있으니까 저희 앱에서는 충분할 것 같아요.

```swift
enum ImageCache {
    static var cache = NSCache<NSString, CacheableImage>()
    static func configureCachePolicy(with maximumBytes: Int) {
        Self.cache.totalCostLimit = maximumBytes
    }
}

// SceneDelegate.swift
ImageCache.configureCachePolicy(with: 52428800) // 50mb
```

### CacheableImage 자료구조 수정 
디스크 캐싱에 대한 정책을 추가하기 위해서 LRU 알고리즘을 사용하는 것이 적절하다고 판단했는데요, 지금은 이미지를 마지막으로 사용한 시간에 대한 정보를 저장하고 있지 않아서 다음과 같이 자료구조를 수정했습니다.

```swift
final class CacheableImage {
    let imageData: Data
    let cacheInfo: CacheInfo
    
    init(imageData: Data, etag: String) {
        self.cacheInfo = CacheInfo(etag: etag, lastRead: Date())
        self.imageData = imageData
    }
}

struct CacheInfo {
    let etag: String
    let lastRead: Date
}
```

CacheInfo라는 타입을 새롭게 추가하고 안에 lastRead를 추가해주었어요. UserDefaults에는 이제 이 CacheInfo가 통채로 저장이 됩니다. 
CacheableImage 인스턴스가 만들어지는 시점은 네트워크에서 새로운 이미지를 다운받는 시점이라서 시간은 따로 주입하지 않고 인스턴스가 만들어질 때의 시간을 사용하도록 헀어요.

### 디스크 캐싱 정책 추가
기존에는 디스크에 계속해서 데이터가 저장되고 있었습니다. 이번에는 용량으로 처리하기에는 구현에 까다로운 부분들이 있어서(디렉토리 용량을 계산하려면 모든 컨텐츠를 불러와서 사이즈를 계산해주어야 해서..) 개수를 기준으로 처리하기로 했습니다. 우리앱에서는 프로필 사진 외에는 캐시 디렉토리에 저장되는 정보가 없어서 이미지를 50개까지 저장할 수 있도록 했어요. 

```swift
private func saveIntoDisk(imageURL: URL, image: CacheableImage) {
        guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else { return }
        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
        let cacheInfo = CacheInfo(etag: image.cacheInfo.etag, lastRead: Date())
        
        if let numOfFiles = try? FileManager.default.contentsOfDirectory(atPath: filePath.path).count { // 디렉토리에 컨텐츠 개수 계산
            var removeTarget: (imageURL: String, minTime: Date) = ("", Date()) // 현재 시간을 기준으로 더미데이터 생성
            if numOfFiles > 50 { 
                UserDefaults.standard.dictionaryRepresentation().forEach({ key, value in // 유저 디폴츠에 있는 데이터를 다 불러와서
                    guard let cacheInfoValue = value as? CacheInfo else { return } // CacheInfo로 타입 캐스팅이 되는 객체들만 확인
                    if removeTarget.minTime > cacheInfoValue.lastRead { // 마지막으로 사용한 시간이 가장 오랜된 데이터 찾기
                        removeTarget = (key, cacheInfoValue.lastRead) // 해당 데이터의 key값을 저장
                    }
                })
            self.deleteFromDisk(imageURL: removeTarget.imageURL) // 가장 오래된 데이터의 key(이미지 요청주소)로 데이터 삭제 요청
            }
        }

        UserDefaults.standard.set(cacheInfo, forKey: imageURL.path)
        FileManager.default.createFile(atPath: filePath.path, contents: image.imageData, attributes: nil)
    }

private func deleteFromDisk(imageURL: String) {
        guard let imageURL = URL(string: imageURL),
              let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else { return }
        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
        
        UserDefaults.standard.removeObject(forKey: imageURL.path) // 유저디폴츠 데이터 제거
        try? FileManager.default.removeItem(atPath: filePath.path) // 캐시디렉토리 데이터 제거
}
```
유저 디폴츠에 대해서 반복문을 매번 돌려야해서 퍼포먼스적으로 좋은 방법은 아니라고 생각이 들지만 현재 구조를 최대한 유지하면서 적용하는 방법은 이 외에 딱히 떠오르지 않네요ㅠ 유저 디폴츠에는 항상 많아야 60개 이내의 데이터가 저장되니 오버헤드가 그렇게 크지는 않을 것이라는 생각입니다.

### 사용시간 갱신 
캐싱된 이미지가 사용될 때마다 사용한 시간을 갱신을 시켜주어야하는데요, 

```swift
    private func updateLastRead(of imageURL: URL, currentEtag: String) {
        let updated = CacheInfo(etag: currentEtag, lastRead: Date())
        UserDefaults.standard.set(updated, forKey: imageURL.path)
    }
```
이 함수를 메모리 히트, 디스크 히트 때마다 매번 불러주고, 조건부 get으로 새로운 데이터가 들어오면 새로운 CacheableImage 인스턴스가 생성되기 때문에 따로 불러주지 않아도 될 것 같습니다.

### 디스크 캐시 히트 시 메모리 캐시 업데이트 
기존에 제가 완전히 잘못한 부분인데, 디스크 히트가 발생해도 메모리로 데이터를 올려주지 않고 있었더라구요.. 그래서 해당 부분을 수정했습니다.

```swift
private func checkDisk(_ imageURL: URL) -> CacheableImage? {
        guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else {
            return nil
        }
        let filePath = path.appendingPathComponent(imageURL.pathComponents.joined(separator: "-"))
        
        if FileManager.default.fileExists(atPath: filePath.path) { // 히트
            guard let imageData = try? Data(contentsOf: filePath),
                  let etag = UserDefaults.standard.string(forKey: imageURL.path) else { return nil }
            
            let image = CacheableImage(imageData: imageData, etag: etag) // 인스턴스 생성
            self.saveIntoCache(imageURL: imageURL, image: image) // 메모리 캐시 갱신
            self.updateLastRead(of: imageURL, currentEtag: etag, to: image.cacheInfo.lastRead) // 사용시간 업데이트
            
            return image
        }
        return nil
    }
```


저희 디비가 사용이 종료되어서 제가 임의로 테스트를 했는데 데이터 개수를 많이 두고 하지는 않아서 예외상황이 있을 수도 있을 것 같아요. 나중에 다들 시간 괜찮으실 때 디비 다시 살려서 최종적으로 보완해보면 좋을 것 같습니다!

리뷰어 태그는 그냥 오랜만이라 추억거리 삼아서 해봤습니다ㅎㅎ approve 해주시면 머지할게요~!

<br/><br/>
