### PR TITLE
디스크 캐시 개선

### DIFF
--- a/MateRunner/MateRunner.xcodeproj/project.pbxproj
+++ b/MateRunner/MateRunner.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 		B0F7026E2757DAAF0082128F /* LocationDidUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CB4D1B27428C3E005E4CD1 /* LocationDidUpdateDelegate.swift */; };
 		B0F7026F2757DAC00082128F /* MapUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00133C3273D949D004E0D1F /* MapUseCase.swift */; };
 		B0F702702757DB3D0082128F /* MockLocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F70265275762270082128F /* MockLocationService.swift */; };
+		B0FA555F279D31C80062E712 /* CacheSizeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FA555E279D31C80062E712 /* CacheSizeConstants.swift */; };
 		E940A6C9E6882B8CDA1DCFF6 /* Pods_MateRunnerViewModelTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DAD775C5AEEF0B8A5CA3A62 /* Pods_MateRunnerViewModelTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -921,6 +922,7 @@
 		B0F70261275761DF0082128F /* MockMapUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMapUseCase.swift; sourceTree = "<group>"; };
 		B0F70265275762270082128F /* MockLocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationService.swift; sourceTree = "<group>"; };
 		B0F7026A2757DA3E0082128F /* MapUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapUseCaseTests.swift; sourceTree = "<group>"; };
+		B0FA555E279D31C80062E712 /* CacheSizeConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheSizeConstants.swift; sourceTree = "<group>"; };
 		D303D404BEFF8406F30DB959 /* Pods-MateRunner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MateRunner.release.xcconfig"; path = "Target Support Files/Pods-MateRunner/Pods-MateRunner.release.xcconfig"; sourceTree = "<group>"; };
 		DAD3EE373EFCD33EEB74A0FC /* Pods-MateRunnerUseCaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MateRunnerUseCaseTests.debug.xcconfig"; path = "Target Support Files/Pods-MateRunnerUseCaseTests/Pods-MateRunnerUseCaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2045,6 +2047,7 @@
 				B02A209127565BA500E86D8A /* SignUpValidationState.swift */,
 				3D92760F2755BC4600D2B9DC /* RealtimeDatabaseKey.swift */,
 				B072F19F2759018400EE4BCA /* FireStoreConstants.swift */,
+				B0FA555E279D31C80062E712 /* CacheSizeConstants.swift */,
 			);
 			path = Constant;
 			sourceTree = "<group>";
@@ -2587,6 +2590,7 @@
 				AE263BE0274D2403004A61E5 /* NoticeDTO+Mapping.swift in Sources */,
 				AE6A6F35272FC170005A3A5C /* DistanceSettingViewController.swift in Sources */,
 				3D2C2198273CF0D700D00C68 /* User.swift in Sources */,
+				B0FA555F279D31C80062E712 /* CacheSizeConstants.swift in Sources */,
 				3D6225492745E42B00E4A327 /* UserRepository.swift in Sources */,
 				5E5E555B274518FB002FE126 /* CumulativeRecordView.swift in Sources */,
 				B0C8517F274E608F0070BB66 /* MateListFirestoreDTO.swift in Sources */,

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -26,13 +26,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.appCoordinator = DefaultAppCoordinator(navigationController)
         self.appCoordinator?.start()
         
-        ImageCache.configureCachePolicy(with: 52428800, with: 52428800)
+        ImageCache.configureCachePolicy(
+            with: CacheConstants.maximumMemoryCacheSize,
+            with: CacheConstants.maximumDiskCacheSize
+        )
         
         guard let notificationResponse = connectionOptions.notificationResponse else { return }
         let userInfo = notificationResponse.notification.request.content.userInfo
         self.configureInvitation(with: userInfo)
         
-
         return
     }
     

--- a/MateRunner/MateRunner/Application/SceneDelegate.swift
+++ b/MateRunner/MateRunner/Application/SceneDelegate.swift
@@ -26,7 +26,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.appCoordinator = DefaultAppCoordinator(navigationController)
         self.appCoordinator?.start()
         
-        ImageCache.configureCachePolicy(with: 52428800)
+        ImageCache.configureCachePolicy(with: 52428800, with: 52428800)
         
         guard let notificationResponse = connectionOptions.notificationResponse else { return }
         let userInfo = notificationResponse.notification.request.content.userInfo

--- a/MateRunner/MateRunner/Util/Constant/CacheSizeConstants.swift
+++ b/MateRunner/MateRunner/Util/Constant/CacheSizeConstants.swift
@@ -1,0 +1,13 @@
+//
+//  CacheSizeConstants.swift
+//  MateRunner
+//
+//  Created by 전여훈 on 2022/01/23.
+//
+
+import Foundation
+
+enum CacheConstants {
+    static let maximumMemoryCacheSize = 52428800
+    static let maximumDiskCacheSize = 52428800
+}

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -158,6 +158,7 @@ final class DefaultImageCacheService {
             guard let encoded = encodeCacheData(cacheInfo: cacheInfo) else { return }
             UserDefaults.standard.set(encoded, forKey: imageURL.path)
             FileManager.default.createFile(atPath: filePath.path, contents: image.imageData, attributes: nil)
+            ImageCache.currentDiskSize += targetByteCount
         }
     }
     
@@ -166,12 +167,12 @@ final class DefaultImageCacheService {
               let filePath = self.createImagePath(with: imageURL),
               let targetFileAttribute = try? FileManager.default.attributesOfItem(atPath: filePath.path) else { return }
         
-        let targetFileSize = targetFileAttribute[FileAttributeKey.size] as? Int ?? 0
+        let targetByteCount = targetFileAttribute[FileAttributeKey.size] as? Int ?? 0
         
         do {
             try FileManager.default.removeItem(atPath: filePath.path)
             UserDefaults.standard.removeObject(forKey: imageURL.path)
-            ImageCache.currentDiskSize -= targetFileSize
+            ImageCache.currentDiskSize -= targetByteCount
         } catch {
             return
         }

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -129,7 +129,9 @@ final class DefaultImageCacheService {
     
     private func updateLastRead(of imageURL: URL, currentEtag: String, to date: Date = Date()) {
         let updated = CacheInfo(etag: currentEtag, lastRead: date)
-        guard let encoded = encodeCacheData(cacheInfo: updated) else { return }
+        guard let encoded = encodeCacheData(cacheInfo: updated),
+            UserDefaults.standard.object(forKey: imageURL.path) != nil else { return }
+        
         UserDefaults.standard.set(encoded, forKey: imageURL.path)
     }
     

--- a/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
+++ b/MateRunner/MateRunner/Util/Service/DefaultImageCacheService.swift
@@ -21,23 +21,19 @@ enum ImageCache {
     }
     
     static func countCurrentDiskSize() -> Int {
-        guard let path = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask).first else {
-            return 0
-        }
-        let profileImageDirPath = path.appendingPathComponent("profileImage")
-        guard let contents = try? FileManager.default.contentsOfDirectory(atPath: profileImageDirPath.path) else {
+        let cacheDirectoryPath = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask)
+        guard let path = cacheDirectoryPath.first else { return 0 }
+        
+        let profileImagePath = path.appendingPathComponent("profileImage")
+        guard let contents = try? FileManager.default.contentsOfDirectory(atPath: profileImagePath.path) else {
             return 0
         }
         
         var totalSize = 0
         for content in contents {
-            do {
-                let fullContentPath = profileImageDirPath.appendingPathComponent(content)
-                let fileAttributes = try FileManager.default.attributesOfItem(atPath: fullContentPath.path)
-                totalSize += fileAttributes[FileAttributeKey.size] as? Int ?? 0
-            } catch _ {
-                continue
-            }
+            let fullContentPath = profileImagePath.appendingPathComponent(content)
+            let fileAttributes = try? FileManager.default.attributesOfItem(atPath: fullContentPath.path)
+            totalSize += fileAttributes?[FileAttributeKey.size] as? Int ?? 0
         }
         return totalSize
     }
@@ -130,7 +126,7 @@ final class DefaultImageCacheService {
     private func updateLastRead(of imageURL: URL, currentEtag: String, to date: Date = Date()) {
         let updated = CacheInfo(etag: currentEtag, lastRead: date)
         guard let encoded = encodeCacheData(cacheInfo: updated),
-            UserDefaults.standard.object(forKey: imageURL.path) != nil else { return }
+              UserDefaults.standard.object(forKey: imageURL.path) != nil else { return }
         
         UserDefaults.standard.set(encoded, forKey: imageURL.path)
     }


### PR DESCRIPTION
### 📕 Issue Number

Close #409 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

### 1. 개수를 기준으로 캐시 정책을 수행하는 로직을 용량 기준으로 개선

```
현재는 용량이 아닌 디렉토리에 저장되는 이미지 데이터의 개수를 기준으로 캐시정책을 수행하고 있습니다. 이 방식의 문제점은 저희가 다운샘플링 같은걸 하지 않다보니 사용자가 업로드한 이미지가 그대로 디스크에 저장되고, 이 용량이 매우 클수도 있다는 점입니다. 디스크에 저장된 이미지가 50개 이상이 되면 삭제하도록 했지만 만약 이미지 용량이 커지면 50개를 저장하기 위해 사용하는 공간이 매우 커질 수도 있습니다.

기존에 용량을 기준으로 캐싱을 수행하려고 시도했을 때 문제가 되었던 부분이 매번 디스크에 있는 파일을 모두 읽어서 용량을 계산해주어야 한다는 것이었는데요, 이 문제를 해결할 수 있는 방법이 있을 것 같아서 이슈를 남기고 추후에 구현을 해보려고 합니다.

아이디어는 아래와 같습니다.

1. 앱이 시작될 때 Library/Caches/profileImage 안에 있는 파일들을 한번 다 읽어서 현재 디스크 용량을 계산합니다.
2. 계산된 현재 용량을 ImageCache 객체에 저장합니다.
3. 디스크에 새로운 데이터를 저장할 때마다 ImageCache에 저장된 용량을 확인합니다.
4. 새로운 데이터를 저장했을 때 허용가능한 디스크 캐시 용량을 초과하게 된다면 기존 방식대로 사용한지 가장 오래된 데이터를 선택해 삭제합니다(LRU).
5. 남은 용량이 새로운 데이터의 용량보다 커질 때까지 데이터를 삭제하고 ImageCache의 용량도 업데이트합니다.
6. 용량이 확보되면 새로운 데이터를 저장합니다.
7. 이런 알고리즘으로 진행하면 매번 디스크를 읽어서 현재 용량을 확인하지 않아도 될 것 같습니다.
```

#### 1. 앱이 시작될 때 Library/Caches/profileImage 안에 있는 파일들을 한번 다 읽어서 현재 디스크 용량을 계산합니다.

SceneDelegate에서 호출하는 configureCachePolicy 메서드에서 메모리 캐시와 디스크 캐시의 크기를 전달합니다.

```swift
ImageCache.configureCachePolicy(
        with: CacheConstants.maximumMemoryCacheSize,
        with: CacheConstants.maximumDiskCacheSize
)
```

내부에서는 사이즈를 결정하고 현재 캐시 디렉토리안에 있는 프로필 이미지의 총 용량을 계산합니다.

```swift
static func configureCachePolicy(with maximumMemoryBytes: Int, with maximumDiskBytes: Int) {
        Self.cache.totalCostLimit = maximumMemoryBytes
        Self.maximumDiskSize = maximumDiskBytes
        Self.currentDiskSize = Self.countCurrentDiskSize()
}
```

용량 계산은 캐시/profileImage 디렉토리에 있는 파일들의 이름을 목록으로 다 가져오고, 각 데이터에 대한 크기를 더해서 계산해주고 있습니다.

```swift
static func countCurrentDiskSize() -> Int {
        let cacheDirectoryPath = FileManager.default.urls(for: .cachesDirectory, in: .allDomainsMask)
        guard let path = cacheDirectoryPath.first else { return 0 }
        
        let profileImagePath = path.appendingPathComponent("profileImage")
        guard let contents = try? FileManager.default.contentsOfDirectory(atPath: profileImagePath.path) else {
            return 0
        }
        
        var totalSize = 0
        for content in contents {
            let fullContentPath = profileImagePath.appendingPathComponent(content)
            let fileAttributes = try? FileManager.default.attributesOfItem(atPath: fullContentPath.path)
            totalSize += fileAttributes?[FileAttributeKey.size] as? Int ?? 0
        }
        return totalSize
}
```

따라서 앱이 처음 시작될 때를 기준으로 디스크 캐시에 저장된 데이터의 총 용량을 들고 시작합니다.

#### 2. 디스크에 새로운 데이터를 저장할 때마다 ImageCache에 저장된 용량을 확인합니다.

```swift
private func saveIntoDisk(imageURL: URL, image: CacheableImage) {
        guard let filePath = self.createImagePath(with: imageURL) else { return }
        
        let cacheInfo = CacheInfo(etag: image.cacheInfo.etag, lastRead: Date())
        let targetByteCount = image.imageData.count // 저장할 사진의 용량 계산
        
        while targetByteCount <= ImageCache.maximumDiskSize // 사진 자체가 캐시 제한 용량보다 크면 저장하지 않는다.
                && ImageCache.currentDiskSize + targetByteCount > ImageCache.maximumDiskSize { // 사진을 추가할 수 있는 만큼 용량 확보
            var removeTarget: (imageURL: String, minTime: Date) = ("", Date())
            UserDefaults.standard.dictionaryRepresentation().forEach({ key, value in
                guard let cacheInfoData = value as? Data,
                      let cacheInfoValue = self.decodeCacheData(data: cacheInfoData) else { return }
                if removeTarget.minTime > cacheInfoValue.lastRead {
                    removeTarget = (key, cacheInfoValue.lastRead)
                }
            })
            self.deleteFromDisk(imageURL: removeTarget.imageURL)
}
        
if ImageCache.currentDiskSize + targetByteCount <= ImageCache.maximumDiskSize { // 저장 가능할 때만 저장. 캐시 크기보다 더 사이즈가 크면 저장하면 안되기 때문에 이를 위한 예외처리
            guard let encoded = encodeCacheData(cacheInfo: cacheInfo) else { return }
            UserDefaults.standard.set(encoded, forKey: imageURL.path)
            FileManager.default.createFile(atPath: filePath.path, contents: image.imageData, attributes: nil)
            ImageCache.currentDiskSize += targetByteCount
        }
}
```
LRU로 가장 오래된 사진을 찾아내는 것은 기존 방식을 그대로 유지했습니다. UserDefaults에 있는 CacheInfo 객체 중에서 가장 오래된 데이터를 찾아 삭제하고, 이 과정을 가용가능한 공간이 확보될 때까지 반복합니다.

캐시에 저장된 데이터가 삭제될 때 캐시 객체에 저장하던 디스크 캐시 현재 용량이 업데이트 되어야하기 때문에 저장할 때는 더해주고, 삭제할 때는 크기를 구해 빼주게됩니다.

```swift
// 추가
if ImageCache.currentDiskSize + targetByteCount <= ImageCache.maximumDiskSize {
            guard let encoded = encodeCacheData(cacheInfo: cacheInfo) else { return }
            UserDefaults.standard.set(encoded, forKey: imageURL.path)
            FileManager.default.createFile(atPath: filePath.path, contents: image.imageData, attributes: nil)
            ImageCache.currentDiskSize += targetByteCount // 갱신
}

// 삭제
 private func deleteFromDisk(imageURL: String) {
        guard let imageURL = URL(string: imageURL),
              let filePath = self.createImagePath(with: imageURL),
              let targetFileAttribute = try? FileManager.default.attributesOfItem(atPath: filePath.path) else { return }
        
        let targetByteCount = targetFileAttribute[FileAttributeKey.size] as? Int ?? 0
        
        do {
            try FileManager.default.removeItem(atPath: filePath.path)
            UserDefaults.standard.removeObject(forKey: imageURL.path)
            ImageCache.currentDiskSize -= targetByteCount // 갱신
        } catch {
            return
        }
}
```

### 2. 예외케이스 처리
```
메모리 캐시에는 데이터가 있는 상태에서 디스크 캐시에는 해당 데이터가 정책에 의해 삭제되었을 때, 마지막으로 읽은 시간을 업데이트하기 위해 UserDefaults에 etag와 읽은 시간 정보를 기록하는 문제가 있습니다.

UserDefaults.standard.set(encoded, forKey: imageURL.path)
무조건 set을 하고있기 때문에 발생하는 문제인데요,

이렇게 되면 LRU에 의해 디스크에 없는 데이터가 선택되었을 때 불필요한 데이터를 선택하게 되고, 의도하지 않은 동작을 만들지는 않지만 좋은 방법은 아니라는 생각이 듭니다.

이 문제는 단순하게 UserDefaults에 새로운 정보를 저장하기 전에 이미 해당 키가 존재하는지 확인하고 있을 때만 저장하도록 하면 디스크에 없는 데이터에 해서 읽은 시간을 업데이트 하는 일은 발생하지 않을 것 같습니다.
```

이 부분은 쉽게 해결할 수 있었어요!

```swift
    private func updateLastRead(of imageURL: URL, currentEtag: String, to date: Date = Date()) {
        let updated = CacheInfo(etag: currentEtag, lastRead: date)
        guard let encoded = encodeCacheData(cacheInfo: updated),
              UserDefaults.standard.object(forKey: imageURL.path) != nil else { return }
        
        UserDefaults.standard.set(encoded, forKey: imageURL.path)
    }
```
key가 존재하는지 먼저 확인하고, 존재할 때만 lastRead를 업데이트 해주었습니다. 

### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 다른 개선점이 있다면 알려주세요!

<br/><br/>
